### PR TITLE
Make test checking the number of calls for GPU details slightly less strict

### DIFF
--- a/tests/test_emissions_tracker.py
+++ b/tests/test_emissions_tracker.py
@@ -59,10 +59,9 @@ class TestCarbonTracker(unittest.TestCase):
         emissions = tracker.stop()
 
         # THEN
-        print("MOCKED GPU DETAILS", mocked_get_gpu_details.call_args_list)
-        self.assertEqual(
+        self.assertGreaterEqual(
             3, mocked_get_gpu_details.call_count
-        )  # 2 times in 5 seconds + once for init = 3
+        )  # at least 2 times in 5 seconds + once for init >= 3
         self.assertEqual(1, mocked_is_gpu_details_available.call_count)
         self.assertEqual(1, len(responses.calls))
         self.assertEqual(

--- a/tests/test_emissions_tracker.py
+++ b/tests/test_emissions_tracker.py
@@ -60,7 +60,7 @@ class TestCarbonTracker(unittest.TestCase):
 
         # THEN
         self.assertGreaterEqual(
-            3, mocked_get_gpu_details.call_count
+            mocked_get_gpu_details.call_count, 3
         )  # at least 2 times in 5 seconds + once for init >= 3
         self.assertEqual(1, mocked_is_gpu_details_available.call_count)
         self.assertEqual(1, len(responses.calls))


### PR DESCRIPTION
As it is based on timing, number of calls might differ based on test server
load.