### PR TITLE
Fix conda package size

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  path: .
+  path: ..
 
 build:
   noarch: python

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,7 +29,7 @@ jobs:
               run: |
                   conda install conda-build conda-verify
                   mkdir -p conda_dist
-                  conda build --python 3.8 . -c conda-forge --output-folder conda_dist
+                  conda build --python 3.8 .conda/ -c conda-forge --output-folder conda_dist
             - name: Archive Conda artifacts
               uses: actions/upload-artifact@v1
               with:


### PR DESCRIPTION
As conda-build is including everything in the repository where `meta.yaml` is
located and its subdirectories, let's put it in its own directory.