### PR TITLE
Fix to raise exception when no CPU/GPU hardware is detected - issue #90

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -7,7 +7,6 @@ import logging
 import os
 import time
 import uuid
-import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import wraps
@@ -79,7 +78,7 @@ class BaseEmissionsTracker(ABC):
         
         # Print warning if no supported hardware is found'
         if not self._hardware:
-            warnings.warn('CODECARBON : No CPU/GPU tracking mode found. This '\
+            logger.warning('CODECARBON : No CPU/GPU tracking mode found. This '\
                 'may be due to your code running on Windows WSL, or due to '\
                 'unsupported hardware (see '\
                 'https://github.com/mlco2/codecarbon#infrastructure-support)')

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -75,7 +75,7 @@ class BaseEmissionsTracker(ABC):
         elif cpu.is_rapl_available():
             logger.info("CODECARBON : Tracking Intel CPU via RAPL interface")
             self._hardware.append(CPU.from_utils(self._output_dir, "intel_rapl"))
-        
+
         # Print warning if no supported hardware is found'
         if not self._hardware:
             logger.warning(
@@ -217,7 +217,7 @@ class OfflineEmissionsTracker(BaseEmissionsTracker):
     Offline implementation of the `EmissionsTracker`
     In addition to the standard arguments, the following are required.
     """
-    
+
     @suppress(Exception)
     def __init__(
         self,

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -78,10 +78,12 @@ class BaseEmissionsTracker(ABC):
         
         # Print warning if no supported hardware is found'
         if not self._hardware:
-            logger.warning('CODECARBON : No CPU/GPU tracking mode found. This '\
-                'may be due to your code running on Windows WSL, or due to '\
-                'unsupported hardware (see '\
-                'https://github.com/mlco2/codecarbon#infrastructure-support)')
+            logger.warning(
+                "CODECARBON : No CPU/GPU tracking mode found. This "
+                "may be due to your code running on Windows WSL, or due to "
+                "unsupported hardware (see "
+                "https://github.com/mlco2/codecarbon#infrastructure-support)"
+            )
 
         # Run `self._measure_power` every `measure_power_secs` seconds in a background thread
         self._scheduler.add_job(

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -75,6 +75,9 @@ class BaseEmissionsTracker(ABC):
         elif cpu.is_rapl_available():
             logger.info("CODECARBON : Tracking Intel CPU via RAPL interface")
             self._hardware.append(CPU.from_utils(self._output_dir, "intel_rapl"))
+        
+        if not self._hardware:
+            raise ValueError('Hardware list empty - no CPU/GPU found.')
 
         # Run `self._measure_power` every `measure_power_secs` seconds in a background thread
         self._scheduler.add_job(
@@ -208,8 +211,7 @@ class OfflineEmissionsTracker(BaseEmissionsTracker):
     Offline implementation of the `EmissionsTracker`
     In addition to the standard arguments, the following are required.
     """
-
-    @suppress(Exception)
+    
     def __init__(
         self,
         country_iso_code: str,

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -7,6 +7,7 @@ import logging
 import os
 import time
 import uuid
+import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import wraps
@@ -76,8 +77,12 @@ class BaseEmissionsTracker(ABC):
             logger.info("CODECARBON : Tracking Intel CPU via RAPL interface")
             self._hardware.append(CPU.from_utils(self._output_dir, "intel_rapl"))
         
+        # Print warning if no supported hardware is found'
         if not self._hardware:
-            raise ValueError('Hardware list empty - no CPU/GPU found.')
+            warnings.warn('CODECARBON : No CPU/GPU tracking mode found. This '\
+                'may be due to your code running on Windows WSL, or due to '\
+                'unsupported hardware (see '\
+                'https://github.com/mlco2/codecarbon#infrastructure-support)')
 
         # Run `self._measure_power` every `measure_power_secs` seconds in a background thread
         self._scheduler.add_job(
@@ -206,6 +211,7 @@ class BaseEmissionsTracker(ABC):
         self._last_measured_time = time.time()
 
 
+@suppress(Exception)
 class OfflineEmissionsTracker(BaseEmissionsTracker):
     """
     Offline implementation of the `EmissionsTracker`

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -218,6 +218,7 @@ class OfflineEmissionsTracker(BaseEmissionsTracker):
     In addition to the standard arguments, the following are required.
     """
     
+    @suppress(Exception)
     def __init__(
         self,
         country_iso_code: str,

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -212,7 +212,6 @@ class BaseEmissionsTracker(ABC):
         self._last_measured_time = time.time()
 
 
-@suppress(Exception)
 class OfflineEmissionsTracker(BaseEmissionsTracker):
     """
     Offline implementation of the `EmissionsTracker`


### PR DESCRIPTION
I added a check in BaseEmissionsTracker to raise ValueError if no CPU/GPU is detected, i.e. if hardware list is empty. I also had to remove exception suppression from OfflineEmissionsTracker otherwise it will not work in that case - not sure why the exception suppression was there in the first place (you don't have one for EmissionsTracker).

With this simple fix we don't force a program exit, i.e. sys.exit(), instead we gave users a graceful option of capturing the exception and proceeding with their code. Example:

```
from codecarbon import EmissionsTracker

def tracker_start(tracker):
    if tracker is not None:
        tracker.start()

def tracker_stop(tracker):
    if tracker is not None:
        tracker.stop()

try:
    tracker = EmissionsTracker()
except ValueError:
    tracker = None

def train():
    # some insane BERTesque model...

tracker_start(tracker)
train()
tracker_stop(tracker)
```

The above can be applied in those instances where CodeCarbon is liberally scattered throughput project code AND you are unsure whether you will run into a situation where you're running the code on Windows machine with WSL.

If using the decorator, then to gracefully handle the exception you need to:

```
from codecarbon import track_emissions

def train():
        # some insane BERTesque model...

try:
    @track_emissions()
    def run_train():
        train()
except ValueError:
    train()
```

Not very elegant, but again, this is extreme case where you want to handle all the scenarios. 99% people benchmarking energy usage when training are going to be doing it in "real" environment with some nice CPUs and GPUs, so this PR essentially just gives an exception to those users (like my naive self!) who get overly excited and try this lovely library on some whimsical Windows machine under WSL1 :-).