### PR TITLE
Add final measurement on process completion

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -117,6 +117,8 @@ class BaseEmissionsTracker(ABC):
 
         self._scheduler.shutdown()
 
+        self._measure_power()  # Run to calculate the power used from last scheduled measurement to shutdown
+
         emissions_data = self._prepare_emissions_data()
 
         for persistence in self.persistence_objs:

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -48,6 +48,9 @@ class TestIntelPowerGadget(unittest.TestCase):
             log_file_name="mock_intel_power_gadget_data.csv",
         )
         cpu_details = power_gadget.get_cpu_details()
+        cpu_details["Cumulative IA Energy_0(mWh)"] = round(
+            cpu_details["Cumulative IA Energy_0(mWh)"], 3
+        )
         self.assertDictEqual(expected_cpu_details, cpu_details)
 
 


### PR DESCRIPTION
When the process finishes running, the scheduler is shutdown. However, there might have been some computation (and therefor power) usage between the last scheduled measurement and shutdown. Running the method once more will account for this. 

Multiple issues have come in (#101 #92) regarding power measurements of 0. It's likely (although not confirmed) that this is happening when the process completes before the scheduler runs a single time.