### PR TITLE
set logging level for module logger not global

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -23,8 +23,8 @@ from codecarbon.external.hardware import CPU, GPU
 from codecarbon.input import DataSource
 from codecarbon.output import BaseOutput, EmissionsData, FileOutput
 
-logging.basicConfig(level=os.environ.get("CODECARBON_LOGLEVEL", "WARN"))
 logger = logging.getLogger(__name__)
+logger.setLevel(level=os.environ.get("CODECARBON_LOGLEVEL", "WARN"))
 
 
 class BaseEmissionsTracker(ABC):

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -23,8 +23,10 @@ from codecarbon.external.hardware import CPU, GPU
 from codecarbon.input import DataSource
 from codecarbon.output import BaseOutput, EmissionsData, FileOutput
 
+logging.getLogger("codecarbon").setLevel(
+    level=os.environ.get("CODECARBON_LOGLEVEL", "WARN")
+)
 logger = logging.getLogger(__name__)
-logger.setLevel(level=os.environ.get("CODECARBON_LOGLEVEL", "WARN"))
 
 
 class BaseEmissionsTracker(ABC):


### PR DESCRIPTION
The way we set the logging level would currently override the user's global logging config. This fixes it so that we only modify CC's logger's level. 