### PR TITLE
add gpu_ids parameter to decorator

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -279,6 +279,7 @@ def track_emissions(
     offline: bool = False,
     country_iso_code: Optional[str] = None,
     region: Optional[str] = None,
+    gpu_ids: Optional[List] = None,
 ):
     """
     Decorator that supports both `EmissionsTracker` and `OfflineEmissionsTracker`
@@ -297,6 +298,7 @@ def track_emissions(
                              being run, required if `offline=True`
     :param region: The provincial region, for example, California in the US.
                    Currently, this only affects calculations for the United States
+    :param gpu_ids: User-specified known gpu ids to track, defaults to None
     :return: The decorated function
     """
 
@@ -315,6 +317,7 @@ def track_emissions(
                     save_to_file=save_to_file,
                     country_iso_code=country_iso_code,
                     region=region,
+                    gpu_ids=gpu_ids,
                 )
                 tracker.start()
                 fn(*args, **kwargs)
@@ -325,6 +328,7 @@ def track_emissions(
                     measure_power_secs=measure_power_secs,
                     output_dir=output_dir,
                     save_to_file=save_to_file,
+                    gpu_ids=gpu_ids,
                 )
                 tracker.start()
                 fn(*args, **kwargs)

--- a/docs/edit/parameters.rst
+++ b/docs/edit/parameters.rst
@@ -27,6 +27,8 @@ The online mode object ``EmissionsTracker`` takes following input parameters:
    * - save_to_file
      - | Boolean variable indicating if the emission artifacts should be logged
        | to a CSV file at ``output_dir/emissions.csv``, defaults to ``True``
+   * - gpu_ids
+     - | User-specified known gpu ids to track, defaults to ``None``
 
 
 OfflineEmissionsTracker
@@ -92,3 +94,5 @@ Decorator ``track_emissions`` takes following input parameters.
      - | Optional Name of the Province/State/City, where the infrastructure is hosted
        | Currently, supported only for US States
        | for example - California or New York, from the `list <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/private_infra/2016/usa_emissions.json>`_
+   * - gpu_ids
+     - | User-specified known gpu ids to track, defaults to ``None``


### PR DESCRIPTION
The decorator was missing the parameter `gpu_ids`