### PR TITLE
add png files to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setuptools.setup(
             "data/cloud/impact.csv",
             "data/private_infra/2016/usa_emissions.json",
             "data/private_infra/2016/global_energy_mix.json",
-        ]
+            "viz/assets/*.png",
+        ],
     },
     python_requires=">=3.6",
     entry_points={"console_scripts": ["carbonboard = codecarbon.viz.carbonboard:main"]},


### PR DESCRIPTION
.png files in the dash assets were not included in setup.py, and so were causing the dash app to render improperly:

![Screen Shot 2021-01-22 at 3 39 47 PM](https://user-images.githubusercontent.com/8690964/105543675-13c7ae00-5cc8-11eb-8aca-900354f304ef.png)

