### PR TITLE
Enable offline mode with cloud configuration

### DIFF
--- a/tests/test_emissions_tracker.py
+++ b/tests/test_emissions_tracker.py
@@ -182,7 +182,7 @@ class TestCarbonTracker(unittest.TestCase):
 
         self.assertRaises(Exception, dummy_train_model)
 
-    def test_decorator_OFFLINE_WITH_ARGS(
+    def test_decorator_OFFLINE_WITH_LOC_ARGS(
         self,
         mocked_get_cloud_metadata,
         mocked_get_gpu_details,
@@ -193,6 +193,21 @@ class TestCarbonTracker(unittest.TestCase):
         @track_emissions(
             offline=True, country_iso_code="CAN", project_name=self.project_name
         )
+        def dummy_train_model():
+            return 42
+
+        dummy_train_model()
+        self.verify_output_file(self.emissions_file_path)
+
+    def test_decorator_OFFLINE_WITH_CLOUD_ARGS(
+        self,
+        mocked_get_cloud_metadata,
+        mocked_get_gpu_details,
+        mocked_is_gpu_details_available,
+    ):
+        # GIVEN
+
+        @track_emissions(offline=True, cloud_provider="gcp", cloud_region="us-central1")
         def dummy_train_model():
             return 42
 


### PR DESCRIPTION
A likely scenario comes when code carbon runs on cloud infrastructure that does not have access to the internet. We enable the user to set `cloud_provider` and `cloud_region` instead of `country_iso_code` and `region`

If cloud parameters AND location parameters are set, the tracker will use the cloud parameters. If parameters are incorrectly configured, the tracker will fail silently in the background. 

The decorator will fail (not silently) if set to offline mode and neither cloud nor location details are provided. 