### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/.conda/py36/meta.yaml
+++ b/.conda/py36/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.0" %}
+{% set version = "1.2.0" %}
 
 package:
   name: codecarbon

--- a/.conda/py37-plus/meta.yaml
+++ b/.conda/py37-plus/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.0" %}
+{% set version = "1.2.0" %}
 
 package:
   name: codecarbon

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ TEST_DEPENDENCIES = ["mock", "pytest", "responses", "tox"]
 
 setuptools.setup(
     name="codecarbon",
-    version="1.1.0",
+    version="1.2.0",
     author="BCG GAMMA, Comet.ml, Haverford College, MILA",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I chose the version number 1.2.0 (rather than 1.1.Z) for two  main reasons:
* We do have a v1.1.2-alpha release on Github, not sure why. Our last release on Pypi was the version 1.1.0 so it wasn't clear if the next version number would be 1.1.1 or 1.1.2.
* The fallback feature seemed important enough to requires a minor version bump.