### PR TITLE
run carbonserver with docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ docs/_build/
 # OS generated files
 .DS_Store
 .DS_Store?
+
+# local database
+code_carbon.db

--- a/carbonserver/Dockerfile
+++ b/carbonserver/Dockerfile
@@ -1,0 +1,19 @@
+# Dockerfile
+
+# pull the official docker image
+FROM python:3.9.4-slim
+
+# set work directory
+WORKDIR /carbonserver
+
+# set env variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# install dependencies
+RUN apt update && apt install -y gcc
+COPY requirements-dev.txt .
+RUN pip install -r requirements-dev.txt
+
+# copy project
+COPY . .

--- a/carbonserver/Dockerfile
+++ b/carbonserver/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile
 
 # pull the official docker image
-FROM python:3.9.4-slim
+FROM python:3.8.10-slim
 
 # set work directory
 WORKDIR /carbonserver

--- a/carbonserver/Dockerfile
+++ b/carbonserver/Dockerfile
@@ -11,7 +11,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 # install dependencies
-RUN apt update && apt install -y gcc
+RUN apt update && apt install -y gcc libpq-dev
 COPY requirements-dev.txt .
 RUN pip install -r requirements-dev.txt
 

--- a/carbonserver/carbonserver/config.py
+++ b/carbonserver/carbonserver/config.py
@@ -1,0 +1,8 @@
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    db_url: str = Field("sqlite:///./code_carbon.db", env="DATABASE_URL")
+
+
+settings = Settings()

--- a/carbonserver/carbonserver/database/database.py
+++ b/carbonserver/carbonserver/database/database.py
@@ -2,12 +2,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./code_carbon.db"
+from carbonserver.config import settings
+
+# SQLALCHEMY_DATABASE_URL = "sqlite:///./code_carbon.db"
 # SQLALCHEMY_DATABASE_URL = "postgresql://user:password@postgresserver/db"
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
+engine = create_engine(settings.db_url, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # We will use the function declarative_base() that returns a class.

--- a/carbonserver/carbonserver/database/database.py
+++ b/carbonserver/carbonserver/database/database.py
@@ -4,10 +4,10 @@ from sqlalchemy.orm import sessionmaker
 
 from carbonserver.config import settings
 
-# SQLALCHEMY_DATABASE_URL = "sqlite:///./code_carbon.db"
-# SQLALCHEMY_DATABASE_URL = "postgresql://user:password@postgresserver/db"
-
-engine = create_engine(settings.db_url, connect_args={"check_same_thread": False})
+engine_kwargs = {}
+if "sqlite" in settings.db_url:
+    engine_kwargs["connect_args"] = {"check_same_thread": False}
+engine = create_engine(settings.db_url, **engine_kwargs)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # We will use the function declarative_base() that returns a class.

--- a/carbonserver/docker/Dockerfile
+++ b/carbonserver/docker/Dockerfile
@@ -15,5 +15,10 @@ RUN apt update && apt install -y gcc libpq-dev
 COPY requirements-dev.txt .
 RUN pip install -r requirements-dev.txt
 
+COPY docker/entrypoint.sh /opt
+RUN chmod a+x /opt/entrypoint.sh
 # copy project
 COPY . .
+RUN tox -e api
+EXPOSE 8000
+ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/carbonserver/docker/README.md
+++ b/carbonserver/docker/README.md
@@ -1,0 +1,13 @@
+# Run Code Carbon API with Docker
+
+This is to start using `docker-compose` to run the carbonserver app.
+
+* Run the carbonserver app with `docker-compose`
+* Switch between sqlite or postgres (comment/uncomment in `docker-compose.yml` the database)
+```yaml
+    environment:
+      # DATABASE_URL: sqlite:///./code_carbon.db
+      DATABASE_URL: postgresql://${DATABASE_USER:-codecarbon-user}:${DATABASE_PASS:-supersecret}@postgres/${DATABASE_NAME:-codecarbon_db}
+```
+
+> Access the app on port `8008` instead of default `8000`, see `ports` in `docker-compose.yml`.

--- a/carbonserver/docker/entrypoint.sh
+++ b/carbonserver/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "Preparing database..."
+cd /carbonserver/carbonserver/database
+python3 -m alembic upgrade head
+if [ $? -eq 0 ]; then
+    echo "Database ready"
+else
+    echo "---------------- ERROR initializing database --------------------------"
+    exit 1
+fi
+cd /carbonserver
+uvicorn --reload main:app --host 0.0.0.0

--- a/carbonserver/requirements-dev.txt
+++ b/carbonserver/requirements-dev.txt
@@ -2,3 +2,4 @@ uvicorn[standard]
 fastapi
 sqlalchemy
 pydantic[email]
+psycopg2

--- a/carbonserver/requirements-dev.txt
+++ b/carbonserver/requirements-dev.txt
@@ -1,5 +1,7 @@
-uvicorn[standard]
+alembic
 fastapi
-sqlalchemy
 pydantic[email]
 psycopg2
+sqlalchemy
+tox
+uvicorn[standard]

--- a/carbonserver/requirements-test.txt
+++ b/carbonserver/requirements-test.txt
@@ -1,5 +1,7 @@
-uvicorn[standard]
+alembic
 fastapi
-sqlalchemy
-requests
 pydantic[email]
+psycopg2
+sqlalchemy
+tox
+uvicorn[standard]

--- a/carbonserver/tox.ini
+++ b/carbonserver/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py37, py38
 
 [testenv:api]
 deps =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   carbonserver:
     build: ./carbonserver
-    command: uvicorn main:app --host 0.0.0.0
+    command: uvicorn --reload main:app --host 0.0.0.0
     volumes:
       - ./carbonserver:/carbonserver
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,18 @@ services:
   #     - codecarbon_api
   #   restart: unless-stopped
 
+  carbonserver:
+    build: ./carbonserver
+    command: uvicorn main:app --host 0.0.0.0
+    volumes:
+      - ./carbonserver:/carbonserver
+    ports:
+      - 8008:8000
+    environment:
+      DATABASE_URL: sqlite:///./code_carbon.db
+    networks:
+      - codecarbon_net
+
   postgres:
     container_name: ${DATABASE_HOST:-postgres_codecarbon}
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,5 @@
 version: '3.7'
 services:
-  # codecarbon_api:
-  #   build:
-  #     context: .
-  #     dockerfile: ./docker/Dockerfile
-  #   networks:
-  #     - codecarbon_net
-  #   ports:
-  #   - 5080:5000
-  #   environment:
-  #     DATABASE_URL: ${DATABASE_URL}
-  #   volumes:
-  #     - .:/opt/codecarbon/api
-  #   depends_on:
-  #     - postgres
-  #   restart: unless-stopped
 
   # codecarbon_package:
   #   build:
@@ -29,8 +14,10 @@ services:
   #   restart: unless-stopped
 
   carbonserver:
-    build: ./carbonserver
-    command: uvicorn --reload main:app --host 0.0.0.0
+    build:
+      context: ./carbonserver/
+      dockerfile: ./docker/Dockerfile
+    #command: cd /carbonserver/carbonserver/database && python3 -m alembic upgrade head && cd ../.. && uvicorn --reload main:app --host 0.0.0.0
     volumes:
       - ./carbonserver:/carbonserver
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,8 @@ services:
     ports:
       - 8008:8000
     environment:
-      DATABASE_URL: sqlite:///./code_carbon.db
+      # DATABASE_URL: sqlite:///./code_carbon.db
+      DATABASE_URL: postgresql://${DATABASE_USER:-codecarbon-user}:${DATABASE_PASS:-supersecret}@postgres/${DATABASE_NAME:-codecarbon_db}
     networks:
       - codecarbon_net
 


### PR DESCRIPTION
Hi all, 

This is to start using `docker-compose` to run the carbonserver app.

* Run the carbonserver app with `docker-compose`
* Switch between sqlite or postgres (comment/uncomment in `docker-compose.yml` the database)
```yaml
    environment:
      # DATABASE_URL: sqlite:///./code_carbon.db
      DATABASE_URL: postgresql://${DATABASE_USER:-codecarbon-user}:${DATABASE_PASS:-supersecret}@postgres/${DATABASE_NAME:-codecarbon_db}
```

> Access the app on port `8008` instead of default `8000`, see `ports` in `docker-compose.yml`.

Using postgresql instead of sqlite leads to some issues when testing some endpoints (database rules seem to be respected only with psql):
* For instance, if you try to `PUT` emission with the given examples it fails for several reasons:
    * `experiment_id` is not an `Integer`
    * Since `experiment_id` is a `ForeignKey`, corresponding experiment entry needs to be created too