### PR TITLE
Seeding API db template

### DIFF
--- a/carbonserver/carbonserver/database/alembic.ini
+++ b/carbonserver/carbonserver/database/alembic.ini
@@ -39,7 +39,7 @@ prepend_sys_path = .
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql://codecarbon-user:supersecret@postgres:5432/codecarbon_db
+sqlalchemy.url = postgresql://codecarbon-user:supersecret@localhost:5480/codecarbon_db
 
 
 [post_write_hooks]

--- a/carbonserver/carbonserver/database/alembic.ini
+++ b/carbonserver/carbonserver/database/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = alembic
+script_location = carbonserver/database/alembic
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
@@ -39,7 +39,8 @@ prepend_sys_path = .
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql://codecarbon-user:supersecret@localhost:5480/codecarbon_db
+#sqlalchemy.url = $(DATABASE_URL)
+#sqlalchemy.url = postgresql://codecarbon-user:supersecret@localhost:5480/codecarbon_db
 
 
 [post_write_hooks]

--- a/carbonserver/carbonserver/database/alembic.ini
+++ b/carbonserver/carbonserver/database/alembic.ini
@@ -39,8 +39,8 @@ prepend_sys_path = .
 # are written from script.py.mako
 # output_encoding = utf-8
 
-#sqlalchemy.url = $(DATABASE_URL)
-#sqlalchemy.url = postgresql://codecarbon-user:supersecret@localhost:5480/codecarbon_db
+# sqlalchemy.url = $(DATABASE_URL)
+# sqlalchemy.url = postgresql://codecarbon-user:supersecret@localhost:5480/codecarbon_db
 
 
 [post_write_hooks]

--- a/carbonserver/carbonserver/database/alembic/env.py
+++ b/carbonserver/carbonserver/database/alembic/env.py
@@ -3,9 +3,16 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+from carbonserver.config import settings
+
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
+
+# this will overwrite the ini-file sqlalchemy.url path
+# with the path given in the config of the main code
+config.set_main_option("sqlalchemy.url", settings.db_url)
+
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/carbonserver/carbonserver/database/alembic/versions/5abae4eb2079_create_tables.py
+++ b/carbonserver/carbonserver/database/alembic/versions/5abae4eb2079_create_tables.py
@@ -1,7 +1,7 @@
 """create_tables stateless script
 
 Revision ID: 5abae4eb2079
-Revises: Tables creation
+Revises: None
 Create Date: 2021-05-18 22:21:49.659708
 
 """
@@ -133,34 +133,40 @@ def upgrade():
     organizations_admin_uuid = uuid.uuid4().__str__()
     teams_admin_uuid = uuid.uuid4().__str__()
     projects_admin_uuid = uuid.uuid4().__str__()
-    op.bulk_insert(organizations,
-              [
-                  {
-                      'id': organizations_admin_uuid,
-                      'name': 'admin',
-                      'description': 'Administration organization',
-                  }
-              ])
+    op.bulk_insert(
+        organizations,
+        [
+            {
+                "id": organizations_admin_uuid,
+                "name": "admin",
+                "description": "Administration organization",
+            }
+        ],
+    )
 
-    op.bulk_insert(teams,
-              [
-                  {
-                      'id': teams_admin_uuid,
-                      'name': 'admin',
-                      'description': 'Administration team',
-                      'organization_id': organizations_admin_uuid
-                  }
-              ])
+    op.bulk_insert(
+        teams,
+        [
+            {
+                "id": teams_admin_uuid,
+                "name": "admin",
+                "description": "Administration team",
+                "organization_id": organizations_admin_uuid,
+            }
+        ],
+    )
 
-    op.bulk_insert(projects,
-              [
-                  {
-                      'id': projects_admin_uuid,
-                      'name': 'admin',
-                      'description': 'Administration project',
-                      'team_id': teams_admin_uuid
-                  }
-              ])
+    op.bulk_insert(
+        projects,
+        [
+            {
+                "id": projects_admin_uuid,
+                "name": "admin",
+                "description": "Administration project",
+                "team_id": teams_admin_uuid,
+            }
+        ],
+    )
 
 
 def downgrade():

--- a/carbonserver/carbonserver/database/alembic/versions/5abae4eb2079_create_tables.py
+++ b/carbonserver/carbonserver/database/alembic/versions/5abae4eb2079_create_tables.py
@@ -1,4 +1,4 @@
-"""create_tables
+"""create_tables stateless script
 
 Revision ID: 5abae4eb2079
 Revises: Tables creation
@@ -21,6 +21,8 @@ def upgrade():
     """
     Create all tables
     """
+    downgrade()
+
     op.create_table(
         "emissions",
         sa.Column(
@@ -31,6 +33,7 @@ def upgrade():
         sa.Column("emissions", sa.Float),
         sa.Column("energy_consumed", sa.Float),
         sa.Column("run_id", UUID),
+        keep_existing=False,
     )
 
     op.create_table(
@@ -40,6 +43,7 @@ def upgrade():
         ),
         sa.Column("timestamp", sa.DateTime),
         sa.Column("experiment_id", UUID),
+        keep_existing=False,
     )
 
     op.create_foreign_key("fk_emissions_runs", "emissions", "runs", ["run_id"], ["id"])
@@ -59,13 +63,14 @@ def upgrade():
         sa.Column("cloud_provider", sa.String),
         sa.Column("cloud_region", sa.String),
         sa.Column("project_id", UUID),
+        keep_existing=False,
     )
 
     op.create_foreign_key(
         "fk_runs_experiments", "runs", "experiments", ["experiment_id"], ["id"]
     )
 
-    op.create_table(
+    projects = op.create_table(
         "projects",
         sa.Column(
             "id", UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4
@@ -73,13 +78,14 @@ def upgrade():
         sa.Column("name", sa.String),
         sa.Column("description", sa.String),
         sa.Column("team_id", UUID),
+        keep_existing=False,
     )
 
     op.create_foreign_key(
         "fk_experiments_projects", "experiments", "projects", ["project_id"], ["id"]
     )
 
-    op.create_table(
+    teams = op.create_table(
         "teams",
         sa.Column(
             "id", UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4
@@ -87,17 +93,19 @@ def upgrade():
         sa.Column("name", sa.String),
         sa.Column("description", sa.String),
         sa.Column("organization_id", UUID),
+        keep_existing=False,
     )
 
     op.create_foreign_key("fk_projects_teams", "projects", "teams", ["team_id"], ["id"])
 
-    op.create_table(
+    organizations = op.create_table(
         "organizations",
         sa.Column(
             "id", UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4
         ),
         sa.Column("name", sa.String),
         sa.Column("description", sa.String),
+        keep_existing=False,
     )
 
     op.create_foreign_key(
@@ -115,11 +123,44 @@ def upgrade():
         sa.Column("hashed_password", sa.String),
         sa.Column("is_active", sa.Boolean, default=True),
         sa.Column("organization_id", UUID),
+        keep_existing=False,
     )
 
     op.create_foreign_key(
         "fk_users_organizations", "users", "organizations", ["organization_id"], ["id"]
     )
+
+    organizations_admin_uuid = uuid.uuid4().__str__()
+    teams_admin_uuid = uuid.uuid4().__str__()
+    projects_admin_uuid = uuid.uuid4().__str__()
+    op.bulk_insert(organizations,
+              [
+                  {
+                      'id': organizations_admin_uuid,
+                      'name': 'admin',
+                      'description': 'Administration organization',
+                  }
+              ])
+
+    op.bulk_insert(teams,
+              [
+                  {
+                      'id': teams_admin_uuid,
+                      'name': 'admin',
+                      'description': 'Administration team',
+                      'organization_id': organizations_admin_uuid
+                  }
+              ])
+
+    op.bulk_insert(projects,
+              [
+                  {
+                      'id': projects_admin_uuid,
+                      'name': 'admin',
+                      'description': 'Administration project',
+                      'team_id': teams_admin_uuid
+                  }
+              ])
 
 
 def downgrade():
@@ -132,8 +173,8 @@ def downgrade():
         "experiments",
         "projects",
         "teams",
-        "organizations",
         "users",
+        "organizations",
     ]
     for t in tables:
         op.drop_table(t)

--- a/carbonserver/carbonserver/database/alembic/versions/5abae4eb2079_create_tables.py
+++ b/carbonserver/carbonserver/database/alembic/versions/5abae4eb2079_create_tables.py
@@ -12,7 +12,7 @@ from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.engine.reflection import Inspector
 
-ADMIN_ORG_ID = 'f52fe339-164d-4c2b-a8c0-f562dfce066d'
+ADMIN_ORG_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
 
 revision = "5abae4eb2079"
 down_revision = None

--- a/carbonserver/carbonserver/database/alembic/versions/73a394753d3a_seed_dfg_team_data.py
+++ b/carbonserver/carbonserver/database/alembic/versions/73a394753d3a_seed_dfg_team_data.py
@@ -7,8 +7,8 @@ Create Date: 2021-05-20 11:34:59.174223
 """
 from alembic import op
 
-ADMIN_ORG_ID = 'f52fe339-164d-4c2b-a8c0-f562dfce066d'
-DFG_TEAM_ID = '8edb03e1-9a28-452a-9c93-a3b6560136d7'
+ADMIN_ORG_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
+DFG_TEAM_ID = "8edb03e1-9a28-452a-9c93-a3b6560136d7"
 
 revision = "73a394753d3a"
 down_revision = "5abae4eb2079"
@@ -21,9 +21,9 @@ def upgrade():
 
     data_for_good_team_values = (
         DFG_TEAM_ID,
-        'DataForGood',
-        'DataForGood Team',
-        ADMIN_ORG_ID
+        "DataForGood",
+        "DataForGood Team",
+        ADMIN_ORG_ID,
     )
     op.execute(
         "INSERT INTO teams {data_for_good_team_columns} VALUES {data_for_good_team_values}".format(

--- a/carbonserver/carbonserver/database/alembic/versions/73a394753d3a_seed_dfg_team_data.py
+++ b/carbonserver/carbonserver/database/alembic/versions/73a394753d3a_seed_dfg_team_data.py
@@ -7,35 +7,34 @@ Create Date: 2021-05-20 11:34:59.174223
 """
 from alembic import op
 
-ADMIN_ORG_ID = '5710d998-8bc7-4786-a918-ecc91f48b799'
-DFG_TEAM_ID = '8edb03e1-9a28-452a-9c93-a3b6560136d7'
+ADMIN_ORG_ID = "5710d998-8bc7-4786-a918-ecc91f48b799"
+DFG_TEAM_ID = "8edb03e1-9a28-452a-9c93-a3b6560136d7"
 
-revision = '73a394753d3a'
-down_revision = '5abae4eb2079'
+revision = "73a394753d3a"
+down_revision = "5abae4eb2079"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
     data_for_good_team_columns = "(id,name,description,organization_id)"
-    data_for_good_team_values = (DFG_TEAM_ID,
-                                 'DataForGood',
-                                 'DataForGood Team',
-                                 ADMIN_ORG_ID
-                                 )
-    print(str(data_for_good_team_values))
-    op.execute("INSERT INTO teams {data_for_good_team_columns} VALUES {data_for_good_team_values}".format(
-        data_for_good_team_columns=data_for_good_team_columns,
-        data_for_good_team_values=str(data_for_good_team_values),
+    data_for_good_team_values = (
+        DFG_TEAM_ID,
+        "DataForGood",
+        "DataForGood Team",
+        ADMIN_ORG_ID,
     )
-               )
+    op.execute(
+        "INSERT INTO teams {data_for_good_team_columns} VALUES {data_for_good_team_values}".format(
+            data_for_good_team_columns=data_for_good_team_columns,
+            data_for_good_team_values=str(data_for_good_team_values),
+        )
+    )
 
 
 def downgrade():
     op.execute(
-        "DELETE FROM teams WHERE id = '{dfg_team_id}'".format(
-            dfg_team_id=DFG_TEAM_ID
-        )
-        )
+        "DELETE FROM teams WHERE id = '{dfg_team_id}'".format(dfg_team_id=DFG_TEAM_ID)
+    )
 
     pass

--- a/carbonserver/carbonserver/database/alembic/versions/73a394753d3a_seed_dfg_team_data.py
+++ b/carbonserver/carbonserver/database/alembic/versions/73a394753d3a_seed_dfg_team_data.py
@@ -7,8 +7,8 @@ Create Date: 2021-05-20 11:34:59.174223
 """
 from alembic import op
 
-ADMIN_ORG_ID = "5710d998-8bc7-4786-a918-ecc91f48b799"
-DFG_TEAM_ID = "8edb03e1-9a28-452a-9c93-a3b6560136d7"
+ADMIN_ORG_ID = 'f52fe339-164d-4c2b-a8c0-f562dfce066d'
+DFG_TEAM_ID = '8edb03e1-9a28-452a-9c93-a3b6560136d7'
 
 revision = "73a394753d3a"
 down_revision = "5abae4eb2079"
@@ -18,11 +18,12 @@ depends_on = None
 
 def upgrade():
     data_for_good_team_columns = "(id,name,description,organization_id)"
+
     data_for_good_team_values = (
         DFG_TEAM_ID,
-        "DataForGood",
-        "DataForGood Team",
-        ADMIN_ORG_ID,
+        'DataForGood',
+        'DataForGood Team',
+        ADMIN_ORG_ID
     )
     op.execute(
         "INSERT INTO teams {data_for_good_team_columns} VALUES {data_for_good_team_values}".format(

--- a/carbonserver/carbonserver/database/alembic/versions/73a394753d3a_seed_dfg_team_data.py
+++ b/carbonserver/carbonserver/database/alembic/versions/73a394753d3a_seed_dfg_team_data.py
@@ -1,0 +1,41 @@
+"""seed_dfg_team_data
+
+Revision ID: 73a394753d3a
+Revises: 5abae4eb2079
+Create Date: 2021-05-20 11:34:59.174223
+
+"""
+from alembic import op
+
+ADMIN_ORG_ID = '5710d998-8bc7-4786-a918-ecc91f48b799'
+DFG_TEAM_ID = '8edb03e1-9a28-452a-9c93-a3b6560136d7'
+
+revision = '73a394753d3a'
+down_revision = '5abae4eb2079'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    data_for_good_team_columns = "(id,name,description,organization_id)"
+    data_for_good_team_values = (DFG_TEAM_ID,
+                                 'DataForGood',
+                                 'DataForGood Team',
+                                 ADMIN_ORG_ID
+                                 )
+    print(str(data_for_good_team_values))
+    op.execute("INSERT INTO teams {data_for_good_team_columns} VALUES {data_for_good_team_values}".format(
+        data_for_good_team_columns=data_for_good_team_columns,
+        data_for_good_team_values=str(data_for_good_team_values),
+    )
+               )
+
+
+def downgrade():
+    op.execute(
+        "DELETE FROM teams WHERE id = '{dfg_team_id}'".format(
+            dfg_team_id=DFG_TEAM_ID
+        )
+        )
+
+    pass

--- a/carbonserver/docker/entrypoint.sh
+++ b/carbonserver/docker/entrypoint.sh
@@ -2,13 +2,12 @@
 echo "Waiting for database to start..."
 sleep 3
 echo "Preparing database..."
-cd /carbonserver/carbonserver/database
-python3 -m alembic upgrade head
+cd /carbonserver
+python3 -m alembic -c carbonserver/database/alembic.ini upgrade head
 if [ $? -eq 0 ]; then
     echo "Database ready"
 else
     echo "---------------- ERROR initializing database --------------------------"
     exit 1
 fi
-cd /carbonserver
 uvicorn --reload main:app --host 0.0.0.0


### PR DESCRIPTION
We could use the execute(sql_statement) operation to generate first sets of data to manipulate the API.
This does not support heavy load as all optimisation is made by the db engine, a better usage of Alembic API is possible