### PR TITLE
Make emissions tracker context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-****![banner](docs/edit/images/banner.png)
+![banner](docs/edit/images/banner.png)
 
 Estimate and track carbon emissions from your compute, quantify and analyze their impact.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![banner](docs/edit/images/banner.png)
+****![banner](docs/edit/images/banner.png)
 
 Estimate and track carbon emissions from your compute, quantify and analyze their impact.
 
@@ -66,6 +66,7 @@ This is the most straightforward usage of the package, which is possible if you 
 
 ```python
 from codecarbon import EmissionsTracker
+
 tracker = EmissionsTracker()
 tracker.start()
 # GPU Intensive code goes here
@@ -80,6 +81,16 @@ from codecarbon import track_emissions
 def training_loop():
    pass
 ```
+
+The `EmissionsTracker` also works as a context manager:
+
+```python
+from codecarbon import EmissionsTracker
+
+with EmissionsTracker() as tracker:
+    # GPU Intensive code goes here
+```
+
 
 This will write a csv file of the CO2 emissions in the current directory.
 
@@ -129,6 +140,16 @@ from codecarbon import track_emissions
 def training_loop():
    pass
 ```
+
+or by using the context manager:
+```python
+from codecarbon import EmissionsTracker
+
+with EmissionsTracker() as tracker:
+    # GPU Intensive code goes here
+```
+
+
 
 ### Using comet.ml
 

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -2,6 +2,7 @@
 Contains implementations of the Public facing API: EmissionsTracker,
 OfflineEmissionsTracker and @track_emissions
 """
+from __future__ import annotations
 
 import dataclasses
 import os
@@ -277,6 +278,7 @@ class BaseEmissionsTracker(ABC):
 
             persistence.out(emissions_data)
 
+        self.final_emissions = emissions_data.emissions
         return emissions_data.emissions
 
     def _prepare_emissions_data(self, delta=False) -> EmissionsData:
@@ -379,6 +381,13 @@ class BaseEmissionsTracker(ABC):
             if self._measure_occurence >= self._api_call_interval:
                 self._cc_api__out.out(self._prepare_emissions_data(delta=True))
                 self._measure_occurence = 0
+
+    def __enter__(self) -> BaseEmissionsTracker:
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb) -> None:
+        self.stop()
 
 
 class OfflineEmissionsTracker(BaseEmissionsTracker):

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -2,8 +2,6 @@
 Contains implementations of the Public facing API: EmissionsTracker,
 OfflineEmissionsTracker and @track_emissions
 """
-from __future__ import annotations
-
 import dataclasses
 import os
 import time
@@ -382,7 +380,7 @@ class BaseEmissionsTracker(ABC):
                 self._cc_api__out.out(self._prepare_emissions_data(delta=True))
                 self._measure_occurence = 0
 
-    def __enter__(self) -> BaseEmissionsTracker:
+    def __enter__(self):
         self.start()
         return self
 

--- a/examples/mnist_context_manager.py
+++ b/examples/mnist_context_manager.py
@@ -1,0 +1,29 @@
+import tensorflow as tf
+
+from codecarbon import EmissionsTracker
+
+
+def train_model():
+    mnist = tf.keras.datasets.mnist
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+    x_train, x_test = x_train / 255.0, x_test / 255.0
+    model = tf.keras.models.Sequential(
+        [
+            tf.keras.layers.Flatten(input_shape=(28, 28)),
+            tf.keras.layers.Dense(128, activation="relu"),
+            tf.keras.layers.Dropout(0.2),
+            tf.keras.layers.Dense(10),
+        ]
+    )
+    loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+
+    model.compile(optimizer="adam", loss=loss_fn, metrics=["accuracy"])
+
+    model.fit(x_train, y_train, epochs=10)
+    return model
+
+
+if __name__ == "__main__":
+    with EmissionsTracker(project_name="mnist") as tracker:
+        model = train_model()
+    print(tracker.final_emissions)

--- a/tests/test_emissions_tracker.py
+++ b/tests/test_emissions_tracker.py
@@ -296,3 +296,56 @@ class TestCarbonTracker(unittest.TestCase):
         with open(file_path, "r") as f:
             lines = [line.rstrip() for line in f]
         assert len(lines) == 2
+
+    @responses.activate
+    def test_carbon_tracker_online_context_manager_TWO_GPU_PRIVATE_INFRA_CANADA(
+        self,
+        mocked_env_cloud_details,
+        mocked_get_gpu_details,
+        mocked_is_gpu_details_available,
+        mock_setup_intel_cli,
+        mock_log_values,
+    ):
+        # GIVEN
+        responses.add(
+            responses.GET,
+            "https://get.geojs.io/v1/ip/geo.json",
+            json=GEO_METADATA_CANADA,
+            status=200,
+        )
+
+        # WHEN
+        with EmissionsTracker(measure_power_secs=1, save_to_file=False) as tracker:
+            heavy_computation()
+
+        # THEN
+        self.assertGreaterEqual(
+            mocked_get_gpu_details.call_count, 2
+        )  # at least 2 times in 5 seconds + once for init >= 3
+        self.assertEqual(1, mocked_is_gpu_details_available.call_count)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual(
+            "https://get.geojs.io/v1/ip/geo.json", responses.calls[0].request.url
+        )
+        self.assertIsInstance(tracker.final_emissions, float)
+        self.assertAlmostEqual(tracker.final_emissions, 6.262572537957655e-05, places=2)
+
+    @responses.activate
+    def test_carbon_tracker_offline_context_manager(
+        self,
+        mocked_env_cloud_details,
+        mocked_get_gpu_details,
+        mocked_is_gpu_details_available,
+        mock_setup_intel_cli,
+        mock_log_values,
+    ):
+        with OfflineEmissionsTracker(
+            country_iso_code="USA", output_dir=self.temp_path
+        ) as tracker:
+            heavy_computation(run_time_secs=2)
+
+        emissions_df = pd.read_csv(self.emissions_file_path)
+
+        self.assertEqual("United States", emissions_df["country_name"].values[0])
+        self.assertEqual("USA", emissions_df["country_iso_code"].values[0])
+        self.assertIsInstance(tracker.final_emissions, float)


### PR DESCRIPTION
closes #137

@benoit-cty Could you please review and provide your feedback?

The [code changes](https://github.com/mlco2/codecarbon/blob/ab24732a9a91967e1a0c60161a3a8faffe87ef83/codecarbon/emissions_tracker.py#L53) are fairly minimal and the [example](https://github.com/mlco2/codecarbon/blob/ab24732a9a91967e1a0c60161a3a8faffe87ef83/examples/mnist_context_manager.py) should demonstrate the fairly straight-forward implementation.

I believe the only somewhat opinionated change is this line [here](https://github.com/mlco2/codecarbon/blob/ab24732a9a91967e1a0c60161a3a8faffe87ef83/codecarbon/emissions_tracker.py#L281). Perhaps you'd want to name that property something different. I deliberately did not choose `BaseEmissionsTracker.emissions` to avoid implying a getter/setter pattern with the existing `BaseEmissionsTracker._emissions` property.