### PR TITLE
Fuzzy cpu matching

### DIFF
--- a/.conda/py36/meta.yaml
+++ b/.conda/py36/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - psutil
     - pynvml
     - py-cpuinfo
+    - fuzzywuzzy
 
 test:
   imports:

--- a/.conda/py37-plus/meta.yaml
+++ b/.conda/py37-plus/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - psutil
     - pynvml
     - py-cpuinfo
+    - fuzzywuzzy
 
 test:
   imports:

--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -54,11 +54,6 @@ def parse_cpu_model(raw_name) -> str:
             .replace("(TM)", "")
             .replace(" CPU", "")
         )
-        splitted = model.split(" ")
-        if len(splitted) == 6 and splitted[2] == "Threadripper":
-            model = (
-                splitted[0] + " " + splitted[1] + " " + splitted[2] + " " + splitted[3]
-            )
         return model
     return ""
 
@@ -243,8 +238,8 @@ class TDP:
         cpu_power_df = DataSource().get_cpu_power_data()
         cpu_model, match_found, _, _ = self._get_matching_cpu(cpu_power_df, raw_model)
         if match_found:
-            power = self.get_match_power(cpu_power_df, cpu_model)
-            return cpu_model, power
+            power = self._get_match_power(cpu_power_df, cpu_model)
+            return power
         else:
             return None
 
@@ -255,7 +250,7 @@ class TDP:
         return cpu_power_df[cpu_power_df['Name'] == match]['TDP'].values[0]
 
 
-    def _get_matching_cpu(self, cpu_power_df, raw_model, threshold=90):
+    def _get_matching_cpu(self, cpu_power_df, raw_model, threshold=80):
         """
         Get the matching CPU name with its similarity ratio
 

--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -267,7 +267,6 @@ class TDP:
 
 
     def _get_matching_cpu(self, model_raw:str, cpu_df:pd.DataFrame,
-                          threshold_direct=100, threshold_token_set=100,
                           greedy=False) -> str:
         """
         Get matching cpu name
@@ -276,12 +275,6 @@ class TDP:
             model_raw (str): raw name of the cpu model detected on the machine
 
             cpu_df (DataFrame): table containing cpu models along their tdp
-
-            threshold_direct (default 100): similiraty ratio value to consider
-            almost-exact matches.
-
-            threshold_token_set (defautl 100): similarity ratio value to
-            consider token_set matches (for more detail see fuzz.token_set_ratio).
 
             greedy (default False): if multiple cpu models match with an equal
             ratio of similarity, greedy (True) selects the first model,
@@ -295,21 +288,30 @@ class TDP:
             with a tdp very different from the actual tdp of current cpu, it
             still enables the relative comparison of models emissions running
             on the same machine.
+
+            THRESHOLD_DIRECT defines the similiraty ratio value to consider
+            almost-exact matches.
+
+            THRESHOLD_TOKEN_SET defines the similarity ratio value to consider
+            token_set matches (for more detail see fuzz.token_set_ratio).
         """
+        THRESHOLD_DIRECT=100
+        THRESHOLD_TOKEN_SET=100
+
         ratios_direct = self._get_direct_matches(model_raw, cpu_df)
         ratios_token_set = self._get_token_set_matches(model_raw, cpu_df)
         max_ratio_direct = max(ratios_direct)
         max_ratio_token_set = max(ratios_token_set)
 
         # Check if a direct match exists
-        if max_ratio_direct >= threshold_direct:
+        if max_ratio_direct >= THRESHOLD_DIRECT:
             cpu_matched = self._get_single_direct_match(ratios_direct,
                                                         max_ratio_direct,
                                                         cpu_df)
             return cpu_matched
 
         # Check if an indirect match exists
-        if max_ratio_token_set < threshold_token_set:
+        if max_ratio_token_set < THRESHOLD_TOKEN_SET:
             return None
         else:
             cpu_idxs = self._get_max_idxs(ratios_token_set, max_ratio_token_set)

--- a/codecarbon/viz/carbonboard.py
+++ b/codecarbon/viz/carbonboard.py
@@ -1,3 +1,4 @@
+import dash
 import dash_bootstrap_components as dbc
 import dash_core_components as dcc
 import dash_table as dt
@@ -5,7 +6,6 @@ import fire
 import pandas as pd
 from dash.dependencies import Input, Output
 
-import dash
 from codecarbon.viz.components import Components
 from codecarbon.viz.data import Data
 

--- a/codecarbon/viz/carbonboard.py
+++ b/codecarbon/viz/carbonboard.py
@@ -1,4 +1,3 @@
-import dash
 import dash_bootstrap_components as dbc
 import dash_core_components as dcc
 import dash_table as dt
@@ -6,6 +5,7 @@ import fire
 import pandas as pd
 from dash.dependencies import Input, Output
 
+import dash
 from codecarbon.viz.components import Components
 from codecarbon.viz.data import Data
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,4 @@ tensorflow
 responses
 py-cpuinfo
 psutil
+fuzzywuzzy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,4 @@ tox
 numpy
 psutil
 requests-mock
+fuzzywuzzy

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ DEPENDENCIES = [
     "requests",
     "psutil",
     "py-cpuinfo",
+    "fuzzywuzzy",
 ]
 
 TEST_DEPENDENCIES = ["mock", "pytest", "responses", "tox", "numpy", "requests-mock"]

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from codecarbon.core.cpu import IntelPowerGadget, IntelRAPL, TDP
+from codecarbon.core.cpu import TDP, IntelPowerGadget, IntelRAPL
 from codecarbon.input import DataSource
 
 
@@ -81,7 +81,6 @@ class TestIntelRAPL(unittest.TestCase):
         self.assertDictEqual(expected_cpu_details, rapl.get_cpu_details())
 
 
-
 class TestTDP(unittest.TestCase):
     def test_get_cpu_power_from_registry(self):
         tdp = TDP()
@@ -91,7 +90,6 @@ class TestTDP(unittest.TestCase):
         self.assertEqual(tdp._get_cpu_power_from_registry(model), 180)
         model = "AMD Ryzen Threadripper 1950X 16-Core Processor"
         self.assertEqual(tdp._get_cpu_power_from_registry(model), 180)
-
 
     def test_get_matching_cpu(self):
         tdp = TDP()
@@ -181,7 +179,6 @@ class TestTDP(unittest.TestCase):
             r"AMD Ryzen 3.*",
         )
 
-
         # LIMIT 1b:
         # Since the following matches many models with varying tdps
         # In non-greedy mode: should return None.
@@ -197,7 +194,6 @@ class TestTDP(unittest.TestCase):
             tdp._get_matching_cpu(model, cpu_data, greedy=True),
             r"AMD Ryzen 3 PRO.*",
         )
-
 
         # LIMIT 2:
         # "AMD Ryzen 3 1200 PRO" matches with both:
@@ -218,7 +214,6 @@ class TestTDP(unittest.TestCase):
             r"AMD Ryzen 3.*1200",
         )
 
-
         # LIMIT 3:
         # Letter missing from a word (instead of "AMD A10-4600M")
         # Returns None since the ratio/score is below 100 (with threshold 100).
@@ -235,7 +230,6 @@ class TestTDP(unittest.TestCase):
             "AMD A10-4600M",
         )
 
-
         # LIMIT 4:
         # Wrong letter from a word (instead of "AMD A10-4600M")
         # Returns None since the ratio/score is below 100 (with threshold 100).
@@ -243,7 +237,6 @@ class TestTDP(unittest.TestCase):
         self.assertIsNone(
             tdp._get_matching_cpu(model, cpu_data, greedy=False),
         )
-
 
         # LIMIT 5:
         # Does not match when both a missing part and an additional part.

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -172,13 +172,12 @@ class TestTDP(unittest.TestCase):
         # /! LIMIT !\ The following matches with both:
         # "AMD Ryzen 3 1200", and "AMD Ryzen 3 PRO 1200"
         # However, it should only match with AMD Ryzen 3 PRO 1200
-        # (the words are in reversed order)
-
-        # model = "AMD Ryzen 3 1200 PRO"
-        # self.assertEqual(
-        #     tdp._get_matching_cpu(model, cpu_data, greedy=False),
-        #     "AMD Ryzen 3 PRO 1200",
-        # )
+        # (words are in reversed order)
+        model = "AMD Ryzen 3 1200 PRO"
+        self.assertIsNone(
+            tdp._get_matching_cpu(model, cpu_data, greedy=False),
+            "AMD Ryzen 3 PRO 1200",
+        )
 
         # Compensates for the previous test failure using greedy mode
         model = "AMD Ryzen 3 1200 PRO"

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -164,7 +164,7 @@ class TestTDP(unittest.TestCase):
         # ======= LIMITS ========
 
         # LIMIT 1a:
-        # The following matches with many "AMD Ryzen 3 ..." models.
+        # The following matches with many "AMD Ryzen 3 [...]" models.
         # Should return None in non-greedy mode
         model = "AMD Ryzen 3"
         self.assertIsNone(

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -5,7 +5,8 @@ from unittest import mock
 
 import pytest
 
-from codecarbon.core.cpu import IntelPowerGadget, IntelRAPL, parse_cpu_model
+from codecarbon.core.cpu import IntelPowerGadget, IntelRAPL, parse_cpu_model, \
+                                TDP
 
 
 class TestIntelPowerGadget(unittest.TestCase):
@@ -86,3 +87,12 @@ class TestTDP(unittest.TestCase):
         model_parsed = parse_cpu_model(model_raw)
         model_parsed_expected = "Intel Core i7-8850H"
         self.assertEqual(model_parsed, model_parsed_expected)
+
+    def test_matching(self):
+        tdp = TDP()
+        model = "Intel Core i7-8850H"
+        self.assertEqual(tdp._get_cpu_constant_power(model), 45)
+        model = "AMD Ryzen Threadripper 1950X"
+        self.assertEqual(tdp._get_cpu_constant_power(model), 180)
+        model = "AMD Ryzen Threadripper 1950X 16-Core Processor"
+        self.assertEqual(tdp._get_cpu_constant_power(model), 180)


### PR DESCRIPTION
Match CPU model name with the CPU list using fuzzy matching, rather than strict equality.

More flexible, enables to match the right model even with:

- addition: _AMD Ryzen Threadripper 1950 16-Core Processor_ matches _AMD Ryzen Threadripper 1950_
- deletion: _AMD Ryzen 1950_ also matches _AMD Ryzen Threadripper 1950_

Still prevents from matching with a wrong model:
- _AMD Ryzen 3_ returns no matches, since it actually matches multiple models
- Greedy mode can force the selection of any model matched
- A threshold can be lowered to consider matches with a similarity ratio lower than 100%*

For additional info on similarity ratio see documentation of [the fuzzywuzzy package](https://github.com/seatgeek/fuzzywuzzy)

Limits:
- Multiple matches (with similarity ratio 100%) when single match would be expected. E.g. _AMD Ryzen 3 1200 PRO_ matches both _AMD Ryzen 3 1200_ and _AMD Ryzen 3 PRO 1200_ although only _AMD Ryzen 3 PRO 1200_ should be matched.

It can be compensated in some cases by forcing the match of any of these two models using greedy mode.