### PR TITLE
feat: add response model to API output

### DIFF
--- a/carbonserver/carbonserver/api/infra/repositories/repository_emissions.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_emissions.py
@@ -2,11 +2,12 @@ from contextlib import AbstractContextManager
 from typing import List
 from uuid import uuid4
 
+from click import UUID
 from dependency_injector.providers import Callable
 
-from carbonserver.api import schemas
 from carbonserver.api.domain.emissions import Emissions
 from carbonserver.api.infra.database import sql_models
+from carbonserver.api.schemas import Emission, EmissionCreate
 
 """
 The emissions are stored in the database by this repository class.
@@ -20,7 +21,7 @@ class SqlAlchemyRepository(Emissions):
     def __init__(self, session_factory) -> Callable[..., AbstractContextManager]:
         self.session_factory = session_factory
 
-    def add_emission(self, emission: schemas.EmissionCreate):
+    def add_emission(self, emission: EmissionCreate) -> UUID:
         """Save an emission to the database.
 
         :emission: An Emission in pyDantic BaseModel format.
@@ -45,7 +46,7 @@ class SqlAlchemyRepository(Emissions):
             session.commit()
             return db_emission.id
 
-    def get_one_emission(self, emission_id) -> schemas.Emission:
+    def get_one_emission(self, emission_id) -> Emission:
         """Find the emission in database and return it
 
         :emission_id: The id of the emission to retreive.
@@ -63,7 +64,7 @@ class SqlAlchemyRepository(Emissions):
             else:
                 return self.map_sql_to_schema(e)
 
-    def get_emissions_from_run(self, run_id) -> List[schemas.Emission]:
+    def get_emissions_from_run(self, run_id) -> List[Emission]:
         """Find the emissions from an run in database and return it
 
         :run_id: The id of the run to retreive emissions from.
@@ -85,14 +86,14 @@ class SqlAlchemyRepository(Emissions):
                 return emissions
 
     @staticmethod
-    def map_sql_to_schema(emission: sql_models.Emission) -> schemas.Emission:
+    def map_sql_to_schema(emission: sql_models.Emission) -> Emission:
         """Convert a models.Emission to a schemas.Emission
 
         :emission: An Emission in SQLAlchemy format.
         :returns: An Emission in pyDantic BaseModel format.
         :rtype: schemas.Emission
         """
-        return schemas.Emission(
+        return Emission(
             id=emission.id,
             timestamp=emission.timestamp,
             duration=emission.duration,

--- a/carbonserver/carbonserver/api/infra/repositories/repository_runs.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_runs.py
@@ -34,7 +34,7 @@ class SqlAlchemyRepository(Runs):
             session.refresh(db_run)
             return self.map_sql_to_schema(db_run)
 
-    def get_one_run(self, run_id):
+    def get_one_run(self, run_id) -> Run:
         """Find the run in database and return it
 
         :run_id: The id of the run to retreive.
@@ -48,7 +48,7 @@ class SqlAlchemyRepository(Runs):
             else:
                 return self.map_sql_to_schema(e)
 
-    def list_runs(self):
+    def list_runs(self) -> List[Run]:
         with self.session_factory() as session:
             e = session.query(SqlModelRun)
             if e is None:

--- a/carbonserver/carbonserver/api/routers/authenticate.py
+++ b/carbonserver/carbonserver/api/routers/authenticate.py
@@ -12,14 +12,16 @@ router = APIRouter()
 
 
 @router.post(
-    "/authenticate", tags=AUTHENTICATE_ROUTER_TAGS, status_code=status.HTTP_200_OK
+    "/authenticate",
+    tags=AUTHENTICATE_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+    response_model=Token,
 )
 @inject
 def auth_user(
     user: UserAuthenticate,
     user_service: UserService = Depends(Provide[ServerContainer.user_service]),
-):
-
+) -> Token:
     verified_user = user_service.verify_user(user)
     if verified_user:
         return Token(access_token="a", token_type="access")

--- a/carbonserver/carbonserver/api/routers/emissions.py
+++ b/carbonserver/carbonserver/api/routers/emissions.py
@@ -1,10 +1,13 @@
+from typing import List
+from uuid import UUID
+
 from container import ServerContainer
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 from starlette import status
 
 from carbonserver.api.dependencies import get_token_header
-from carbonserver.api.schemas import EmissionCreate
+from carbonserver.api.schemas import Emission, EmissionCreate
 from carbonserver.api.services.emissions_service import EmissionService
 
 EMISSIONS_ROUTER_TAGS = ["Emissions"]
@@ -15,7 +18,10 @@ router = APIRouter(
 
 
 @router.post(
-    "/emission", tags=EMISSIONS_ROUTER_TAGS, status_code=status.HTTP_201_CREATED
+    "/emission",
+    tags=EMISSIONS_ROUTER_TAGS,
+    status_code=status.HTTP_201_CREATED,
+    response_model=UUID,
 )
 @inject
 def add_emission(
@@ -23,27 +29,34 @@ def add_emission(
     emission_service: EmissionService = Depends(
         Provide[ServerContainer.emission_service]
     ),
-):
+) -> UUID:
     return emission_service.add_emission(emission)
 
 
-@router.get("/emission/{emission_id}", tags=EMISSIONS_ROUTER_TAGS)
+@router.get(
+    "/emission/{emission_id}",
+    tags=EMISSIONS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+    response_model=Emission,
+)
 @inject
 def read_emission(
     emission_id: str,
     emission_service: EmissionService = Depends(
         Provide[ServerContainer.emission_service]
     ),
-):
+) -> Emission:
     return emission_service.get_one_emission(emission_id)
 
 
-@router.get("/emissions/run/{run_id}", tags=EMISSIONS_ROUTER_TAGS)
+@router.get(
+    "/emissions/run/{run_id}", tags=EMISSIONS_ROUTER_TAGS, response_model=List[Emission]
+)
 @inject
 def get_emissions_from_run(
     run_id: str,
     emission_service: EmissionService = Depends(
         Provide[ServerContainer.emission_service]
     ),
-):
+) -> List[Emission]:
     return emission_service.get_emissions_from_run(run_id)

--- a/carbonserver/carbonserver/api/routers/experiments.py
+++ b/carbonserver/carbonserver/api/routers/experiments.py
@@ -1,10 +1,13 @@
+from typing import List
+from uuid import UUID
+
 from container import ServerContainer
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 from starlette import status
 
 from carbonserver.api.dependencies import get_token_header
-from carbonserver.api.schemas import ExperimentCreate
+from carbonserver.api.schemas import Experiment, ExperimentCreate
 from carbonserver.api.services.experiments_service import ExperimentService
 
 EXPERIMENTS_ROUTER_TAGS = ["Experiments"]
@@ -15,7 +18,10 @@ router = APIRouter(
 
 
 @router.post(
-    "/experiment", tags=EXPERIMENTS_ROUTER_TAGS, status_code=status.HTTP_201_CREATED
+    "/experiment",
+    tags=EXPERIMENTS_ROUTER_TAGS,
+    status_code=status.HTTP_201_CREATED,
+    response_model=UUID,
 )
 @inject
 def add_experiment(
@@ -23,7 +29,7 @@ def add_experiment(
     experiment_service: ExperimentService = Depends(
         Provide[ServerContainer.experiment_service]
     ),
-):
+) -> Experiment:
     return experiment_service.add_experiment(experiment)
 
 
@@ -31,6 +37,7 @@ def add_experiment(
     "/experiment/{experiment_id}",
     tags=EXPERIMENTS_ROUTER_TAGS,
     status_code=status.HTTP_200_OK,
+    response_model=Experiment,
 )
 @inject
 def read_experiment(
@@ -38,7 +45,7 @@ def read_experiment(
     experiment_service: ExperimentService = Depends(
         Provide[ServerContainer.experiment_service]
     ),
-):
+) -> Experiment:
     return experiment_service.get_one_experiment(experiment_id)
 
 
@@ -46,6 +53,7 @@ def read_experiment(
     "/experiments/project/{project_id}",
     tags=EXPERIMENTS_ROUTER_TAGS,
     status_code=status.HTTP_200_OK,
+    response_model=List[Experiment],
 )
 @inject
 def read_experiment_experiments(
@@ -53,6 +61,6 @@ def read_experiment_experiments(
     experiment_service: ExperimentService = Depends(
         Provide[ServerContainer.experiment_service]
     ),
-):
+) -> List[Experiment]:
 
     return experiment_service.get_experiments_from_project(project_id)

--- a/carbonserver/carbonserver/api/routers/organizations.py
+++ b/carbonserver/carbonserver/api/routers/organizations.py
@@ -20,6 +20,7 @@ router = APIRouter(
     "/organization",
     tags=ORGANIZATIONS_ROUTER_TAGS,
     status_code=status.HTTP_201_CREATED,
+    response_model=Organization,
 )
 @inject
 def add_organization(
@@ -27,7 +28,7 @@ def add_organization(
     organization_service: OrganizationService = Depends(
         Provide[ServerContainer.organization_service]
     ),
-):
+) -> Organization:
     return organization_service.add_organization(organization)
 
 
@@ -35,6 +36,7 @@ def add_organization(
     "/organization/{organization_id}",
     tags=ORGANIZATIONS_ROUTER_TAGS,
     status_code=status.HTTP_200_OK,
+    response_model=Organization,
 )
 @inject
 def read_organization(
@@ -47,7 +49,10 @@ def read_organization(
 
 
 @router.get(
-    "/organizations", tags=ORGANIZATIONS_ROUTER_TAGS, status_code=status.HTTP_200_OK
+    "/organizations",
+    tags=ORGANIZATIONS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+    response_model=List[Organization],
 )
 @inject
 def list_organizations(

--- a/carbonserver/carbonserver/api/routers/projects.py
+++ b/carbonserver/carbonserver/api/routers/projects.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends
 from starlette import status
 
 from carbonserver.api.dependencies import get_token_header
-from carbonserver.api.schemas import ProjectCreate
+from carbonserver.api.schemas import Project, ProjectCreate
 
 PROJECTS_ROUTER_TAGS = ["Projects"]
 
@@ -16,18 +16,23 @@ router = APIRouter(
 projects_temp_db = []
 
 
-@router.post("/project", tags=PROJECTS_ROUTER_TAGS, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/project",
+    tags=PROJECTS_ROUTER_TAGS,
+    status_code=status.HTTP_201_CREATED,
+    response_model=Project,
+)
 @inject
 def add_project(
     project: ProjectCreate,
     project_service=Depends(Provide[ServerContainer.project_service]),
-):
+) -> Project:
     return project_service.add_project(project)
 
 
-@router.get("/project/{project_id}", tags=PROJECTS_ROUTER_TAGS)
+@router.get("/project/{project_id}", tags=PROJECTS_ROUTER_TAGS, response_model=Project)
 @inject
 def read_project(
     project_id: str, project_service=Depends(Provide[ServerContainer.project_service])
-):
+) -> Project:
     return project_service.get_one_project(project_id)

--- a/carbonserver/carbonserver/api/routers/runs.py
+++ b/carbonserver/carbonserver/api/routers/runs.py
@@ -21,12 +21,13 @@ runs_temp_db = []
     "/run",
     tags=RUNS_ROUTER_TAGS,
     status_code=status.HTTP_201_CREATED,
+    response_model=Run,
 )
 @inject
 def add_run(
     run: RunCreate,
     run_service: RunService = Depends(Provide[ServerContainer.run_service]),
-):
+) -> Run:
     return run_service.add_run(run)
 
 
@@ -34,6 +35,7 @@ def add_run(
     "/run/{run_id}",
     tags=RUNS_ROUTER_TAGS,
     status_code=status.HTTP_200_OK,
+    response_model=Run,
 )
 @inject
 def read_run(
@@ -47,6 +49,7 @@ def read_run(
     "/runs",
     tags=RUNS_ROUTER_TAGS,
     status_code=status.HTTP_200_OK,
+    response_model=List[Run],
 )
 @inject
 def list_runs(

--- a/carbonserver/carbonserver/api/routers/teams.py
+++ b/carbonserver/carbonserver/api/routers/teams.py
@@ -20,12 +20,13 @@ router = APIRouter(
     "/team",
     tags=TEAMS_ROUTER_TAGS,
     status_code=status.HTTP_201_CREATED,
+    response_model=Team,
 )
 @inject
 def add_team(
     team: TeamCreate,
     team_service: TeamService = Depends(Provide[ServerContainer.team_service]),
-):
+) -> Team:
     return team_service.add_team(team)
 
 
@@ -33,6 +34,7 @@ def add_team(
     "/team/{team_id}",
     tags=TEAMS_ROUTER_TAGS,
     status_code=status.HTTP_200_OK,
+    response_model=Team,
 )
 @inject
 def read_team(
@@ -46,6 +48,7 @@ def read_team(
     "/teams",
     tags=TEAMS_ROUTER_TAGS,
     status_code=status.HTTP_200_OK,
+    response_model=List[Team],
 )
 @inject
 def list_teams(

--- a/carbonserver/carbonserver/api/routers/users.py
+++ b/carbonserver/carbonserver/api/routers/users.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from container import ServerContainer
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, status
@@ -14,7 +16,12 @@ router = APIRouter(
 )
 
 
-@router.post("/user", tags=USERS_ROUTER_TAGS, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/user",
+    tags=USERS_ROUTER_TAGS,
+    status_code=status.HTTP_201_CREATED,
+    response_model=User,
+)
 @inject
 def create_user(
     user: UserCreate,
@@ -24,7 +31,10 @@ def create_user(
 
 
 @router.post(
-    "/user/signup", tags=USERS_ROUTER_TAGS, status_code=status.HTTP_201_CREATED
+    "/user/signup",
+    tags=USERS_ROUTER_TAGS,
+    status_code=status.HTTP_201_CREATED,
+    response_model=User,
 )
 @inject
 def sign_up(
@@ -34,19 +44,28 @@ def sign_up(
     return signup_service.sign_up(user)
 
 
-@router.get("/users", tags=USERS_ROUTER_TAGS, status_code=status.HTTP_200_OK)
+@router.get(
+    "/users",
+    tags=USERS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+    response_model=List[User],
+)
 @inject
 def list_users(
     user_service: UserService = Depends(Provide[ServerContainer.user_service]),
-):
+) -> List[User]:
     return user_service.list_users()
 
 
-@router.get("/user/{user_id}", tags=USERS_ROUTER_TAGS, status_code=status.HTTP_200_OK)
+@router.get(
+    "/user/{user_id}",
+    tags=USERS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+    response_model=User,
+)
 @inject
 def get_user_by_id(
     user_id: str,
     user_service: UserService = Depends(Provide[ServerContainer.user_service]),
-):
-
+) -> User:
     return user_service.get_user_by_id(user_id)

--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -171,7 +171,7 @@ class Team(TeamBase):
     id: UUID
     api_key: str
     organization_id: UUID
-    projects: List[Project] = []
+    projects: Optional[List[Project]]
 
 
 class OrganizationBase(BaseModel):

--- a/carbonserver/carbonserver/api/services/emissions_service.py
+++ b/carbonserver/carbonserver/api/services/emissions_service.py
@@ -12,8 +12,8 @@ class EmissionService:
         self._repository = emission_repository
 
     def add_emission(self, emission: EmissionCreate) -> UUID:
-        emission = self._repository.add_emission(emission)
-        return emission
+        emission_id = self._repository.add_emission(emission)
+        return emission_id
 
     def get_one_emission(self, emission_id) -> Emission:
         emission = self._repository.get_one_emission(emission_id)

--- a/carbonserver/carbonserver/api/services/experiments_service.py
+++ b/carbonserver/carbonserver/api/services/experiments_service.py
@@ -10,9 +10,9 @@ class ExperimentService:
     def __init__(self, experiment_repository: ExperimentSqlRepository):
         self._repository = experiment_repository
 
-    def add_experiment(self, experiment_id: ExperimentCreate) -> Experiment:
-        experiment_id = self._repository.add_experiment(experiment_id)
-        return experiment_id
+    def add_experiment(self, experiment: ExperimentCreate) -> Experiment:
+        experiment = self._repository.add_experiment(experiment)
+        return experiment
 
     def get_one_experiment(self, experiment_id) -> Experiment:
         experiment = self._repository.get_one_experiment(experiment_id)

--- a/carbonserver/carbonserver/api/services/organization_service.py
+++ b/carbonserver/carbonserver/api/services/organization_service.py
@@ -14,17 +14,14 @@ class OrganizationService:
         created_organization: Organization = self._repository.add_organization(
             organization
         )
-
         return created_organization
 
     def read_organization(self, organization_id: str) -> Organization:
         organization: Organization = self._repository.get_one_organization(
             organization_id
         )
-
         return organization
 
     def list_organizations(self) -> List[Organization]:
         organizations: List[Organization] = self._repository.list_organizations()
-
         return organizations

--- a/carbonserver/carbonserver/api/services/run_service.py
+++ b/carbonserver/carbonserver/api/services/run_service.py
@@ -1,3 +1,4 @@
+from typing import List
 from uuid import UUID
 
 from carbonserver.api.infra.repositories.repository_runs import SqlAlchemyRepository
@@ -15,5 +16,5 @@ class RunService:
     def read_run(self, run_id: UUID) -> Run:
         return self._repository.get_one_run(run_id)
 
-    def list_runs(self):
+    def list_runs(self) -> List[Run]:
         return self._repository.list_runs()

--- a/carbonserver/tests/api/routers/test_emissions.py
+++ b/carbonserver/tests/api/routers/test_emissions.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from uuid import UUID
 
 import pytest
 from container import ServerContainer
@@ -6,11 +7,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette import status
 
-from carbonserver.api.infra.database.sql_models import Emission as SqlModelEmission
 from carbonserver.api.infra.repositories.repository_emissions import (
     SqlAlchemyRepository,
 )
 from carbonserver.api.routers import emissions
+from carbonserver.api.schemas import Emission
 
 RUN_1_ID = "40088f1a-d28e-4980-8d80-bf5600056a14"
 RUN_2_ID = "07614c15-c5b0-4c9a-8101-6b6ad3733543"
@@ -101,8 +102,8 @@ def client(custom_test_server):
 
 def test_add_emission(client, custom_test_server):
     repository_mock = mock.Mock(spec=SqlAlchemyRepository)
-    expected_emission = EMISSION_1
-    repository_mock.add_emission.return_value = SqlModelEmission(**EMISSION_1)
+    expected_emission = EMISSION_ID
+    repository_mock.add_emission.return_value = UUID(EMISSION_ID)
 
     with custom_test_server.container.emission_repository.override(repository_mock):
         response = client.post("/emission", json=EMISSION_TO_CREATE)
@@ -115,9 +116,7 @@ def test_add_emission(client, custom_test_server):
 def test_get_emissions_by_id_returns_correct_emission(client, custom_test_server):
     repository_mock = mock.Mock(spec=SqlAlchemyRepository)
     expected_emission = EMISSION_1
-    repository_mock.get_one_emission.return_value = SqlModelEmission(
-        **expected_emission
-    )
+    repository_mock.get_one_emission.return_value = Emission(**expected_emission)
 
     with custom_test_server.container.emission_repository.override(repository_mock):
         response = client.get(
@@ -135,8 +134,8 @@ def test_get_emissions_from_run_retreives_all_emissions_from_run(
     repository_mock = mock.Mock(spec=SqlAlchemyRepository)
     expected_emissions_id_list = [EMISSION_ID, EMISSION_ID_2]
     repository_mock.get_emissions_from_run.return_value = [
-        SqlModelEmission(**EMISSION_1),
-        SqlModelEmission(**EMISSION_2),
+        Emission(**EMISSION_1),
+        Emission(**EMISSION_2),
     ]
 
     with custom_test_server.container.emission_repository.override(repository_mock):

--- a/carbonserver/tests/api/routers/test_runs.py
+++ b/carbonserver/tests/api/routers/test_runs.py
@@ -5,15 +5,15 @@ from container import ServerContainer
 from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
-from carbonserver.api.infra.database.sql_models import Run as SqlModelRun
 from carbonserver.api.infra.repositories.repository_runs import SqlAlchemyRepository
 from carbonserver.api.routers import runs
+from carbonserver.api.schemas import Run
 
 EXPE_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
 EXPE_ID_2 = "e52fe339-164d-4c2b-a8c0-f562dfce066d"
 
-RUN_ID = "f52fe339-164d-4c2b-a8c0-f562dfcerun"
-RUN_ID_2 = "e52fe339-164d-4c2b-a8c0-f562dfcerun"
+RUN_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
+RUN_ID_2 = "e52fe339-164d-4c2b-a8c0-f562dfce066d"
 
 RUN_TO_CREATE = {
     "timestamp": "2021-06-22 14:15:15",
@@ -22,13 +22,14 @@ RUN_TO_CREATE = {
 
 RUN_1 = {
     "id": RUN_ID,
-    # timestamp
+    "timestamp": "2021-04-04T08:43:00+02:00",
     "experiment_id": EXPE_ID,
 }
 
 
 RUN_2 = {
     "id": RUN_ID_2,
+    "timestamp": "2021-04-04T08:43:00+02:00",
     "experiment_id": EXPE_ID_2,
 }
 
@@ -51,7 +52,7 @@ def client(custom_test_server):
 def test_add_run(client, custom_test_server):
     repository_mock = mock.Mock(spec=SqlAlchemyRepository)
     expected_run = RUN_1
-    repository_mock.add_run.return_value = SqlModelRun(**RUN_1)
+    repository_mock.add_run.return_value = Run(**RUN_1)
 
     with custom_test_server.container.run_repository.override(repository_mock):
         response = client.post("/run", json=RUN_TO_CREATE)
@@ -64,13 +65,11 @@ def test_add_run(client, custom_test_server):
 def test_get_run_by_id_returns_correct_run(client, custom_test_server):
     repository_mock = mock.Mock(spec=SqlAlchemyRepository)
     expected_run = RUN_1
-    repository_mock.get_one_run.return_value = [
-        SqlModelRun(**expected_run),
-    ]
+    repository_mock.get_one_run.return_value = Run(**expected_run)
 
     with custom_test_server.container.run_repository.override(repository_mock):
         response = client.get("/run/read_run/", params={"id": RUN_ID})
-        actual_run = response.json()[0]
+        actual_run = response.json()
 
     assert response.status_code == status.HTTP_200_OK
     assert actual_run == expected_run
@@ -82,8 +81,8 @@ def test_list_runs_returns_all_runs(client, custom_test_server):
     expected_run_2 = RUN_2
     expected_org_list = [expected_run_1, expected_run_2]
     repository_mock.list_runs.return_value = [
-        SqlModelRun(**expected_run_1),
-        SqlModelRun(**expected_run_2),
+        Run(**expected_run_1),
+        Run(**expected_run_2),
     ]
 
     with custom_test_server.container.run_repository.override(repository_mock):

--- a/carbonserver/tests/api/routers/test_users.py
+++ b/carbonserver/tests/api/routers/test_users.py
@@ -5,9 +5,9 @@ from container import ServerContainer
 from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
-from carbonserver.api.infra.database.sql_models import User as ModelUser
 from carbonserver.api.infra.repositories.repository_users import SqlAlchemyRepository
 from carbonserver.api.routers import users
+from carbonserver.api.schemas import User
 
 API_KEY = "U5W0EUP9y6bBENOnZWJS0g"
 
@@ -65,7 +65,7 @@ def client(custom_test_server):
 def test_create_user(client, custom_test_server):
     repository_mock = mock.Mock(spec=SqlAlchemyRepository)
     expected_user = USER_1
-    repository_mock.create_user.return_value = ModelUser(**expected_user)
+    repository_mock.create_user.return_value = User(**expected_user)
 
     with custom_test_server.container.user_repository.override(repository_mock):
         response = client.post("/user", json=USER_TO_CREATE)
@@ -89,8 +89,8 @@ def test_list_users_list_all_existing_users_with_200(client, custom_test_server)
     expected_user_2 = USER_2
     expected_user_list = [expected_user, expected_user_2]
     repository_mock.list_users.return_value = [
-        ModelUser(**expected_user),
-        ModelUser(**expected_user_2),
+        User(**expected_user),
+        User(**expected_user_2),
     ]
 
     with custom_test_server.container.user_repository.override(repository_mock):
@@ -106,7 +106,7 @@ def test_get_user_by_id_returns_correct_user_with_correct_id(
 ):
     repository_mock = mock.Mock(spec=SqlAlchemyRepository)
     expected_user = USER_1
-    repository_mock.get_user_by_id.return_value = ModelUser(**expected_user)
+    repository_mock.get_user_by_id.return_value = User(**expected_user)
 
     container_mock = mock.Mock(spec=ServerContainer)
     container_mock.db.return_value = True


### PR DESCRIPTION
Adding response model to describe API outputs.
The objects returned by the API are defined in the schemas.py file, we do not suffix them as we identify the input objects with the Create suffix when needed. Otherwise the types can be shared between the application and its HTTP users.
Fix #205 