### PR TITLE
Add api routes to list all teams, projects and runs

### DIFF
--- a/carbonserver/carbonserver/api/infra/repositories/repository_emissions.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_emissions.py
@@ -79,11 +79,7 @@ class SqlAlchemyRepository(Emissions):
             if res.first() is None:
                 return []
             else:
-                emissions = []
-                for e in res:
-                    emission = self.map_sql_to_schema(e)
-                    emissions.append(emission)
-                return emissions
+                return [self.map_sql_to_schema(e) for e in res]
 
     @staticmethod
     def map_sql_to_schema(emission: sql_models.Emission) -> Emission:

--- a/carbonserver/carbonserver/api/infra/repositories/repository_projects.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_projects.py
@@ -1,5 +1,5 @@
 from contextlib import AbstractContextManager
-
+from typing import List
 from dependency_injector.providers import Callable
 
 from carbonserver.api.domain.projects import Projects
@@ -35,6 +35,26 @@ class SqlAlchemyRepository(Projects):
                 return None
             else:
                 return self.map_sql_to_schema(e)
+
+    def get_projects_from_team(self, team_id) -> List[Project]:
+        """Find the list of projects from a team in database and return it
+
+        :team_id: The id of the team to retreive projects from.
+        :returns: List of Projects in pyDantic BaseModel format.
+        :rtype: List[schemas.Project]
+        """
+        with self.session_factory() as session:
+            res = session.query(SqlModelProject).filter(
+                SqlModelProject.team_id == team_id
+            )
+            if res.first() is None:
+                return []
+            else:
+                projects = []
+                for e in res:
+                    project = self.map_sql_to_schema(e)
+                    projects.append(project)
+                return projects
 
     @staticmethod
     def map_sql_to_schema(project: SqlModelProject) -> Project:

--- a/carbonserver/carbonserver/api/infra/repositories/repository_projects.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_projects.py
@@ -51,11 +51,7 @@ class SqlAlchemyRepository(Projects):
             if res.first() is None:
                 return []
             else:
-                projects = []
-                for e in res:
-                    project = self.map_sql_to_schema(e)
-                    projects.append(project)
-                return projects
+                return [self.map_sql_to_schema(e) for e in res]
 
     @staticmethod
     def map_sql_to_schema(project: SqlModelProject) -> Project:

--- a/carbonserver/carbonserver/api/infra/repositories/repository_projects.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_projects.py
@@ -1,5 +1,6 @@
 from contextlib import AbstractContextManager
 from typing import List
+
 from dependency_injector.providers import Callable
 
 from carbonserver.api.domain.projects import Projects

--- a/carbonserver/carbonserver/api/infra/repositories/repository_runs.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_runs.py
@@ -73,11 +73,7 @@ class SqlAlchemyRepository(Runs):
             if res.first() is None:
                 return []
             else:
-                runs = []
-                for e in res:
-                    run = self.map_sql_to_schema(e)
-                    runs.append(run)
-                return runs
+                return [self.map_sql_to_schema(e) for e in res]
 
     @staticmethod
     def map_sql_to_schema(run: SqlModelRun) -> Run:

--- a/carbonserver/carbonserver/api/infra/repositories/repository_runs.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_runs.py
@@ -59,6 +59,26 @@ class SqlAlchemyRepository(Runs):
                     runs.append(self.map_sql_to_schema(run))
                 return runs
 
+    def get_runs_from_experiment(self, experiment_id) -> List[Run]:
+        """Find the list of runs from an experiment in database and return it
+
+        :experiment_id: The id of the experiment to retreive runs from.
+        :returns: List of Run in pyDantic BaseModel format.
+        :rtype: List[schemas.Run]
+        """
+        with self.session_factory() as session:
+            res = session.query(SqlModelRun).filter(
+                SqlModelRun.experiment_id == experiment_id
+            )
+            if res.first() is None:
+                return []
+            else:
+                runs = []
+                for e in res:
+                    run = self.map_sql_to_schema(e)
+                    runs.append(run)
+                return runs
+
     @staticmethod
     def map_sql_to_schema(run: SqlModelRun) -> Run:
         """Convert a models.Run to a schemas.Run

--- a/carbonserver/carbonserver/api/infra/repositories/repository_teams.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_teams.py
@@ -72,11 +72,7 @@ class SqlAlchemyRepository(Teams):
             if res.first() is None:
                 return []
             else:
-                teams = []
-                for e in res:
-                    team = self.map_sql_to_schema(e)
-                    teams.append(team)
-                return teams
+                return [self.map_sql_to_schema(e) for e in res]
 
     def is_api_key_valid(self, organization_id: UUID, api_key: str):
         with self.session_factory() as session:

--- a/carbonserver/carbonserver/api/infra/repositories/repository_teams.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_teams.py
@@ -58,6 +58,26 @@ class SqlAlchemyRepository(Teams):
                     teams.append(self.map_sql_to_schema(team))
                 return teams
 
+    def get_teams_from_organization(self, organization_id) -> List[Team]:
+        """Find the list of teams from an organization in database and return it
+
+        :organization_id: The id of the organization to retreive teams from.
+        :returns: List of Teams in pyDantic BaseModel format.
+        :rtype: List[schemas.Team]
+        """
+        with self.session_factory() as session:
+            res = session.query(SqlModelTeam).filter(
+                SqlModelTeam.organization_id == organization_id
+            )
+            if res.first() is None:
+                return []
+            else:
+                teams = []
+                for e in res:
+                    team = self.map_sql_to_schema(e)
+                    teams.append(team)
+                return teams
+
     def is_api_key_valid(self, organization_id: UUID, api_key: str):
         with self.session_factory() as session:
             return bool(

--- a/carbonserver/carbonserver/api/routers/projects.py
+++ b/carbonserver/carbonserver/api/routers/projects.py
@@ -42,8 +42,6 @@ def read_project(
 @inject
 def read_projects_from_team(
     team_id: str,
-    project_service: ProjectService = Depends(
-        Provide[ServerContainer.project_service]
-    ),
+    project_service: ProjectService = Depends(Provide[ServerContainer.project_service]),
 ):
     return project_service.list_projects_from_team(team_id)

--- a/carbonserver/carbonserver/api/routers/projects.py
+++ b/carbonserver/carbonserver/api/routers/projects.py
@@ -5,6 +5,7 @@ from starlette import status
 
 from carbonserver.api.dependencies import get_token_header
 from carbonserver.api.schemas import ProjectCreate
+from carbonserver.api.services.project_service import ProjectService
 
 PROJECTS_ROUTER_TAGS = ["Projects"]
 
@@ -31,3 +32,18 @@ def read_project(
     project_id: str, project_service=Depends(Provide[ServerContainer.project_service])
 ):
     return project_service.get_one_project(project_id)
+
+
+@router.get(
+    "/projects/team/{team_id}",
+    tags=PROJECTS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+)
+@inject
+def read_projects_from_team(
+    team_id: str,
+    project_service: ProjectService = Depends(
+        Provide[ServerContainer.project_service]
+    ),
+):
+    return project_service.list_projects_from_team(team_id)

--- a/carbonserver/carbonserver/api/routers/projects.py
+++ b/carbonserver/carbonserver/api/routers/projects.py
@@ -4,10 +4,8 @@ from fastapi import APIRouter, Depends
 from starlette import status
 
 from carbonserver.api.dependencies import get_token_header
-
 from carbonserver.api.schemas import Project, ProjectCreate
 from carbonserver.api.services.project_service import ProjectService
-
 
 PROJECTS_ROUTER_TAGS = ["Projects"]
 

--- a/carbonserver/carbonserver/api/routers/runs.py
+++ b/carbonserver/carbonserver/api/routers/runs.py
@@ -63,8 +63,6 @@ def list_runs(
 @inject
 def read_runs_from_experiment(
     experiment_id: str,
-    run_service: RunService = Depends(
-        Provide[ServerContainer.run_service]
-    ),
+    run_service: RunService = Depends(Provide[ServerContainer.run_service]),
 ):
     return run_service.list_runs_from_experiment(experiment_id)

--- a/carbonserver/carbonserver/api/routers/runs.py
+++ b/carbonserver/carbonserver/api/routers/runs.py
@@ -53,3 +53,18 @@ def list_runs(
     run_service: RunService = Depends(Provide[ServerContainer.run_service]),
 ) -> List[Run]:
     return run_service.list_runs()
+
+
+@router.get(
+    "/runs/experiment/{experiment_id}",
+    tags=RUNS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+)
+@inject
+def read_runs_from_experiment(
+    experiment_id: str,
+    run_service: RunService = Depends(
+        Provide[ServerContainer.run_service]
+    ),
+):
+    return run_service.list_runs_from_experiment(experiment_id)

--- a/carbonserver/carbonserver/api/routers/teams.py
+++ b/carbonserver/carbonserver/api/routers/teams.py
@@ -52,3 +52,19 @@ def list_teams(
     team_service: TeamService = Depends(Provide[ServerContainer.team_service]),
 ) -> List[Team]:
     return team_service.list_teams()
+
+
+@router.get(
+    "/teams/organization/{organization_id}",
+    tags=TEAMS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+)
+@inject
+def read_teams_from_organization(
+    organization_id: str,
+    team_service: TeamService = Depends(
+        Provide[ServerContainer.team_service]
+    ),
+):
+    return team_service.list_teams_from_organization(organization_id)
+

--- a/carbonserver/carbonserver/api/routers/teams.py
+++ b/carbonserver/carbonserver/api/routers/teams.py
@@ -62,9 +62,6 @@ def list_teams(
 @inject
 def read_teams_from_organization(
     organization_id: str,
-    team_service: TeamService = Depends(
-        Provide[ServerContainer.team_service]
-    ),
+    team_service: TeamService = Depends(Provide[ServerContainer.team_service]),
 ):
     return team_service.list_teams_from_organization(organization_id)
-

--- a/carbonserver/carbonserver/api/services/project_service.py
+++ b/carbonserver/carbonserver/api/services/project_service.py
@@ -13,3 +13,6 @@ class ProjectService:
 
     def get_one_project(self, project_id):
         return self._repository.get_one_project(project_id)
+
+    def list_projects_from_team(self, team_id: str):
+        return self._repository.get_projects_from_team(team_id)

--- a/carbonserver/carbonserver/api/services/run_service.py
+++ b/carbonserver/carbonserver/api/services/run_service.py
@@ -17,3 +17,6 @@ class RunService:
 
     def list_runs(self):
         return self._repository.list_runs()
+
+    def list_runs_from_experiment(self, experiment_id: str):
+        return self._repository.get_runs_from_experiment(experiment_id)

--- a/carbonserver/carbonserver/api/services/team_service.py
+++ b/carbonserver/carbonserver/api/services/team_service.py
@@ -16,3 +16,6 @@ class TeamService:
 
     def list_teams(self):
         return self._repository.list_teams()
+
+    def list_teams_from_organization(self, organization_id: str):
+        return self._repository.get_teams_from_organization(organization_id)

--- a/carbonserver/tests/api/routers/test_projects.py
+++ b/carbonserver/tests/api/routers/test_projects.py
@@ -1,0 +1,95 @@
+from unittest import mock
+
+import pytest
+from container import ServerContainer
+from fastapi import FastAPI, status
+from fastapi.testclient import TestClient
+
+from carbonserver.api.infra.database.sql_models import Project as SqlModelProject
+from carbonserver.api.infra.repositories.repository_projects import SqlAlchemyRepository
+from carbonserver.api.routers import projects
+
+PROJECT_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
+PROJECT_ID_2 = "e52fe339-164d-4c2b-a8c0-f562dfce066d"
+
+TEAM_ID = "f52fe339-164d-4c2b-a8c0-f562dfcerun"
+TEAM_ID_2 = "e52fe339-164d-4c2b-a8c0-f562dfcerun"
+
+
+PROJECT_TO_CREATE = {
+    "name": "API Code Carbon",
+    "description": "API for Code Carbon",
+    "team_id": "8edb03e1-9a28-452a-9c93-a3b6560136d7",
+}
+
+PROJECT_1 = {
+    "id": PROJECT_ID,
+    "description": "Calculates CO2 emissions of AI projects",
+    "team_id": TEAM_ID,
+}
+
+
+PROJECT_2 = {
+    "id": PROJECT_ID_2,
+    "description": "Calculates CO2 emissions of AI projects",
+    "team_id": TEAM_ID_2,
+}
+
+
+@pytest.fixture
+def custom_test_server():
+    container = ServerContainer()
+    container.wire(modules=[projects])
+    app = FastAPI()
+    app.container = container
+    app.include_router(projects.router)
+    yield app
+
+
+@pytest.fixture
+def client(custom_test_server):
+    yield TestClient(custom_test_server)
+
+
+def test_add_project(client, custom_test_server):
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_project = PROJECT_1
+    repository_mock.add_project.return_value = SqlModelProject(**PROJECT_1)
+
+    with custom_test_server.container.project_repository.override(repository_mock):
+        response = client.post("/project", json=PROJECT_TO_CREATE)
+        actual_project = response.json()
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert actual_project == expected_project
+
+
+def test_get_project_by_id_returns_correct_project(client, custom_test_server):
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_project = PROJECT_1
+    repository_mock.get_one_project.return_value = [
+        SqlModelProject(**expected_project),
+    ]
+
+    with custom_test_server.container.project_repository.override(repository_mock):
+        response = client.get("/project/read_project/", params={"id": PROJECT_ID})
+        actual_project = response.json()[0]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert actual_project == expected_project
+
+
+def test_get_projects_from_team_returns_correct_project(client, custom_test_server):
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_project = PROJECT_1
+    expected_project_list = [expected_project]
+    repository_mock.get_projects_from_team.return_value = [
+        SqlModelProject(**expected_project),
+    ]
+
+    with custom_test_server.container.project_repository.override(repository_mock):
+        response = client.get("/projects/team/" + TEAM_ID)
+        actual_project_list = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert actual_project_list == expected_project_list

--- a/carbonserver/tests/api/routers/test_projects.py
+++ b/carbonserver/tests/api/routers/test_projects.py
@@ -1,36 +1,40 @@
 from unittest import mock
+from uuid import UUID
 
 import pytest
 from container import ServerContainer
 from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
-from carbonserver.api.infra.database.sql_models import Project as SqlModelProject
 from carbonserver.api.infra.repositories.repository_projects import SqlAlchemyRepository
 from carbonserver.api.routers import projects
+from carbonserver.api.schemas import Project
 
 PROJECT_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
 PROJECT_ID_2 = "e52fe339-164d-4c2b-a8c0-f562dfce066d"
 
-TEAM_ID = "f52fe339-164d-4c2b-a8c0-f562dfcerun"
-TEAM_ID_2 = "e52fe339-164d-4c2b-a8c0-f562dfcerun"
+TEAM_ID = "c13e851f-5c2f-403d-98d0-51fe15df3bc3"
+TEAM_ID_2 = "c13e851f-5c2f-403d-98d0-51fe15df3bc4"
 
 
 PROJECT_TO_CREATE = {
     "name": "API Code Carbon",
     "description": "API for Code Carbon",
-    "team_id": "8edb03e1-9a28-452a-9c93-a3b6560136d7",
+    "team_id": "c13e851f-5c2f-403d-98d0-51fe15df3bc3",
 }
 
 PROJECT_1 = {
     "id": PROJECT_ID,
-    "description": "Calculates CO2 emissions of AI projects",
+    "name": "API Code Carbon",
+    "description": "API for Code Carbon",
     "team_id": TEAM_ID,
+    "experiments": []
 }
 
 
 PROJECT_2 = {
     "id": PROJECT_ID_2,
+    "name": "API Code Carbon",
     "description": "Calculates CO2 emissions of AI projects",
     "team_id": TEAM_ID_2,
 }
@@ -54,7 +58,7 @@ def client(custom_test_server):
 def test_add_project(client, custom_test_server):
     repository_mock = mock.Mock(spec=SqlAlchemyRepository)
     expected_project = PROJECT_1
-    repository_mock.add_project.return_value = SqlModelProject(**PROJECT_1)
+    repository_mock.add_project.return_value = Project(**PROJECT_1)
 
     with custom_test_server.container.project_repository.override(repository_mock):
         response = client.post("/project", json=PROJECT_TO_CREATE)
@@ -67,13 +71,11 @@ def test_add_project(client, custom_test_server):
 def test_get_project_by_id_returns_correct_project(client, custom_test_server):
     repository_mock = mock.Mock(spec=SqlAlchemyRepository)
     expected_project = PROJECT_1
-    repository_mock.get_one_project.return_value = [
-        SqlModelProject(**expected_project),
-    ]
+    repository_mock.get_one_project.return_value = Project(**expected_project)
 
     with custom_test_server.container.project_repository.override(repository_mock):
         response = client.get("/project/read_project/", params={"id": PROJECT_ID})
-        actual_project = response.json()[0]
+        actual_project = response.json()
 
     assert response.status_code == status.HTTP_200_OK
     assert actual_project == expected_project
@@ -84,7 +86,7 @@ def test_get_projects_from_team_returns_correct_project(client, custom_test_serv
     expected_project = PROJECT_1
     expected_project_list = [expected_project]
     repository_mock.get_projects_from_team.return_value = [
-        SqlModelProject(**expected_project),
+        Project(**expected_project),
     ]
 
     with custom_test_server.container.project_repository.override(repository_mock):

--- a/carbonserver/tests/api/routers/test_projects.py
+++ b/carbonserver/tests/api/routers/test_projects.py
@@ -1,5 +1,4 @@
 from unittest import mock
-from uuid import UUID
 
 import pytest
 from container import ServerContainer
@@ -28,7 +27,7 @@ PROJECT_1 = {
     "name": "API Code Carbon",
     "description": "API for Code Carbon",
     "team_id": TEAM_ID,
-    "experiments": []
+    "experiments": [],
 }
 
 

--- a/carbonserver/tests/api/routers/test_runs.py
+++ b/carbonserver/tests/api/routers/test_runs.py
@@ -103,7 +103,7 @@ def test_get_runs_from_experiment_returns_correct_run(client, custom_test_server
     ]
 
     with custom_test_server.container.run_repository.override(repository_mock):
-        response = client.get("/runs/experiment/"+EXPE_ID)
+        response = client.get("/runs/experiment/" + EXPE_ID)
         actual_run_list = response.json()
 
     assert response.status_code == status.HTTP_200_OK

--- a/carbonserver/tests/api/routers/test_runs.py
+++ b/carbonserver/tests/api/routers/test_runs.py
@@ -98,7 +98,7 @@ def test_get_runs_from_experiment_returns_correct_run(client, custom_test_server
     expected_run_1 = RUN_1
     expected_run_list = [RUN_1]
     repository_mock.get_runs_from_experiment.return_value = [
-        SqlModelRun(**expected_run_1),
+        Run(**expected_run_1),
     ]
 
     with custom_test_server.container.run_repository.override(repository_mock):

--- a/carbonserver/tests/api/routers/test_runs.py
+++ b/carbonserver/tests/api/routers/test_runs.py
@@ -92,3 +92,19 @@ def test_list_runs_returns_all_runs(client, custom_test_server):
 
     assert response.status_code == status.HTTP_200_OK
     assert actual_org_list == expected_org_list
+
+
+def test_get_runs_from_experiment_returns_correct_run(client, custom_test_server):
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_run_1 = RUN_1
+    expected_run_list = [RUN_1]
+    repository_mock.get_runs_from_experiment.return_value = [
+        SqlModelRun(**expected_run_1),
+    ]
+
+    with custom_test_server.container.run_repository.override(repository_mock):
+        response = client.get("/runs/experiment/"+EXPE_ID)
+        actual_run_list = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert actual_run_list == expected_run_list

--- a/carbonserver/tests/api/routers/test_teams.py
+++ b/carbonserver/tests/api/routers/test_teams.py
@@ -125,7 +125,7 @@ def test_get_teams_from_organization_returns_correct_team(client, custom_test_se
     expected_team_1 = TEAM_1
     expected_team_list = [expected_team_1]
     repository_mock.get_teams_from_organization.return_value = [
-        SqlModelTeam(**expected_team_1),
+        Team(**expected_team_1),
     ]
 
     with custom_test_server.container.team_repository.override(repository_mock):

--- a/carbonserver/tests/api/routers/test_teams.py
+++ b/carbonserver/tests/api/routers/test_teams.py
@@ -115,3 +115,19 @@ def test_list_teams_returns_all_teams(client, custom_test_server):
 
     assert response.status_code == status.HTTP_200_OK
     assert actual_team_list == expected_team_list
+
+
+def test_get_teams_from_organization_returns_correct_team(client, custom_test_server):
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_team_1 = TEAM_1
+    expected_team_list = [expected_team_1]
+    repository_mock.get_teams_from_organization.return_value = [
+        SqlModelTeam(**expected_team_1),
+    ]
+
+    with custom_test_server.container.team_repository.override(repository_mock):
+        response = client.get("/teams/organization/" + ORG_ID)
+        actual_team_list = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert actual_team_list == expected_team_list

--- a/carbonserver/tests/api/service/test_project_service.py
+++ b/carbonserver/tests/api/service/test_project_service.py
@@ -41,3 +41,15 @@ def test_project_service_retrieves_correct_project_by_id():
 
     assert actual_saved_project.id == expected_project.id
     assert actual_saved_project.name == expected_project.name
+
+
+def test_project_service_retrieves__correct_project_by_team_id():
+
+    repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
+    expected_team_id = TEAM_ID
+    project_service: ProjectService = ProjectService(repository_mock)
+    repository_mock.get_projects_from_team.return_value = [PROJECT]
+
+    actual_projects = project_service.list_projects_from_team(TEAM_ID)
+
+    assert actual_projects[0].team_id == expected_team_id

--- a/carbonserver/tests/api/service/test_run_service.py
+++ b/carbonserver/tests/api/service/test_run_service.py
@@ -27,7 +27,7 @@ RUN_2 = Run(
 
 
 @mock.patch("uuid.uuid4", return_value=RUN_ID)
-def test_teams_service_creates_correct_team(_):
+def test_run_service_creates_correct_run(_):
 
     repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
     expected_id = RUN_ID
@@ -45,14 +45,14 @@ def test_teams_service_creates_correct_team(_):
     assert actual_saved_run.id == expected_id
 
 
-def test_teams_service_retrieves_all_existing_teams():
+def test_run_service_retrieves_all_existing_runs():
 
     repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
     expected_run_ids_list = [RUN_ID, RUN_ID_2]
-    organization_service: RunService = RunService(repository_mock)
+    run_service: RunService = RunService(repository_mock)
     repository_mock.list_runs.return_value = [RUN_1, RUN_2]
 
-    run_list = organization_service.list_runs()
+    run_list = run_service.list_runs()
     actual_run_ids_list = map(lambda x: x.id, iter(run_list))
     diff = set(actual_run_ids_list) ^ set(expected_run_ids_list)
 
@@ -60,13 +60,25 @@ def test_teams_service_retrieves_all_existing_teams():
     assert len(run_list) == len(expected_run_ids_list)
 
 
-def test_teams_service_retrieves_correct_team_by_id():
+def test_run_service_retrieves_correct_run_by_id():
 
     repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
     expected_org: Run = RUN_1
-    organization_service: RunService = RunService(repository_mock)
+    run_service: RunService = RunService(repository_mock)
     repository_mock.get_one_run.return_value = RUN_1
 
-    actual_saved_org = organization_service.read_run(RUN_ID)
+    actual_saved_org = run_service.read_run(RUN_ID)
 
     assert actual_saved_org.id == expected_org.id
+
+
+def test_run_service_retrieves_correct_run_by_experiment_id():
+
+    repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
+    expected_experiment_id = EXPERIMENT_ID
+    run_service: RunService = RunService(repository_mock)
+    repository_mock.get_runs_from_experiment.return_value = [RUN_1]
+
+    actual_runs = run_service.list_runs_from_experiment(EXPERIMENT_ID)
+
+    assert actual_runs[0].experiment_id == expected_experiment_id

--- a/carbonserver/tests/api/service/test_teams_service.py
+++ b/carbonserver/tests/api/service/test_teams_service.py
@@ -75,3 +75,16 @@ def test_teams_service_retrieves_correct_team_by_id():
 
     assert actual_saved_org.id == expected_org.id
     assert actual_saved_org.name == expected_org.name
+
+
+def test_teams_service_retrieves_correct_team_by_organization_id():
+
+    repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
+    expected_organization_id = ORG_ID
+    team_service: TeamService = TeamService(repository_mock)
+    repository_mock.get_teams_from_organization.return_value = [TEAM_1]
+
+    actual_teams = team_service.list_teams_from_organization(ORG_ID)
+
+    assert actual_teams[0].organization_id == expected_organization_id
+

--- a/carbonserver/tests/api/service/test_teams_service.py
+++ b/carbonserver/tests/api/service/test_teams_service.py
@@ -87,4 +87,3 @@ def test_teams_service_retrieves_correct_team_by_organization_id():
     actual_teams = team_service.list_teams_from_organization(ORG_ID)
 
     assert actual_teams[0].organization_id == expected_organization_id
-

--- a/carbonserver/tests/postman/TestCollection.postman_collection.json
+++ b/carbonserver/tests/postman/TestCollection.postman_collection.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "0f05af20-07c9-4ce5-a0d3-06ef21364095",
+		"_postman_id": "8765906a-21a1-482c-9b1f-65ca5677dfc6",
 		"name": "Test Collection",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -13,14 +13,14 @@
 				"followAuthorizationHeader": false
 			},
 			"request": {
-				"method": "PUT",
+				"method": "POST",
 				"header": [
 					{
 						"key": "Content-Type",
 						"value": "application/json"
 					},
 					{
-						"key": "x_token\n",
+						"key": "x_token",
 						"value": "fake-super-secret-token"
 					},
 					{
@@ -30,9 +30,19 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"timestamp\":\"2021-04-04T08:43:00+02:00\",\"run_id\":\"40088f1a-d28e-4980-8d80-bf5600056a14\",\"duration\":98745,\"emissions\":1.548444,\"energy_consumed\":57.21874}"
+					"raw": "{\n  \"timestamp\": \"2021-04-04T08:43:00+02:00\",\n  \"run_id\": \"402e152a-0e89-4259-b920-41e85f6a414e\",\n  \"duration\": 98745,\n  \"emissions_sum\": 1544.54,\n  \"emissions_rate\": 1.548444,\n  \"cpu_power\": 0.3,\n  \"gpu_power\": 0,\n  \"ram_power\": 0.15,\n  \"cpu_energy\": 55.21874,\n  \"gpu_energy\": 0,\n  \"ram_energy\": 2,\n  \"energy_consumed\": 57.21874\n}"
 				},
-				"url": "http://localhost:8000/emission"
+				"url": {
+					"raw": "http://localhost:8000/emission",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"emission"
+					]
+				}
 			},
 			"response": []
 		},
@@ -51,7 +61,7 @@
 						"value": "application/json"
 					},
 					{
-						"key": "x_token\n",
+						"key": "x_token",
 						"value": "fake-super-secret-token"
 					},
 					{
@@ -60,7 +70,7 @@
 					}
 				],
 				"url": {
-					"raw": "http://localhost:8000/emission/1?id=1",
+					"raw": "http://localhost:8000/emission/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -69,12 +79,6 @@
 					"path": [
 						"emission",
 						"1"
-					],
-					"query": [
-						{
-							"key": "id",
-							"value": "1"
-						}
 					]
 				},
 				"description": "Get saved emission objects by id."
@@ -96,7 +100,7 @@
 						"value": "application/json"
 					},
 					{
-						"key": "x_token\n",
+						"key": "x_token",
 						"value": "fake-super-secret-token"
 					},
 					{
@@ -105,7 +109,7 @@
 					}
 				],
 				"url": {
-					"raw": "http://localhost:8000/emissions/40088f1a-d28e-4980-8d80-bf5600056a14?id=1",
+					"raw": "http://localhost:8000/emissions/run/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -113,13 +117,8 @@
 					"port": "8000",
 					"path": [
 						"emissions",
-						"40088f1a-d28e-4980-8d80-bf5600056a14"
-					],
-					"query": [
-						{
-							"key": "id",
-							"value": "1"
-						}
+						"run",
+						"1"
 					]
 				},
 				"description": "Get saved emission objects for example run id."
@@ -134,10 +133,10 @@
 				"followAuthorizationHeader": false
 			},
 			"request": {
-				"method": "PUT",
+				"method": "POST",
 				"header": [
 					{
-						"key": "x_token\n",
+						"key": "x_token",
 						"value": "fake-super-secret-token"
 					},
 					{
@@ -149,7 +148,129 @@
 					"mode": "raw",
 					"raw": "{\n  \"timestamp\": \"2021-04-04T08:43:00+02:00\",\n  \"experiment_id\": \"1\"\n}"
 				},
-				"url": "http://localhost:8000/run"
+				"url": {
+					"raw": "http://localhost:8000/run",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"run"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Run by id",
+			"protocolProfileBehavior": {
+				"followRedirects": false,
+				"followOriginalHttpMethod": false,
+				"followAuthorizationHeader": false,
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x_token",
+						"value": "fake-super-secret-token"
+					},
+					{
+						"key": "token",
+						"value": "jessica"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"timestamp\": \"2021-04-04T08:43:00+02:00\",\n  \"experiment_id\": \"1\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8000/run/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"run",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Runs",
+			"protocolProfileBehavior": {
+				"followRedirects": false,
+				"followOriginalHttpMethod": false,
+				"followAuthorizationHeader": false,
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x_token",
+						"value": "fake-super-secret-token"
+					},
+					{
+						"key": "token",
+						"value": "jessica"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"timestamp\": \"2021-04-04T08:43:00+02:00\",\n  \"experiment_id\": \"1\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8000/runs",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"runs"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Runs by Experiment",
+			"protocolProfileBehavior": {
+				"followRedirects": false,
+				"followOriginalHttpMethod": false,
+				"followAuthorizationHeader": false
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x_token",
+						"value": "fake-super-secret-token"
+					},
+					{
+						"key": "token",
+						"value": "jessica"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8000/runs/experiment/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"runs",
+						"experiment",
+						"1"
+					]
+				}
 			},
 			"response": []
 		},
@@ -161,10 +282,10 @@
 				"followAuthorizationHeader": false
 			},
 			"request": {
-				"method": "PUT",
+				"method": "POST",
 				"header": [
 					{
-						"key": "x_token\n",
+						"key": "x_token",
 						"value": "fake-super-secret-token"
 					},
 					{
@@ -176,7 +297,17 @@
 					"mode": "raw",
 					"raw": "{\n  \"name\": \"Run on AWS\",\n  \"description\": \"AWS API for Code Carbon\",\n  \"timestamp\": \"2021-04-04T08:43:00+02:00\",\n  \"country_name\": \"France\",\n  \"country_iso_code\": \"FRA\",\n  \"region\": \"france\",\n  \"on_cloud\": true,\n  \"cloud_provider\": \"aws\",\n  \"cloud_region\": \"eu-west-1a\",\n  \"project_id\": \"1\"\n}"
 				},
-				"url": "http://localhost:8000/experiment"
+				"url": {
+					"raw": "http://localhost:8000/experiment",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"experiment"
+					]
+				}
 			},
 			"response": []
 		},
@@ -191,7 +322,7 @@
 				"method": "GET",
 				"header": [
 					{
-						"key": "x_token\n",
+						"key": "x_token",
 						"value": "fake-super-secret-token"
 					},
 					{
@@ -199,7 +330,53 @@
 						"value": "jessica"
 					}
 				],
-				"url": "http://localhost:8000/experiment/1"
+				"url": {
+					"raw": "http://localhost:8000/experiment/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"experiment",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Experiments by Project",
+			"protocolProfileBehavior": {
+				"followRedirects": false,
+				"followOriginalHttpMethod": false,
+				"followAuthorizationHeader": false
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x_token",
+						"value": "fake-super-secret-token"
+					},
+					{
+						"key": "token",
+						"value": "jessica"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8000/experiments/project/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"experiments",
+						"project",
+						"1"
+					]
+				}
 			},
 			"response": []
 		},
@@ -211,7 +388,7 @@
 				"followAuthorizationHeader": false
 			},
 			"request": {
-				"method": "PUT",
+				"method": "POST",
 				"header": [
 					{
 						"key": "Content-Type",
@@ -230,7 +407,17 @@
 					"mode": "raw",
 					"raw": "{\"name\":\"Code Carbon\",\"description\":\"Save the world, one run at a time.\"}"
 				},
-				"url": "http://localhost:8000/organization"
+				"url": {
+					"raw": "http://localhost:8000/organization",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"organization"
+					]
+				}
 			},
 			"response": []
 		},
@@ -257,7 +444,55 @@
 						"value": "jessica"
 					}
 				],
-				"url": "http://localhost:8000/organization/1"
+				"url": {
+					"raw": "http://localhost:8000/organization/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"organization",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Organizations",
+			"protocolProfileBehavior": {
+				"followRedirects": false,
+				"followOriginalHttpMethod": false,
+				"followAuthorizationHeader": false
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "x_token",
+						"value": "fake-super-secret-token"
+					},
+					{
+						"key": "token",
+						"value": "jessica"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8000/organizations",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"organizations"
+					]
+				}
 			},
 			"response": []
 		},
@@ -269,7 +504,7 @@
 				"followAuthorizationHeader": false
 			},
 			"request": {
-				"method": "PUT",
+				"method": "POST",
 				"header": [
 					{
 						"key": "x_token",
@@ -284,7 +519,17 @@
 					"mode": "raw",
 					"raw": "{\n  \"name\": \"API Code Carbon\",\n  \"description\": \"API for Code Carbon\",\n  \"team_id\": \"1\"\n}\n"
 				},
-				"url": "http://localhost:8000/project"
+				"url": {
+					"raw": "http://localhost:8000/project",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"project"
+					]
+				}
 			},
 			"response": []
 		},
@@ -307,7 +552,50 @@
 						"value": "jessica"
 					}
 				],
-				"url": "http://localhost:8000/project/1"
+				"url": {
+					"raw": "http://localhost:8000/project/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"project",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Projects by Team",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x_token",
+						"value": "fake-super-secret-token",
+						"type": "text"
+					},
+					{
+						"key": "token",
+						"value": "jessica",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8000/projects/team/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"projects",
+						"team",
+						"1"
+					]
+				}
 			},
 			"response": []
 		},
@@ -319,7 +607,7 @@
 				"followAuthorizationHeader": false
 			},
 			"request": {
-				"method": "PUT",
+				"method": "POST",
 				"header": [
 					{
 						"key": "x_token",
@@ -332,9 +620,19 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"name\": \"Data For Good\",\n  \"description\": \"Data For Good France\",\n  \"organization_id\": \"1\"\n}"
+					"raw": "{\n  \"name\": \"Data For Good\",\n  \"description\": \"Data For Good France\",\n  \"organization_id\": \"1\"\n  \"api_key\": \"default\"\n}"
 				},
-				"url": "http://localhost:8000/team"
+				"url": {
+					"raw": "http://localhost:8000/team",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"team"
+					]
+				}
 			},
 			"response": []
 		},
@@ -357,7 +655,86 @@
 						"value": "jessica"
 					}
 				],
-				"url": "http://localhost:8000/team/1"
+				"url": {
+					"raw": "http://localhost:8000/team/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"team",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Teams",
+			"protocolProfileBehavior": {
+				"followRedirects": false,
+				"followOriginalHttpMethod": false,
+				"followAuthorizationHeader": false
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x_token",
+						"value": "fake-super-secret-token"
+					},
+					{
+						"key": "token",
+						"value": "jessica"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8000/teams",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"teams"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Teams by Organization",
+			"protocolProfileBehavior": {
+				"followRedirects": false,
+				"followOriginalHttpMethod": false,
+				"followAuthorizationHeader": false
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x_token",
+						"value": "fake-super-secret-token"
+					},
+					{
+						"key": "token",
+						"value": "jessica"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8000/teams/organization/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"teams",
+						"organization",
+						"1"
+					]
+				}
 			},
 			"response": []
 		},
@@ -369,14 +746,33 @@
 				"followAuthorizationHeader": false
 			},
 			"request": {
-				"method": "PUT",
+				"method": "POST",
 				"header": [],
-				"url": "C"
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"email\": \"user@example.com\",\n  \"name\": \"string\",\n  \"password\": \"string\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8000/user",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"user"
+					]
+				}
 			},
 			"response": []
 		},
 		{
-			"name": "Get User",
+			"name": "Get User by id",
 			"protocolProfileBehavior": {
 				"followRedirects": false,
 				"followOriginalHttpMethod": false,
@@ -385,7 +781,42 @@
 			"request": {
 				"method": "GET",
 				"header": [],
-				"url": "C"
+				"url": {
+					"raw": "http://localhost:8000/user/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"user",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Users",
+			"protocolProfileBehavior": {
+				"followRedirects": false,
+				"followOriginalHttpMethod": false,
+				"followAuthorizationHeader": false
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8000/users",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"users"
+					]
+				}
 			},
 			"response": []
 		}


### PR DESCRIPTION
This change adds new routes in the API.

Closes #219 

-     GET /teams/organization/{organization_id} to list all teams of a given organization.
-     GET /projects/team/{team_id} to list all projects of a given team.
-     GET /runs/experiment/{experiment_id} to list all runs of a given experiment.
