### PR TITLE
Restart tracker

### DIFF
--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -144,11 +144,10 @@ class IntelPowerGadget:
                 else:
                     cpu_details[col_name] = cpu_data[col_name].mean()
         except Exception as e:
-            logger.info(
-                f"Unable to read Intel Power Gadget logged file at {self._log_file_path}\n \
-                Exception occurred {e}",
-                exc_info=True,
+            logger.warning(
+                f"Unable to read Intel Power Gadget logged file. Exception:\n{e}"
             )
+            logger.debug("Full error:\n", exc_info=True)
         return cpu_details
 
 
@@ -210,10 +209,10 @@ class IntelRAPL:
                 cpu_details[rapl_file.name] = rapl_file.power_measurement.kW
         except Exception as e:
             logger.info(
-                f"Unable to read Intel RAPL files at {self._rapl_files}\n \
-                Exception occurred {e}",
-                exc_info=True,
+                f"Unable to read Intel RAPL files at {self._rapl_files}."
+                + f" Exception:\n {e}"
             )
+            logger.debug("Full error:\n", exc_info=True)
         return cpu_details
 
 

--- a/codecarbon/core/util.py
+++ b/codecarbon/core/util.py
@@ -13,7 +13,6 @@ def suppress(*exceptions):
         logger.warning(
             exceptions if len(exceptions) != 1 else exceptions[0], exc_info=True
         )
-        logger.warning("stopping.")
         pass
 
 

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -288,6 +288,29 @@ class BaseEmissionsTracker(ABC):
             self.persistence_objs.append(self._cc_api__out)
 
     @suppress(Exception)
+    def flush(self) -> Optional[float]:
+        """
+        Write emission to disk or call the API depending of the configuration
+        but keep running the experiment.
+        :return: CO2 emissions in kgs
+        """
+        if self._start_time is None:
+            logger.error("Need to first start the tracker")
+            return None
+
+        # Run to calculate the power used from last
+        # scheduled measurement to shutdown
+        self._measure_power()
+
+        emissions_data = self._prepare_emissions_data()
+        for persistence in self.persistence_objs:
+            if isinstance(persistence, CodeCarbonAPIOutput):
+                emissions_data = self._prepare_emissions_data(delta=True)
+            persistence.out(emissions_data)
+
+        return emissions_data.emissions
+
+    @suppress(Exception)
     def start(self) -> None:
         """
         Starts tracking the experiment.

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -291,29 +291,6 @@ class BaseEmissionsTracker(ABC):
         return value
 
     @suppress(Exception)
-    def flush(self) -> Optional[float]:
-        """
-        Write emission to disk or call the API depending of the configuration
-        but keep running the experiment.
-        :return: CO2 emissions in kgs
-        """
-        if self._start_time is None:
-            logger.error("Need to first start the tracker")
-            return None
-
-        # Run to calculate the power used from last
-        # scheduled measurement to shutdown
-        self._measure_power()
-
-        emissions_data = self._prepare_emissions_data()
-        for persistence in self.persistence_objs:
-            if isinstance(persistence, CodeCarbonAPIOutput):
-                emissions_data = self._prepare_emissions_data(delta=True)
-            persistence.out(emissions_data)
-
-        return emissions_data.emissions
-
-    @suppress(Exception)
     def start(self) -> None:
         """
         Starts tracking the experiment.
@@ -347,6 +324,29 @@ class BaseEmissionsTracker(ABC):
             logger.info("Starting tracker.")
         self._last_measured_time = self._start_time = time.time()
         self._scheduler.start()
+
+    @suppress(Exception)
+    def flush(self) -> Optional[float]:
+        """
+        Write emission to disk or call the API depending of the configuration
+        but keep running the experiment.
+        :return: CO2 emissions in kgs
+        """
+        if self._start_time is None:
+            logger.error("Need to first start the tracker")
+            return None
+
+        # Run to calculate the power used from last
+        # scheduled measurement to shutdown
+        self._measure_power()
+
+        emissions_data = self._prepare_emissions_data()
+        for persistence in self.persistence_objs:
+            if isinstance(persistence, CodeCarbonAPIOutput):
+                emissions_data = self._prepare_emissions_data(delta=True)
+            persistence.out(emissions_data)
+
+        return emissions_data.emissions
 
     @suppress(Exception)
     def stop(self) -> Optional[EmissionsData]:

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -24,5 +24,6 @@ model.compile(optimizer="adam", loss=loss_fn, metrics=["accuracy"])
 tracker = EmissionsTracker()
 tracker.start()
 model.fit(x_train, y_train, epochs=100)
-emissions: float = tracker.stop()
+emissions_data = tracker.stop()
+emissions: float = emissions_data.emissions
 print(f"Emissions: {emissions} kg")

--- a/examples/mnist_callback.py
+++ b/examples/mnist_callback.py
@@ -1,0 +1,45 @@
+import tensorflow as tf
+from tensorflow.keras.callbacks import Callback
+
+from codecarbon import EmissionsTracker
+
+"""
+This sample code show how to use CodeCarbon as a Keras Callback
+to save emissions after each epoch.
+"""
+
+
+class CodeCarbonCallBack(Callback):
+    def __init__(self, codecarbon_tracker):
+        self.codecarbon_tracker = codecarbon_tracker
+        pass
+
+    def on_epoch_end(self, epoch, logs=None):
+        self.codecarbon_tracker.flush()
+
+
+mnist = tf.keras.datasets.mnist
+
+(x_train, y_train), (x_test, y_test) = mnist.load_data()
+x_train, x_test = x_train / 255.0, x_test / 255.0
+
+
+model = tf.keras.models.Sequential(
+    [
+        tf.keras.layers.Flatten(input_shape=(28, 28)),
+        tf.keras.layers.Dense(128, activation="relu"),
+        tf.keras.layers.Dropout(0.2),
+        tf.keras.layers.Dense(10),
+    ]
+)
+
+loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+
+model.compile(optimizer="adam", loss=loss_fn, metrics=["accuracy"])
+
+tracker = EmissionsTracker()
+tracker.start()
+codecarbon_cb = CodeCarbonCallBack(tracker)
+model.fit(x_train, y_train, epochs=4, callbacks=[codecarbon_cb])
+emissions: float = tracker.stop()
+print(f"Emissions: {emissions} kg")

--- a/examples/mnist_context_manager.py
+++ b/examples/mnist_context_manager.py
@@ -26,4 +26,4 @@ def train_model():
 if __name__ == "__main__":
     with EmissionsTracker(project_name="mnist") as tracker:
         model = train_model()
-    print(tracker.final_emissions)
+    print(tracker.final_emissions_data.emissions)

--- a/examples/mnist_grid_search.py
+++ b/examples/mnist_grid_search.py
@@ -31,7 +31,8 @@ def main():
     tracker = EmissionsTracker(project_name="mnist_grid_search")
     tracker.start()
     grid_result = grid.fit(x_train, y_train)
-    emissions = tracker.stop()
+    emissions_data = tracker.stop()
+    emissions = emissions_data.emissions
 
     print(f"Best Accuracy : {grid_result.best_score_} using {grid_result.best_params_}")
     print(f"Emissions : {emissions} kg CO₂")

--- a/examples/mnist_random_search.py
+++ b/examples/mnist_random_search.py
@@ -45,7 +45,8 @@ def main():
     tracker = EmissionsTracker(project_name="mnist_random_search")
     tracker.start()
     tuner.search(x_train, y_train, epochs=10, validation_data=(x_test, y_test))
-    emissions = tracker.stop()
+    emissions_data = tracker.stop()
+    emissions = emissions_data.emissions
 
     print(f"Emissions : {emissions} kg CO₂")
 

--- a/tests/test_emissions_tracker.py
+++ b/tests/test_emissions_tracker.py
@@ -6,6 +6,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import numpy as np
 import pandas as pd
 import requests
 import responses
@@ -80,7 +81,7 @@ class TestCarbonTracker(unittest.TestCase):
         # WHEN
         tracker.start()
         heavy_computation()
-        emissions = tracker.stop()
+        emissions = tracker.stop().emissions
 
         # THEN
         self.assertGreaterEqual(
@@ -116,7 +117,7 @@ class TestCarbonTracker(unittest.TestCase):
         # WHEN
         tracker.start()
         heavy_computation(run_time_secs=2)
-        emissions = tracker.stop()
+        emissions = tracker.stop().emissions
         self.assertEqual(1, mocked_requests_get.call_count)
         self.assertIsInstance(emissions, float)
         self.assertAlmostEqual(1.1037980397280433e-05, emissions, places=2)
@@ -386,8 +387,10 @@ class TestCarbonTracker(unittest.TestCase):
         self.assertEqual(
             "https://get.geojs.io/v1/ip/geo.json", responses.calls[0].request.url
         )
-        self.assertIsInstance(tracker.final_emissions, float)
-        self.assertAlmostEqual(tracker.final_emissions, 6.262572537957655e-05, places=2)
+        self.assertIsInstance(tracker.final_emissions_data.emissions, float)
+        self.assertAlmostEqual(
+            tracker.final_emissions_data.emissions, 6.262572537957655e-05, places=2
+        )
 
     @responses.activate
     def test_carbon_tracker_offline_context_manager(
@@ -407,4 +410,168 @@ class TestCarbonTracker(unittest.TestCase):
 
         self.assertEqual("United States", emissions_df["country_name"].values[0])
         self.assertEqual("USA", emissions_df["country_iso_code"].values[0])
-        self.assertIsInstance(tracker.final_emissions, float)
+        self.assertIsInstance(tracker.final_emissions_data.emissions, float)
+
+    def test_offline_tracker_start_stop_start_stop(
+        self,
+        mocked_get_cloud_metadata,
+        mocked_get_gpu_details,
+        mocked_is_gpu_details_available,
+        mock_setup_intel_cli,
+        mock_log_values,
+    ):
+        tracker = OfflineEmissionsTracker(
+            measure_power_secs=2, country_iso_code="USA", output_dir=self.temp_path
+        )
+
+        tracker.start()
+        heavy_computation(run_time_secs=5)
+        tracker.stop()
+
+        tracker.start()
+        heavy_computation(run_time_secs=5)
+        tracker.stop()
+
+    def test_online_tracker_start_stop_start_stop(
+        self,
+        mocked_get_cloud_metadata,
+        mocked_get_gpu_details,
+        mocked_is_gpu_details_available,
+        mock_setup_intel_cli,
+        mock_log_values,
+    ):
+
+        tracker = EmissionsTracker(measure_power_secs=1, save_to_file=False)
+
+        tracker.start()
+        heavy_computation(run_time_secs=1.2)
+        tracker.stop()
+
+        tracker.start()
+        heavy_computation(run_time_secs=1.2)
+        tracker.stop()
+
+    def test_tracker_resume(
+        self,
+        mocked_get_cloud_metadata,
+        mocked_get_gpu_details,
+        mocked_is_gpu_details_available,
+        mock_setup_intel_cli,
+        mock_log_values,
+    ):
+
+        run_time = 3
+        pause_time = 2
+        keys = [
+            "timestamp",
+            "project_name",
+            "duration",
+            "emissions",
+            "energy_consumed",
+        ]
+        for tracker, name in [
+            (
+                OfflineEmissionsTracker(
+                    measure_power_secs=1,
+                    country_iso_code="USA",
+                    output_dir=self.temp_path,
+                    output_file="resume_emissions_offline.csv",
+                ),
+                "resume_emissions_offline.csv",
+            ),
+            (
+                EmissionsTracker(
+                    measure_power_secs=1,
+                    output_dir=self.temp_path,
+                    output_file="resume_emissions.csv",
+                ),
+                "resume_emissions.csv",
+            ),
+        ]:
+
+            with self.subTest(tracker=tracker):
+
+                path = self.temp_path / name
+
+                tracker.start()
+                heavy_computation(run_time_secs=run_time)
+                first_data = tracker.stop()
+                df1 = pd.read_csv(path)
+
+                heavy_computation(run_time_secs=pause_time)
+
+                tracker.start()
+                heavy_computation(run_time_secs=run_time)
+                second_data = tracker.stop()
+                df2 = pd.read_csv(path)
+
+                dict_df = dict(df2.iloc[-1].fillna(""))
+                dict_data = dict(second_data.values)
+
+                self.assertAlmostEqual(second_data.duration, 2 * run_time, delta=0.1)
+                self.assertGreater(second_data.emissions, first_data.emissions)
+                self.assertGreater(
+                    second_data.energy_consumed, first_data.energy_consumed
+                )
+                self.assertEqual(len(df1), len(df2))
+                for k in keys:
+                    if isinstance(dict_df[k], (float, int)):
+                        self.assertAlmostEqual(dict_df[k], dict_data[k])
+                    else:
+                        self.assertEqual(dict_df[k], dict_data[k])
+
+    def test_tracker_resume_update_row(
+        self,
+        mocked_get_cloud_metadata,
+        mocked_get_gpu_details,
+        mocked_is_gpu_details_available,
+        mock_setup_intel_cli,
+        mock_log_values,
+    ):
+
+        n_trackers = 3
+        n_loops = 3
+
+        trackers = [
+            EmissionsTracker(
+                measure_power_secs=1,
+                output_dir=self.temp_path,
+                output_file="resume_emissions_update_row.csv",
+                log_level="error",
+            )
+            for _ in range(n_trackers)
+        ]
+
+        for i in range(n_loops):
+
+            print("\nLoop", i)
+
+            for t, tracker in enumerate(trackers):
+                print("Tracker", t)
+                tracker.start()
+                heavy_computation(2)
+                tracker.stop()
+
+            id_tracker = np.random.randint(0, n_trackers)
+            tracker = trackers[id_tracker]
+            keys = [
+                "timestamp",
+                "project_name",
+                "duration",
+                "emissions",
+                "energy_consumed",
+            ]
+            path = self.temp_path / "resume_emissions_update_row.csv"
+
+            df = pd.read_csv(path)
+
+            self.assertEqual(len(df), len(trackers))
+
+            dict_df = dict(df.iloc[id_tracker])
+            dict_data = dict(trackers[id_tracker].final_emissions_data.values)
+
+            for k in keys:
+                if isinstance(dict_df[k], (float, int)):
+                    self.assertAlmostEqual(dict_df[k], dict_data[k])
+                else:
+                    self.assertEqual(dict_df[k], dict_data[k])

--- a/tests/test_emissions_tracker_constant.py
+++ b/tests/test_emissions_tracker_constant.py
@@ -28,7 +28,7 @@ class TestCarbonTrackerConstant(unittest.TestCase):
         tracker = EmissionsTracker()
         tracker.start()
         heavy_computation(run_time_secs=1)
-        emissions = tracker.stop()
+        emissions = tracker.stop().emissions
         assert isinstance(emissions, float)
         self.assertNotEqual(emissions, 0.0)
         self.assertAlmostEqual(emissions, 6.262572537957655e-05, places=2)
@@ -38,7 +38,7 @@ class TestCarbonTrackerConstant(unittest.TestCase):
         tracker = OfflineEmissionsTracker(country_iso_code="USA")
         tracker.start()
         heavy_computation(run_time_secs=1)
-        emissions = tracker.stop()
+        emissions = tracker.stop().emissions
         assert isinstance(emissions, float)
         self.assertNotEqual(emissions, 0.0)
         self.assertAlmostEqual(emissions, 6.262572537957655e-05, places=2)


### PR DESCRIPTION
Addressing #217 

* call the (`start()`, `stop()`) pair multiple times
* use pandas to read/update the csv output

WIP -> this may delete or mess with existing csv files

**How it works**: the gist of it is that if `tracker.stop()` stores and `_end_time` so calling `tracker.start()` after `stop()` will use this to detect it was re-started. Each `persistence_obj` should handle this appropriately. As of now, only the CSV output is implemented (see issue below)

**Issue**: I could not get the scheduler to just `start()` again so I create a new one if the tracker is re-started

**Issue**: There is currently no ID in the csv file (there used to be one but now it's gone) so the current PR expects `(timestamp, project_name)` to be a unique pair.

**Warning**: only the latest `emissions_data` is written. This means the `timestamp` is that of the latest write not the first one. Is this an issue? 

**To do**: 

* [x] check `duration` implem
* [ ] Doc
* [x] re-start tests (csv)
* [ ] Handle CodeCarbon API
* [ ] re-start tests (API)