### PR TITLE
Method to flush emission to CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,16 @@ with EmissionsTracker() as tracker:
     # GPU Intensive code goes here
 ```
 
+### Flush data when running
 
+By default, Code Carbon only write the CVS output file when it stop.
+But for long run you may want to get intermediate data.
+It is possible to call the flush() methode to do so.
+
+Have a look to [./examples/mnist_callback.py](./examples/mnist_callback.py) for an example.
+
+Note that if you use the API it will also call it when you call flush().
+You could set *api_call_interval* to -1, so that it will not be called automatically and then force a call at the end of each epoch to get the emission of each epoch.
 
 ### Using comet.ml
 

--- a/codecarbon/core/api_client.py
+++ b/codecarbon/core/api_client.py
@@ -52,14 +52,19 @@ class ApiClient:  # (AsyncClient)
         self._previous_call = time.time()
         if self.run_id is None:
             # TODO : raise an Exception ?
-            logger.error(
-                "add_emissionadd_emission need a run_id : the initial call may "
+            logger.debug(
+                "ApiClient.add_emission need a run_id : the initial call may "
                 + "have failed. Retrying..."
             )
             self._create_run(self.experiment_id)
+            if self.run_id is None:
+                logger.error(
+                    "ApiClient.add_emission still no run_id, arborting for this time !"
+                )
+            return False
         if carbon_emission["duration"] < 1:
             logger.warning(
-                "Warning : emission not send because of a duration smaller than 1."
+                "ApiClient : emissions not send because of a duration smaller than 1."
             )
             return False
         emission = EmissionCreate(
@@ -80,10 +85,10 @@ class ApiClient:  # (AsyncClient)
             payload = dataclasses.asdict(emission)
             url = self.url + "/emission"
             r = requests.post(url=url, json=payload, timeout=2)
-            logger.debug(f"Successful upload emission {payload} to {url}")
             if r.status_code != 201:
                 self._log_error(url, payload, r)
                 return False
+            logger.debug(f"ApiClient - Successful upload emission {payload} to {url}")
         except Exception as e:
             logger.error(e, exc_info=True)
             return False
@@ -96,7 +101,7 @@ class ApiClient:  # (AsyncClient)
         """
         if self.experiment_id is None:
             # TODO : raise an Exception ?
-            logger.error("FATAL The API _create_run need an experiment_id !")
+            logger.error("ApiClient FATAL The API _create_run need an experiment_id !")
             return None
         try:
             run = RunCreate(
@@ -110,7 +115,7 @@ class ApiClient:  # (AsyncClient)
                 return None
             self.run_id = r.json()["id"]
             logger.info(
-                "Successfully registered your run on the API.\n\n"
+                "ApiClient Successfully registered your run on the API.\n\n"
                 + f"Run ID: {self.run_id}\n"
                 + f"Experiment ID: {self.experiment_id}\n"
             )
@@ -134,10 +139,10 @@ class ApiClient:  # (AsyncClient)
 
     def _log_error(self, url, payload, response):
         logger.error(
-            f" Error when calling the API on {url} with : {json.dumps(payload)}"
+            f"ApiClient Error when calling the API on {url} with : {json.dumps(payload)}"
         )
         logger.error(
-            f" API return http code {response.status_code} and answer : {response.text}"
+            f"ApiClient API return http code {response.status_code} and answer : {response.text}"
         )
 
     def close_experiment(self):

--- a/codecarbon/core/api_client.py
+++ b/codecarbon/core/api_client.py
@@ -59,12 +59,12 @@ class ApiClient:  # (AsyncClient)
             self._create_run(self.experiment_id)
             if self.run_id is None:
                 logger.error(
-                    "ApiClient.add_emission still no run_id, arborting for this time !"
+                    "ApiClient.add_emission still no run_id, aborting for this time !"
                 )
             return False
         if carbon_emission["duration"] < 1:
             logger.warning(
-                "ApiClient : emissions not send because of a duration smaller than 1."
+                "ApiClient : emissions not sent because of a duration smaller than 1."
             )
             return False
         emission = EmissionCreate(
@@ -101,7 +101,7 @@ class ApiClient:  # (AsyncClient)
         """
         if self.experiment_id is None:
             # TODO : raise an Exception ?
-            logger.error("ApiClient FATAL The API _create_run need an experiment_id !")
+            logger.error("ApiClient FATAL The API _create_run needs an experiment_id !")
             return None
         try:
             run = RunCreate(

--- a/codecarbon/core/util.py
+++ b/codecarbon/core/util.py
@@ -2,7 +2,6 @@ import logging
 from contextlib import contextmanager
 from os.path import expandvars
 from pathlib import Path
-import pathlib
 from typing import Optional, Union
 
 from codecarbon.external.logger import logger

--- a/codecarbon/core/util.py
+++ b/codecarbon/core/util.py
@@ -1,5 +1,9 @@
 import logging
 from contextlib import contextmanager
+from os.path import expandvars
+from pathlib import Path
+import pathlib
+from typing import Optional, Union
 
 from codecarbon.external.logger import logger
 
@@ -36,3 +40,45 @@ def set_log_level(level: str):
             logger.setLevel(getattr(logging, level))
             return
     logger.error(f"Unknown log level: {level}")
+
+
+def resolve_path(path: Union[str, Path]) -> None:
+
+    """
+    Fully resolve a path:
+    resolve env vars ($HOME etc.) -> expand user (~) -> make absolute
+
+    Args:
+        path (Union[str, Path]): Path to a file or repository to resolve as
+            string or pathlib.Path
+
+    Returns:
+        pathlib.Path: resolved absolute path
+    """
+    return Path(expandvars(str(path))).expanduser().resolve()
+
+
+def backup(file_path: Union[str, Path], ext: Optional[str] = ".bak") -> None:
+    """
+    Resolves the path to a path then backs it up, adding the extension provided.
+
+    Args:
+        file_path (Union[str, Path]): Path to a file to backup.
+        ext (Optional[str], optional): extension to append to the filename when
+            backing it up. Defaults to ".bak".
+    """
+    file_path = resolve_path(file_path)
+    if not file_path.exists():
+        return
+    assert file_path.is_file()
+    idx = 0
+    parent = file_path.parent
+    file_name = f"{file_path.name}{ext}"
+    backup = parent / file_name
+
+    while backup.exists():
+        file_name = f"{file_path.name}_{idx}{ext}"
+        backup = parent / file_name
+        idx += 1
+
+    file_path.rename(backup)

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -309,7 +309,7 @@ class BaseEmissionsTracker(ABC):
     @suppress(Exception)
     def flush(self) -> Optional[float]:
         """
-        Write emission to disk or call the API depending of the configuration
+        Write emission to disk or call the API depending on the configuration
         but keep running the experiment.
         :return: CO2 emissions in kgs
         """

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -279,9 +279,8 @@ class BaseEmissionsTracker(ABC):
         if self._save_to_file:
             self.persistence_objs.append(
                 FileOutput(
-                    os.path.join(
-                        self._output_dir, self._output_file, self._on_csv_write
-                    )
+                    os.path.join(self._output_dir, self._output_file),
+                    self._on_csv_write,
                 )
             )
 

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -5,6 +5,7 @@ OfflineEmissionsTracker and @track_emissions
 import dataclasses
 import os
 import time
+import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import wraps
@@ -286,7 +287,10 @@ class BaseEmissionsTracker(ABC):
                 experiment_id=experiment_id,
                 api_key=api_key,
             )
+            self.run_id = self._cc_api__out.run_id
             self.persistence_objs.append(self._cc_api__out)
+        else:
+            self.run_id = uuid.uuid4()
 
     @suppress(Exception)
     def start(self) -> None:
@@ -381,6 +385,7 @@ class BaseEmissionsTracker(ABC):
         total_emissions = EmissionsData(
             timestamp=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
             project_name=self._project_name,
+            run_id=self.run_id,
             duration=duration.seconds,
             emissions=emissions,
             emissions_rate=emissions * 1000 / duration.seconds,

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -153,6 +153,7 @@ class BaseEmissionsTracker(ABC):
         :param measure_power_secs: Interval (in seconds) to measure hardware power
                                    usage, defaults to 15
         :param api_call_interval: Occurrence to wait before calling API :
+                            -1 : only call api on flush() and at the end.
                             1 : at every measure
                             2 : every 2 measure, etc...
         :param api_endpoint: Optional URL of Code Carbon API endpoint for sending
@@ -475,7 +476,7 @@ class BaseEmissionsTracker(ABC):
         )
         self._last_measured_time = time.time()
         self._measure_occurrence += 1
-        if self._cc_api__out is not None:
+        if self._cc_api__out is not None and self._api_call_interval != -1:
             if self._measure_occurrence >= self._api_call_interval:
                 emissions = self._prepare_emissions_data(delta=True)
                 logger.info(

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -302,6 +302,29 @@ class BaseEmissionsTracker(ABC):
         self._scheduler.start()
 
     @suppress(Exception)
+    def flush(self) -> Optional[float]:
+        """
+        Write emission to disk or call the API depending of the configuration
+        but keep running the experiment.
+        :return: CO2 emissions in kgs
+        """
+        if self._start_time is None:
+            logger.error("Need to first start the tracker")
+            return None
+
+        # Run to calculate the power used from last
+        # scheduled measurement to shutdown
+        self._measure_power()
+
+        emissions_data = self._prepare_emissions_data()
+        for persistence in self.persistence_objs:
+            if isinstance(persistence, CodeCarbonAPIOutput):
+                emissions_data = self._prepare_emissions_data(delta=True)
+            persistence.out(emissions_data)
+
+        return emissions_data.emissions
+
+    @suppress(Exception)
     def stop(self) -> Optional[float]:
         """
         Stops tracking the experiment

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -362,6 +362,7 @@ class BaseEmissionsTracker(ABC):
 
             persistence.out(emissions_data)
 
+        self.final_emissions_data = emissions_data
         self.final_emissions = emissions_data.emissions
         return emissions_data.emissions
 

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -674,6 +674,7 @@ def track_emissions(
     def _decorate(fn: Callable):
         @wraps(fn)
         def wrapped_fn(*args, **kwargs):
+            fn_result = None
             if offline and offline is not _sentinel:
                 if (country_iso_code is None or country_iso_code is _sentinel) and (
                     cloud_provider is None or cloud_provider is _sentinel
@@ -694,7 +695,7 @@ def track_emissions(
                     co2_signal_api_token=co2_signal_api_token,
                 )
                 tracker.start()
-                fn(*args, **kwargs)
+                fn_result = fn(*args, **kwargs)
                 tracker.stop()
             else:
                 tracker = EmissionsTracker(
@@ -715,7 +716,7 @@ def track_emissions(
                 )
                 tracker.start()
                 try:
-                    fn(*args, **kwargs)
+                    fn_result = fn(*args, **kwargs)
                 finally:
                     logger.info(
                         "\nGraceful stopping: collecting and writing information.\n"
@@ -723,6 +724,7 @@ def track_emissions(
                     )
                     tracker.stop()
                     logger.info("Done!\n")
+            return fn_result
 
         return wrapped_fn
 

--- a/codecarbon/output.py
+++ b/codecarbon/output.py
@@ -94,7 +94,12 @@ class FileOutput(BaseOutput):
         file_exists: bool = os.path.isfile(self.save_file_path)
         if file_exists and not self.has_valid_headers(data):
             logger.info("Backing up old emission file")
-            os.rename(self.save_file_path, self.save_file_path + ".bak")
+            new_name = self.save_file_path + ".bak"
+            idx = 1
+            while os.path.isfile(new_name):
+                new_name = self.save_file_path + f"_{idx}.bak"
+                idx += 1
+            os.rename(self.save_file_path, new_name)
             file_exists = False
 
         with open(self.save_file_path, "a+") as f:

--- a/codecarbon/output.py
+++ b/codecarbon/output.py
@@ -81,13 +81,13 @@ class FileOutput(BaseOutput):
     Saves experiment artifacts to a file
     """
 
-    def __init__(self, save_file_path: str, on_flush: str = "append"):
-        if on_flush not in {"append", "update"}:
+    def __init__(self, save_file_path: str, on_csv_write: str = "append"):
+        if on_csv_write not in {"append", "update"}:
             raise ValueError(
-                f"Unknown `on_flush` value: {on_flush}"
+                f"Unknown `on_csv_write` value: {on_csv_write}"
                 + " (should be one of 'append' or 'update'"
             )
-        self.on_flush: str = on_flush
+        self.on_csv_write: str = on_csv_write
         self.save_file_path: str = save_file_path
 
     def has_valid_headers(self, data: EmissionsData):
@@ -112,7 +112,7 @@ class FileOutput(BaseOutput):
         if not file_exists:
             df = pd.DataFrame(columns=data.values.keys())
             df = df.append(dict(data.values), ignore_index=True)
-        elif self.on_flush == "append":
+        elif self.on_csv_write == "append":
             df = pd.read_csv(self.save_file_path)
             df = df.append(dict(data.values), ignore_index=True)
         else:

--- a/codecarbon/output.py
+++ b/codecarbon/output.py
@@ -9,10 +9,9 @@ import os
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
-from pathlib import Path
 
-import requests
 import pandas as pd
+import requests
 
 # from core.schema import EmissionCreate, Emission
 from codecarbon.core.api_client import ApiClient

--- a/codecarbon/output.py
+++ b/codecarbon/output.py
@@ -25,6 +25,7 @@ class EmissionsData:
 
     timestamp: str
     project_name: str
+    run_id: str
     duration: float
     emissions: float
     emissions_rate: float
@@ -132,6 +133,8 @@ class CodeCarbonAPIOutput(BaseOutput):
     Send emissions data to HTTP endpoint
     """
 
+    run_id = None
+
     def __init__(self, endpoint_url: str, experiment_id: str, api_key: str):
         self.endpoint_url: str = endpoint_url
         self.api = ApiClient(
@@ -139,6 +142,7 @@ class CodeCarbonAPIOutput(BaseOutput):
             endpoint_url=endpoint_url,
             api_key=api_key,
         )
+        self.run_id = self.api.run_id
 
     def out(self, data: EmissionsData):
         try:

--- a/codecarbon/output.py
+++ b/codecarbon/output.py
@@ -9,12 +9,14 @@ import os
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
+from pathlib import Path
 
 import requests
 import pandas as pd
 
 # from core.schema import EmissionCreate, Emission
 from codecarbon.core.api_client import ApiClient
+from codecarbon.core.util import backup
 from codecarbon.external.logger import logger
 
 
@@ -101,12 +103,7 @@ class FileOutput(BaseOutput):
         file_exists: bool = os.path.isfile(self.save_file_path)
         if file_exists and not self.has_valid_headers(data):
             logger.info("Backing up old emission file")
-            new_name = self.save_file_path + ".bak"
-            idx = 1
-            while os.path.isfile(new_name):
-                new_name = self.save_file_path + f"_{idx}.bak"
-                idx += 1
-            os.rename(self.save_file_path, new_name)
+            backup(self.save_file_path)
             file_exists = False
 
         if not file_exists:

--- a/codecarbon/output.py
+++ b/codecarbon/output.py
@@ -81,7 +81,13 @@ class FileOutput(BaseOutput):
     Saves experiment artifacts to a file
     """
 
-    def __init__(self, save_file_path: str):
+    def __init__(self, save_file_path: str, on_flush: str = "append"):
+        if on_flush not in {"append", "update"}:
+            raise ValueError(
+                f"Unknown `on_flush` value: {on_flush}"
+                + " (should be one of 'append' or 'update'"
+            )
+        self.on_flush: str = on_flush
         self.save_file_path: str = save_file_path
 
     def has_valid_headers(self, data: EmissionsData):
@@ -105,6 +111,9 @@ class FileOutput(BaseOutput):
 
         if not file_exists:
             df = pd.DataFrame(columns=data.values.keys())
+            df = df.append(dict(data.values), ignore_index=True)
+        elif self.on_flush == "append":
+            df = pd.read_csv(self.save_file_path)
             df = df.append(dict(data.values), ignore_index=True)
         else:
             df = pd.read_csv(self.save_file_path)

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ pip install -r requirements-examples.txt
 ## Examples
 * [mnist.py](mnist.py): Usage using explicit `CO2Tracker` objects.
 * [mnist_decorator.py](mnist_decorator.py): Using the `@track_co2` decorator.
+* [mnist_callback.py](mnist_callback.py): Using Keras callbacks to save emission after each epoch.
 * [comet-mnist.py](comet-mnist.py): Using `CO2Tracker` with [`Comet`](https://www.comet.ml/site) for automatic experiment and emissions tracking.
 * [api_call_demo.py](api_call_demo.py) : Simplest demo to send computer emissions to CodeCarbon API.
 * [api_call_debug.py](api_call_debug.py) : Script to send computer emissions to CodeCarbon API. Made for debugging : debug log and send data every 20 seconds.

--- a/examples/mnist_callback.py
+++ b/examples/mnist_callback.py
@@ -1,0 +1,45 @@
+import tensorflow as tf
+from tensorflow.keras.callbacks import Callback
+
+from codecarbon import EmissionsTracker
+
+"""
+This sample code show how to use CodeCarbon as a Keras Callback
+to save emissions after each epoch.
+"""
+
+
+class CodeCarbonCallBack(Callback):
+    def __init__(self, codecarbon_tracker):
+        self.codecarbon_tracker = codecarbon_tracker
+        pass
+
+    def on_epoch_end(self, epoch, logs=None):
+        self.codecarbon_tracker.flush()
+
+
+mnist = tf.keras.datasets.mnist
+
+(x_train, y_train), (x_test, y_test) = mnist.load_data()
+x_train, x_test = x_train / 255.0, x_test / 255.0
+
+
+model = tf.keras.models.Sequential(
+    [
+        tf.keras.layers.Flatten(input_shape=(28, 28)),
+        tf.keras.layers.Dense(128, activation="relu"),
+        tf.keras.layers.Dropout(0.2),
+        tf.keras.layers.Dense(10),
+    ]
+)
+
+loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+
+model.compile(optimizer="adam", loss=loss_fn, metrics=["accuracy"])
+
+tracker = EmissionsTracker()
+tracker.start()
+codecarbon_cb = CodeCarbonCallBack(tracker)
+model.fit(x_train, y_train, epochs=4, callbacks=[codecarbon_cb])
+emissions: float = tracker.stop()
+print(f"Emissions: {emissions} kg")

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+from uuid import uuid4
+
 import requests_mock
 
 from codecarbon.core.api_client import ApiClient
@@ -25,6 +27,7 @@ def test_call_api():
         carbon_emission = EmissionsData(
             timestamp="222",
             project_name="",
+            run_id=uuid4(),
             duration=1.5,
             emissions=2.0,
             emissions_rate=2.0,

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -1,5 +1,4 @@
 import dataclasses
-
 from uuid import uuid4
 
 import requests_mock

--- a/tests/test_data/emissions_valid_headers.csv
+++ b/tests/test_data/emissions_valid_headers.csv
@@ -1,2 +1,2 @@
-timestamp,project_name,duration,emissions,emissions_rate,cpu_power,gpu_power,ram_power,cpu_energy,gpu_energy,ram_energy,energy_consumed,country_name,country_iso_code,region,on_cloud,cloud_provider,cloud_region
-2021-07-13T17:36:33,codecarbon,175.7496521,0.001327206,0.000663603,0.27,0,0.154618823,0.001079437,0,0.000618153,0.00169759,Morocco,MAR,casablanca-settat,N,,
+timestamp,project_name,run_id,duration,emissions,emissions_rate,cpu_power,gpu_power,ram_power,cpu_energy,gpu_energy,ram_energy,energy_consumed,country_name,country_iso_code,region,on_cloud,cloud_provider,cloud_region
+2021-07-13T17:36:33,codecarbon,3b3639f6-776c-4216-97de-bc52fc895bca,175.7496521,0.001327206,0.000663603,0.27,0,0.154618823,0.001079437,0,0.000618153,0.00169759,Morocco,MAR,casablanca-settat,N,,

--- a/tests/test_emissions_tracker_flush.py
+++ b/tests/test_emissions_tracker_flush.py
@@ -16,10 +16,10 @@ def heavy_computation(run_time_secs: int = 3):
         pass
 
 
-class TestCarbonTrackerConstant(unittest.TestCase):
+class TestCarbonTrackerFlush(unittest.TestCase):
     def setUp(self) -> None:
-        self.project_name = "project_TestCarbonTrackerConstant"
-        self.emissions_file = "emissions-test-TestCarbonTrackerConstant.csv"
+        self.project_name = "project_TestCarbonTrackerFlush"
+        self.emissions_file = "emissions-test-TestCarbonTrackerFlush.csv"
         self.emissions_path = tempfile.gettempdir()
         self.emissions_file_path = os.path.join(
             self.emissions_path, self.emissions_file
@@ -31,11 +31,13 @@ class TestCarbonTrackerConstant(unittest.TestCase):
         if os.path.isfile(self.emissions_file_path):
             os.remove(self.emissions_file_path)
 
-    def test_carbon_tracker_online_constant(self):
+    def test_carbon_tracker_online_flush(self):
         tracker = EmissionsTracker(
             output_dir=self.emissions_path, output_file=self.emissions_file
         )
         tracker.start()
+        heavy_computation(run_time_secs=1)
+        tracker.flush()
         heavy_computation(run_time_secs=1)
         emissions = tracker.stop()
         assert isinstance(emissions, float)
@@ -43,7 +45,7 @@ class TestCarbonTrackerConstant(unittest.TestCase):
         self.assertAlmostEqual(emissions, 6.262572537957655e-05, places=2)
         self.verify_output_file(self.emissions_file_path)
 
-    def test_carbon_tracker_offline_constant(self):
+    def test_carbon_tracker_offline_flush(self):
         tracker = OfflineEmissionsTracker(
             country_iso_code="USA",
             output_dir=self.emissions_path,
@@ -51,26 +53,30 @@ class TestCarbonTrackerConstant(unittest.TestCase):
         )
         tracker.start()
         heavy_computation(run_time_secs=1)
+        tracker.flush()
+        heavy_computation(run_time_secs=1)
         emissions = tracker.stop()
         assert isinstance(emissions, float)
         self.assertNotEqual(emissions, 0.0)
         self.assertAlmostEqual(emissions, 6.262572537957655e-05, places=2)
         self.verify_output_file(self.emissions_file_path)
 
-    def test_decorator_constant(self):
+    def test_decorator_flush(self):
         @track_emissions(
             project_name=self.project_name,
             output_dir=self.emissions_path,
             output_file=self.emissions_file,
         )
         def dummy_train_model():
+            # I don't know how to call flush() in decorator mode
             return 42
 
-        dummy_train_model()
+        res = dummy_train_model()
+        self.assertEqual(res, 42)
 
-        self.verify_output_file(self.emissions_file_path)
+        self.verify_output_file(self.emissions_file_path, 2)
 
-    def verify_output_file(self, file_path: str) -> None:
+    def verify_output_file(self, file_path: str, expected_lines=3) -> None:
         with open(file_path, "r") as f:
             lines = [line.rstrip() for line in f]
-        assert len(lines) == 2
+        assert len(lines) == expected_lines


### PR DESCRIPTION
Addressing #217 after talking with @stas00 (see https://github.com/mlco2/codecarbon/pull/235)  I add a new method `flush()` that compute emissions and add them to the CSV, and/or call the API if you use it.
I use it in a Keras callback and it do the job of adding a line in the CSV after each epoch.
You can see it in `mnist_callback.py`

I've added documentation. **But no unit test.**