### PR TITLE
add logger preamble and misfire_grace_time

### DIFF
--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -28,8 +28,8 @@ def is_powergadget_available():
         return True
     except Exception as e:
         logger.debug(
-            f"Exception occurred while instantiating IntelPowerGadget : {e}",
-            exc_info=True,
+            "Not using PowerGadget, an exception occurred while instantiating"
+            + f" IntelPowerGadget : {e}",
         )
         return False
 
@@ -40,8 +40,8 @@ def is_rapl_available():
         return True
     except Exception as e:
         logger.debug(
-            f"Exception occurred while instantiating RAPLInterface : {e}",
-            exc_info=True,
+            "Not using the RAPL interface, an exception occurred while instantiating "
+            + f"IntelRAPL : {e}",
         )
         return False
 

--- a/codecarbon/core/util.py
+++ b/codecarbon/core/util.py
@@ -1,4 +1,3 @@
-import logging
 from contextlib import contextmanager
 from os.path import expandvars
 from pathlib import Path
@@ -18,27 +17,6 @@ def suppress(*exceptions):
         )
         logger.warning("stopping.")
         pass
-
-
-def set_log_level(level: str):
-    level = level.upper()
-    levels = {
-        "CRITICAL",
-        "FATAL",
-        "ERROR",
-        "WARN",
-        "WARNING",
-        "INFO",
-        "DEBUG",
-        "NOTSET",
-    }
-    assert level in levels
-
-    for lev in levels:
-        if level == lev:
-            logger.setLevel(getattr(logging, level))
-            return
-    logger.error(f"Unknown log level: {level}")
 
 
 def resolve_path(path: Union[str, Path]) -> None:

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -149,6 +149,7 @@ class BaseEmissionsTracker(ABC):
         log_level: Optional[Union[int, str]] = _sentinel,
         on_csv_write: Optional[str] = _sentinel,
         logger_preamble: Optional[str] = _sentinel,
+        misfire_grace_time: Optional[int] = _sentinel,
     ):
         """
         :param project_name: Project name for current experiment run, default name
@@ -188,6 +189,8 @@ class BaseEmissionsTracker(ABC):
                              Accepts one of "append" or "update".
         :param logger_preamble: String to systematically include in the logger's.
                                 messages. Defaults to "".
+        :param misfire_grace_time: Parameter to configure the BackgroundScheduler's
+                                   `misfire_grace_time` argument.
         """
         self._external_conf = get_hierarchical_config()
 
@@ -206,6 +209,7 @@ class BaseEmissionsTracker(ABC):
         self._set_from_conf(tracking_mode, "tracking_mode", "machine")
         self._set_from_conf(on_csv_write, "on_csv_write", "append")
         self._set_from_conf(logger_preamble, "logger_preamble", "")
+        self._set_from_conf(misfire_grace_time, "misfire_grace_time", 1, int)
 
         assert self._tracking_mode in ["machine", "process"]
         set_logger_level(self._log_level)
@@ -273,6 +277,7 @@ class BaseEmissionsTracker(ABC):
             "interval",
             seconds=self._measure_power_secs,
             max_instances=1,
+            misfire_grace_time=self._misfire_grace_time,
         )
 
         self._data_source = DataSource()

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -493,7 +493,7 @@ class BaseEmissionsTracker(ABC):
                 self._total_ram_energy += energy
                 self._ram_power = power
             else:
-                raise ValueError(
+                logger.error(
                     f"Unknown hardware type: {hardware} ({type(hardware)})"
                 )
             h_time = time.time() - h_time

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -17,10 +17,10 @@ from codecarbon.core import cpu, gpu
 from codecarbon.core.config import get_hierarchical_config, parse_gpu_ids
 from codecarbon.core.emissions import Emissions
 from codecarbon.core.units import Energy, Power, Time
-from codecarbon.core.util import set_log_level, suppress
+from codecarbon.core.util import suppress
 from codecarbon.external.geography import CloudMetadata, GeoMetadata
 from codecarbon.external.hardware import CPU, GPU, RAM
-from codecarbon.external.logger import logger
+from codecarbon.external.logger import logger, set_logger_format, set_logger_level
 from codecarbon.input import DataSource
 from codecarbon.output import (
     BaseOutput,
@@ -148,6 +148,7 @@ class BaseEmissionsTracker(ABC):
         tracking_mode: Optional[str] = _sentinel,
         log_level: Optional[Union[int, str]] = _sentinel,
         on_csv_write: Optional[str] = _sentinel,
+        logger_preamble: Optional[str] = _sentinel,
     ):
         """
         :param project_name: Project name for current experiment run, default name
@@ -185,6 +186,8 @@ class BaseEmissionsTracker(ABC):
                              to the csv when writing or to update the existing `run_id`
                              row (useful when calling`tracker.flush()` manually).
                              Accepts one of "append" or "update".
+        :param logger_preamble: String to systematically include in the logger's.
+                                messages. Defaults to "".
         """
         self._external_conf = get_hierarchical_config()
 
@@ -202,9 +205,11 @@ class BaseEmissionsTracker(ABC):
         self._set_from_conf(save_to_file, "save_to_file", True, bool)
         self._set_from_conf(tracking_mode, "tracking_mode", "machine")
         self._set_from_conf(on_csv_write, "on_csv_write", "append")
+        self._set_from_conf(logger_preamble, "logger_preamble", "")
 
         assert self._tracking_mode in ["machine", "process"]
-        set_log_level(self._log_level)
+        set_logger_level(self._log_level)
+        set_logger_format(self._logger_preamble)
 
         self._start_time: Optional[float] = None
         self._last_measured_time: float = time.time()

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -469,6 +469,7 @@ class BaseEmissionsTracker(ABC):
             logger.warning(warn_msg, last_duration)
 
         for hardware in self._hardware:
+            h_time = time.time()
             power = hardware.total_power()
             energy = Energy.from_power_and_time(
                 power=power, time=Time.from_seconds(last_duration)
@@ -491,10 +492,10 @@ class BaseEmissionsTracker(ABC):
                 raise ValueError(
                     f"Unknown hardware type: {hardware} ({type(hardware)})"
                 )
-
+            h_time = time.time() - h_time
             logger.debug(
                 f"{hardware.__class__.__name__} : {hardware.total_power().W:,.2f} "
-                + f"W during {last_duration:,.2f} s"
+                + f"W during {last_duration:,.2f} s [measurement time: {h_time:,.2f}]"
             )
         logger.info(
             f"{self._total_energy.kWh:.6f} kWh of electricity used since the begining."

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -493,9 +493,7 @@ class BaseEmissionsTracker(ABC):
                 self._total_ram_energy += energy
                 self._ram_power = power
             else:
-                logger.error(
-                    f"Unknown hardware type: {hardware} ({type(hardware)})"
-                )
+                logger.error(f"Unknown hardware type: {hardware} ({type(hardware)})")
             h_time = time.time() - h_time
             logger.debug(
                 f"{hardware.__class__.__name__} : {hardware.total_power().W:,.2f} "

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -150,6 +150,7 @@ class BaseEmissionsTracker(ABC):
         on_csv_write: Optional[str] = _sentinel,
         logger_preamble: Optional[str] = _sentinel,
         misfire_grace_time: Optional[int] = _sentinel,
+        max_instances: Optional[int] = _sentinel,
     ):
         """
         :param project_name: Project name for current experiment run, default name
@@ -191,6 +192,8 @@ class BaseEmissionsTracker(ABC):
                                 messages. Defaults to "".
         :param misfire_grace_time: Parameter to configure the BackgroundScheduler's
                                    `misfire_grace_time` argument.
+        :param max_instances: Parameter to configure the BackgroundScheduler's
+                              `max_instances` argument
         """
         self._external_conf = get_hierarchical_config()
 
@@ -210,6 +213,7 @@ class BaseEmissionsTracker(ABC):
         self._set_from_conf(on_csv_write, "on_csv_write", "append")
         self._set_from_conf(logger_preamble, "logger_preamble", "")
         self._set_from_conf(misfire_grace_time, "misfire_grace_time", 1, int)
+        self._set_from_conf(max_instances, "max_instances", 1, int)
 
         assert self._tracking_mode in ["machine", "process"]
         set_logger_level(self._log_level)
@@ -276,7 +280,7 @@ class BaseEmissionsTracker(ABC):
             self._measure_power,
             "interval",
             seconds=self._measure_power_secs,
-            max_instances=1,
+            max_instances=self._max_instances,
             misfire_grace_time=self._misfire_grace_time,
         )
 

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -495,7 +495,7 @@ class BaseEmissionsTracker(ABC):
             h_time = time.time() - h_time
             logger.debug(
                 f"{hardware.__class__.__name__} : {hardware.total_power().W:,.2f} "
-                + f"W during {last_duration:,.2f} s [measurement time: {h_time:,.2f}]"
+                + f"W during {last_duration:,.2f} s [measurement time: {h_time:,.4f}]"
             )
         logger.info(
             f"{self._total_energy.kWh:.6f} kWh of electricity used since the begining."

--- a/codecarbon/external/logger.py
+++ b/codecarbon/external/logger.py
@@ -1,18 +1,48 @@
 import logging
 import os
+from typing import Optional
+
+
+def set_logger_format(custom_preamble: Optional[str] = ""):
+    logger = logging.getLogger("codecarbon")
+    format = f"[%(name)s %(levelname)s @ %(asctime)s]{custom_preamble} %(message)s"
+    formatter = logging.Formatter(format, datefmt="%H:%M:%S")
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    if logger.hasHandlers():
+        logger.handlers.clear()
+
+    logger.addHandler(handler)
+
+
+def set_logger_level(level: Optional[str] = None):
+
+    if level is None:
+        lower_envs = {k.lower(): v for k, v in os.environ.items()}
+        level = lower_envs.get("codecarbon_log_level", "INFO")
+
+    level = level.upper()
+    known_levels = {
+        "CRITICAL",
+        "FATAL",
+        "ERROR",
+        "WARN",
+        "WARNING",
+        "INFO",
+        "DEBUG",
+        "NOTSET",
+    }
+
+    logger = logging.getLogger("codecarbon")
+
+    if level not in known_levels:
+        logger.error(f"Unknown log level: {level}. Doing nothing.")
+        return
+    logger.setLevel(level)
+
+
+set_logger_format()
+set_logger_level()
 
 logger = logging.getLogger("codecarbon")
-formatter = logging.Formatter(
-    "[%(name)s %(levelname)s @ %(asctime)s] %(message)s",
-    datefmt="%H:%M:%S",
-)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-if not logger.handlers:
-    logger.addHandler(handler)
-env_level = os.environ.get("CODECARBON_LOG_LEVEL")
-if env_level is None:
-    env_level = os.environ.get("codecarbon_log_level")
-if env_level is None:
-    env_level = "INFO"
-logger.setLevel(level=env_level)

--- a/codecarbon/external/logger.py
+++ b/codecarbon/external/logger.py
@@ -22,24 +22,36 @@ def set_logger_level(level: Optional[str] = None):
         lower_envs = {k.lower(): v for k, v in os.environ.items()}
         level = lower_envs.get("codecarbon_log_level", "INFO")
 
-    level = level.upper()
-    known_levels = {
-        "CRITICAL",
-        "FATAL",
-        "ERROR",
-        "WARN",
-        "WARNING",
-        "INFO",
-        "DEBUG",
-        "NOTSET",
-    }
-
     logger = logging.getLogger("codecarbon")
 
-    if level not in known_levels:
-        logger.error(f"Unknown log level: {level}. Doing nothing.")
+    if isinstance(level, int):
+        known_levels_int = {0, 10, 20, 30, 40, 50}
+        if level not in known_levels_int:
+            logger.error(f"Unknown int log level: {level}. Doing nothing.")
+            return
+        logger.setLevel(level)
         return
-    logger.setLevel(level)
+
+    if isinstance(level, str):
+        level = level.upper()
+        known_levels_str = {
+            "CRITICAL",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "WARNING",
+            "INFO",
+            "DEBUG",
+            "NOTSET",
+        }
+
+        if level not in known_levels_str:
+            logger.error(f"Unknown str log level: {level}. Doing nothing.")
+            return
+        logger.setLevel(level)
+        return
+
+    logger.error(f"Unknown log level: {level}. Doing nothing.")
 
 
 set_logger_format()

--- a/codecarbon/external/logger.py
+++ b/codecarbon/external/logger.py
@@ -5,7 +5,10 @@ from typing import Optional
 
 def set_logger_format(custom_preamble: Optional[str] = ""):
     logger = logging.getLogger("codecarbon")
-    format = f"[%(name)s %(levelname)s @ %(asctime)s]{custom_preamble} %(message)s"
+    format = "[%(name)s %(levelname)s @ %(asctime)s]"
+    if custom_preamble:
+        format += f"[{custom_preamble}]"
+    format += " %(message)s"
     formatter = logging.Formatter(format, datefmt="%H:%M:%S")
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)

--- a/codecarbon/external/logger.py
+++ b/codecarbon/external/logger.py
@@ -58,3 +58,4 @@ set_logger_format()
 set_logger_level()
 
 logger = logging.getLogger("codecarbon")
+logger.propagate = False


### PR DESCRIPTION
Addressing #238 

```python
In [5]: e = EmissionsTracker(logger_preamble=" [Node1]")
[codecarbon INFO @ 15:52:23] [Node1] Tracking Intel CPU via Power Gadget
```

and 

```
        self._scheduler.add_job(
            self._measure_power,
            "interval",
            seconds=self._measure_power_secs,
            max_instances=1,
            misfire_grace_time=self._misfire_grace_time,
        )
```