### PR TITLE
[API] Allow reading emissions created before #210

### DIFF
--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -28,25 +28,25 @@ class EmissionBase(BaseModel):
         ..., ge=0, description="The emissions rate must be greater than zero"
     )
     energy_consumed: Optional[float] = Field(
-        ..., gt=0, description="The energy_consumed must be greater than zero"
+        ..., ge=0, description="The energy_consumed must be greater than zero"
     )
     cpu_power: Optional[float] = Field(
-        ..., gt=0, description="The cpu_power must be greater than zero"
+        ..., ge=0, description="The cpu_power must be greater than zero"
     )
     gpu_power: Optional[float] = Field(
-        ..., gt=0, description="The gpu_power must be greater than zero"
+        ..., ge=0, description="The gpu_power must be greater than zero"
     )
     ram_power: Optional[float] = Field(
-        ..., gt=0, description="The ram_power must be greater than zero"
+        ..., ge=0, description="The ram_power must be greater than zero"
     )
     cpu_energy: Optional[float] = Field(
-        ..., gt=0, description="The cpu_energy must be greater than zero"
+        ..., ge=0, description="The cpu_energy must be greater than zero"
     )
     gpu_energy: Optional[float] = Field(
-        ..., gt=0, description="The gpu_energy must be greater than zero"
+        ..., ge=0, description="The gpu_energy must be greater than zero"
     )
     ram_energy: Optional[float] = Field(
-        ..., gt=0, description="The ram_energy must be greater than zero"
+        ..., ge=0, description="The ram_energy must be greater than zero"
     )
 
     class Config:

--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -21,21 +21,33 @@ class EmissionBase(BaseModel):
     duration: int = Field(
         ..., gt=0, description="The duration must be greater than zero"
     )
-    emissions_sum: float = Field(
+    emissions_sum: Optional[float] = Field(
         ..., ge=0, description="The emissions must be greater than zero"
     )
-    emissions_rate: float = Field(
+    emissions_rate: Optional[float] = Field(
         ..., ge=0, description="The emissions rate must be greater than zero"
     )
-    energy_consumed: float = Field(
+    energy_consumed: Optional[float] = Field(
         ..., gt=0, description="The energy_consumed must be greater than zero"
     )
-    cpu_power: float
-    gpu_power: float
-    ram_power: float
-    cpu_energy: float
-    gpu_energy: float
-    ram_energy: float
+    cpu_power: Optional[float] = Field(
+        ..., gt=0, description="The cpu_power must be greater than zero"
+    )
+    gpu_power: Optional[float] = Field(
+        ..., gt=0, description="The gpu_power must be greater than zero"
+    )
+    ram_power: Optional[float] = Field(
+        ..., gt=0, description="The ram_power must be greater than zero"
+    )
+    cpu_energy: Optional[float] = Field(
+        ..., gt=0, description="The cpu_energy must be greater than zero"
+    )
+    gpu_energy: Optional[float] = Field(
+        ..., gt=0, description="The gpu_energy must be greater than zero"
+    )
+    ram_energy: Optional[float] = Field(
+        ..., gt=0, description="The ram_energy must be greater than zero"
+    )
 
     class Config:
         schema_extra = {


### PR DESCRIPTION
I've set emissions fields to Optional to allow reading emissions created before deploying https://github.com/mlco2/codecarbon/pull/210

Example run_id that  has the problem : ccc90761-d6ca-4666-a810-273ea70425e7
