### PR TITLE
Set encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 DEPENDENCIES = [


### PR DESCRIPTION
Windows is unhappy when trying to open the README file if I do not specify utf-8 as the encoding (which prevents me from running `pip install -e .`)