### PR TITLE
Add sum computed by experiment for a given project

### DIFF
--- a/carbonserver/carbonserver/api/infra/repositories/repository_emissions.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_emissions.py
@@ -73,8 +73,10 @@ class SqlAlchemyRepository(Emissions):
         """
         with self.session_factory() as session:
 
-            res = session.query(sql_models.Emission).filter(
-                sql_models.Emission.run_id == run_id
+            res = (
+                session.query(sql_models.Emission)
+                .filter(sql_models.Emission.run_id == run_id)
+                .order_by(sql_models.Emission.timestamp.desc())
             )
             if res.first() is None:
                 return []

--- a/carbonserver/carbonserver/api/infra/repositories/repository_experiments.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_experiments.py
@@ -149,8 +149,8 @@ class SqlAlchemyRepository(Experiments):
                 )
                 .filter(SqlModelExperiment.project_id == project_id)
                 .filter(
-                    and_(SqlModelExperiment.timestamp >= start_date),
-                    (SqlModelExperiment.timestamp < end_date),
+                    and_(SqlModelEmission.timestamp >= start_date),
+                    (SqlModelEmission.timestamp < end_date),
                 )
                 .group_by(
                     SqlModelExperiment.id,

--- a/carbonserver/carbonserver/api/infra/repositories/repository_experiments.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_experiments.py
@@ -2,7 +2,7 @@ from contextlib import AbstractContextManager
 from typing import List
 
 from dependency_injector.providers import Callable
-from sqlalchemy import func
+from sqlalchemy import and_, func
 
 from carbonserver.api.domain.experiments import Experiments
 from carbonserver.api.infra.database.sql_models import Emission as SqlModelEmission
@@ -107,7 +107,7 @@ class SqlAlchemyRepository(Experiments):
             )
             return res
 
-    def get_project_detailed_sums_by_experiment(self, project_id):
+    def get_project_detailed_sums_by_experiment(self, project_id, start_date, end_date):
         with self.session_factory() as session:
             res = (
                 session.query(
@@ -148,6 +148,10 @@ class SqlAlchemyRepository(Experiments):
                     isouter=True,
                 )
                 .filter(SqlModelExperiment.project_id == project_id)
+                .filter(
+                    and_(SqlModelExperiment.timestamp >= start_date),
+                    (SqlModelExperiment.timestamp < end_date),
+                )
                 .group_by(
                     SqlModelExperiment.id,
                     SqlModelExperiment.timestamp,

--- a/carbonserver/carbonserver/api/infra/repositories/repository_experiments.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_experiments.py
@@ -8,7 +8,7 @@ from carbonserver.api.domain.experiments import Experiments
 from carbonserver.api.infra.database.sql_models import Emission as SqlModelEmission
 from carbonserver.api.infra.database.sql_models import Experiment as SqlModelExperiment
 from carbonserver.api.infra.database.sql_models import Run as SqlModelRun
-from carbonserver.api.schemas import Experiment, ExperimentCreate
+from carbonserver.api.schemas import Experiment, ExperimentCreate, ExperimentReport
 
 
 class SqlAlchemyRepository(Experiments):
@@ -107,7 +107,9 @@ class SqlAlchemyRepository(Experiments):
             )
             return res
 
-    def get_project_detailed_sums_by_experiment(self, project_id, start_date, end_date):
+    def get_project_detailed_sums_by_experiment(
+        self, project_id, start_date, end_date
+    ) -> List[ExperimentReport]:
         with self.session_factory() as session:
             res = (
                 session.query(

--- a/carbonserver/carbonserver/api/routers/emissions.py
+++ b/carbonserver/carbonserver/api/routers/emissions.py
@@ -1,14 +1,28 @@
+from typing import Generic, TypeVar
 from uuid import UUID
 
 from container import ServerContainer
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from fastapi_pagination import Page, paginate
+from fastapi_pagination.default import Page as BasePage
+from fastapi_pagination.default import Params as BaseParams
 from starlette import status
 
 from carbonserver.api.dependencies import get_token_header
 from carbonserver.api.schemas import Emission, EmissionCreate
 from carbonserver.api.services.emissions_service import EmissionService
+
+T = TypeVar("T")
+
+
+class Params(BaseParams):
+    size: int = Query(1_000, ge=1, le=10_000, description="Page size")
+
+
+class Page(BasePage[T], Generic[T]):  # noqa: F811
+    __params_type__ = Params
+
 
 EMISSIONS_ROUTER_TAGS = ["Emissions"]
 
@@ -58,5 +72,6 @@ def get_emissions_from_run(
     emission_service: EmissionService = Depends(
         Provide[ServerContainer.emission_service]
     ),
+    params: Params = Depends(),
 ) -> Page[Emission]:
-    return paginate(emission_service.get_emissions_from_run(run_id))
+    return paginate(emission_service.get_emissions_from_run(run_id), params)

--- a/carbonserver/carbonserver/api/routers/emissions.py
+++ b/carbonserver/carbonserver/api/routers/emissions.py
@@ -13,6 +13,7 @@ from carbonserver.api.dependencies import get_token_header
 from carbonserver.api.schemas import Emission, EmissionCreate
 from carbonserver.api.services.emissions_service import EmissionService
 
+# T, Params and Page are needed to override default pagination of get_emissions_from_run
 T = TypeVar("T")
 
 

--- a/carbonserver/carbonserver/api/routers/emissions.py
+++ b/carbonserver/carbonserver/api/routers/emissions.py
@@ -18,7 +18,8 @@ T = TypeVar("T")
 
 
 class Params(BaseParams):
-    size: int = Query(1_000, ge=1, le=10_000, description="Page size")
+    # Default results to 100 to avoid crash in /docs
+    size: int = Query(100, ge=1, le=10_000, description="Page size")
 
 
 class Page(BasePage[T], Generic[T]):  # noqa: F811

--- a/carbonserver/carbonserver/api/routers/experiments.py
+++ b/carbonserver/carbonserver/api/routers/experiments.py
@@ -1,5 +1,7 @@
-from typing import Any, List
+from datetime import datetime
+from typing import Any, List, Optional
 
+import dateutil.relativedelta
 from container import ServerContainer
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
@@ -94,8 +96,13 @@ def read_project_sums_by_experiment(
 @inject
 def read_project_detailed_sums_by_experiment(
     project_id: str,
+    start_date: Optional[datetime] = datetime.now()
+    - dateutil.relativedelta.relativedelta(months=3),
+    end_date: Optional[datetime] = datetime.now(),
     project_global_sum_by_experiment_usecase: ProjectGlobalSumsByExperimentUsecase = Depends(
         Provide[ServerContainer.project_global_sum_by_experiment_usecase]
     ),
 ) -> Any:
-    return project_global_sum_by_experiment_usecase.compute_with_details(project_id)
+    return project_global_sum_by_experiment_usecase.compute_with_details(
+        project_id, start_date, end_date
+    )

--- a/carbonserver/carbonserver/api/routers/experiments.py
+++ b/carbonserver/carbonserver/api/routers/experiments.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 from container import ServerContainer
 from dependency_injector.wiring import Provide, inject
@@ -8,6 +8,9 @@ from starlette import status
 from carbonserver.api.dependencies import get_token_header
 from carbonserver.api.schemas import Experiment, ExperimentCreate
 from carbonserver.api.services.experiments_service import ExperimentService
+from carbonserver.api.usecases.experiment.project_global_sum_by_experiment import (
+    ProjectGlobalSumsByExperimentUsecase,
+)
 from carbonserver.logger import logger
 
 EXPERIMENTS_ROUTER_TAGS = ["Experiments"]
@@ -58,7 +61,7 @@ def read_experiment(
     response_model=List[Experiment],
 )
 @inject
-def read_experiment_experiments(
+def read_project_experiments(
     project_id: str,
     experiment_service: ExperimentService = Depends(
         Provide[ServerContainer.experiment_service]
@@ -66,3 +69,18 @@ def read_experiment_experiments(
 ) -> List[Experiment]:
 
     return experiment_service.get_experiments_from_project(project_id)
+
+
+@router.get(
+    "/experiments/{project_id}/global_sums/",
+    tags=EXPERIMENTS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+)
+@inject
+def compute_project_sums_by_experiment(
+    project_id: str,
+    project_global_sum_by_experiment_usecase: ProjectGlobalSumsByExperimentUsecase = Depends(
+        Provide[ServerContainer.project_global_sum_by_experiment_usecase]
+    ),
+) -> Any:
+    return project_global_sum_by_experiment_usecase.compute(project_id)

--- a/carbonserver/carbonserver/api/routers/experiments.py
+++ b/carbonserver/carbonserver/api/routers/experiments.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import List, Optional
 
 import dateutil.relativedelta
 from container import ServerContainer

--- a/carbonserver/carbonserver/api/routers/experiments.py
+++ b/carbonserver/carbonserver/api/routers/experiments.py
@@ -77,10 +77,25 @@ def read_project_experiments(
     status_code=status.HTTP_200_OK,
 )
 @inject
-def compute_project_sums_by_experiment(
+def read_project_sums_by_experiment(
     project_id: str,
     project_global_sum_by_experiment_usecase: ProjectGlobalSumsByExperimentUsecase = Depends(
         Provide[ServerContainer.project_global_sum_by_experiment_usecase]
     ),
 ) -> Any:
     return project_global_sum_by_experiment_usecase.compute(project_id)
+
+
+@router.get(
+    "/experiments/{project_id}/detailed_sums/",
+    tags=EXPERIMENTS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+)
+@inject
+def read_project_detailed_sums_by_experiment(
+    project_id: str,
+    project_global_sum_by_experiment_usecase: ProjectGlobalSumsByExperimentUsecase = Depends(
+        Provide[ServerContainer.project_global_sum_by_experiment_usecase]
+    ),
+) -> Any:
+    return project_global_sum_by_experiment_usecase.compute_with_details(project_id)

--- a/carbonserver/carbonserver/api/routers/experiments.py
+++ b/carbonserver/carbonserver/api/routers/experiments.py
@@ -11,7 +11,7 @@ from carbonserver.api.dependencies import get_token_header
 from carbonserver.api.schemas import Experiment, ExperimentCreate
 from carbonserver.api.services.experiments_service import ExperimentService
 from carbonserver.api.usecases.experiment.project_global_sum_by_experiment import (
-    ProjectGlobalSumsByExperimentUsecase,
+    ProjectGlobalSumByExperimentUsecase,
 )
 from carbonserver.logger import logger
 
@@ -81,7 +81,7 @@ def read_project_experiments(
 @inject
 def read_project_sums_by_experiment(
     project_id: str,
-    project_global_sum_by_experiment_usecase: ProjectGlobalSumsByExperimentUsecase = Depends(
+    project_global_sum_by_experiment_usecase: ProjectGlobalSumByExperimentUsecase = Depends(
         Provide[ServerContainer.project_global_sum_by_experiment_usecase]
     ),
 ) -> Any:
@@ -99,7 +99,7 @@ def read_project_detailed_sums_by_experiment(
     start_date: Optional[datetime] = datetime.now()
     - dateutil.relativedelta.relativedelta(months=3),
     end_date: Optional[datetime] = datetime.now(),
-    project_global_sum_by_experiment_usecase: ProjectGlobalSumsByExperimentUsecase = Depends(
+    project_global_sum_by_experiment_usecase: ProjectGlobalSumByExperimentUsecase = Depends(
         Provide[ServerContainer.project_global_sum_by_experiment_usecase]
     ),
 ) -> Any:

--- a/carbonserver/carbonserver/api/routers/experiments.py
+++ b/carbonserver/carbonserver/api/routers/experiments.py
@@ -96,13 +96,18 @@ def read_project_sums_by_experiment(
 @inject
 def read_project_detailed_sums_by_experiment(
     project_id: str,
-    start_date: Optional[datetime] = datetime.now()
-    - dateutil.relativedelta.relativedelta(months=3),
-    end_date: Optional[datetime] = datetime.now(),
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
     project_global_sum_by_experiment_usecase: ProjectGlobalSumByExperimentUsecase = Depends(
         Provide[ServerContainer.project_global_sum_by_experiment_usecase]
     ),
 ) -> Any:
+    start_date = (
+        start_date
+        if start_date
+        else datetime.now() - dateutil.relativedelta.relativedelta(months=3)
+    )
+    end_date = end_date if end_date else datetime.now()
     return project_global_sum_by_experiment_usecase.compute_with_details(
         project_id, start_date, end_date
     )

--- a/carbonserver/carbonserver/api/routers/experiments.py
+++ b/carbonserver/carbonserver/api/routers/experiments.py
@@ -10,8 +10,8 @@ from starlette import status
 from carbonserver.api.dependencies import get_token_header
 from carbonserver.api.schemas import Experiment, ExperimentCreate
 from carbonserver.api.services.experiments_service import ExperimentService
-from carbonserver.api.usecases.experiment.project_global_sum_by_experiment import (
-    ProjectGlobalSumByExperimentUsecase,
+from carbonserver.api.usecases.experiment.project_sum_by_experiment import (
+    ProjectSumsByExperimentUsecase,
 )
 from carbonserver.logger import logger
 
@@ -74,22 +74,7 @@ def read_project_experiments(
 
 
 @router.get(
-    "/experiments/{project_id}/global_sums/",
-    tags=EXPERIMENTS_ROUTER_TAGS,
-    status_code=status.HTTP_200_OK,
-)
-@inject
-def read_project_sums_by_experiment(
-    project_id: str,
-    project_global_sum_by_experiment_usecase: ProjectGlobalSumByExperimentUsecase = Depends(
-        Provide[ServerContainer.project_global_sum_by_experiment_usecase]
-    ),
-) -> Any:
-    return project_global_sum_by_experiment_usecase.compute(project_id)
-
-
-@router.get(
-    "/experiments/{project_id}/detailed_sums/",
+    "/experiments/{project_id}/sums/",
     tags=EXPERIMENTS_ROUTER_TAGS,
     status_code=status.HTTP_200_OK,
 )
@@ -98,8 +83,8 @@ def read_project_detailed_sums_by_experiment(
     project_id: str,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
-    project_global_sum_by_experiment_usecase: ProjectGlobalSumByExperimentUsecase = Depends(
-        Provide[ServerContainer.project_global_sum_by_experiment_usecase]
+    project_global_sum_by_experiment_usecase: ProjectSumsByExperimentUsecase = Depends(
+        Provide[ServerContainer.project_sums_by_experiment_usecase]
     ),
 ) -> Any:
     start_date = (
@@ -108,6 +93,6 @@ def read_project_detailed_sums_by_experiment(
         else datetime.now() - dateutil.relativedelta.relativedelta(months=3)
     )
     end_date = end_date if end_date else datetime.now()
-    return project_global_sum_by_experiment_usecase.compute_with_details(
+    return project_global_sum_by_experiment_usecase.compute_detailed_sum(
         project_id, start_date, end_date
     )

--- a/carbonserver/carbonserver/api/routers/experiments.py
+++ b/carbonserver/carbonserver/api/routers/experiments.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends
 from starlette import status
 
 from carbonserver.api.dependencies import get_token_header
-from carbonserver.api.schemas import Experiment, ExperimentCreate
+from carbonserver.api.schemas import Experiment, ExperimentCreate, ExperimentReport
 from carbonserver.api.services.experiments_service import ExperimentService
 from carbonserver.api.usecases.experiment.project_sum_by_experiment import (
     ProjectSumsByExperimentUsecase,
@@ -86,7 +86,7 @@ def read_project_detailed_sums_by_experiment(
     project_global_sum_by_experiment_usecase: ProjectSumsByExperimentUsecase = Depends(
         Provide[ServerContainer.project_sums_by_experiment_usecase]
     ),
-) -> Any:
+) -> List[ExperimentReport]:
     start_date = (
         start_date
         if start_date

--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -159,6 +159,56 @@ class Experiment(ExperimentBase):
     id: UUID
 
 
+class ExperimentReport(ExperimentBase):
+    experiment_id: UUID
+    timestamp: datetime
+    name: str
+    description: str
+    country_name: str
+    country_iso_code: str
+    region: str
+    on_cloud: str
+    cloud_provider: str
+    cloud_region: str
+    emission: float
+    cpu_power: float
+    gpu_power: float
+    ram_power: float
+    cpu_energy: float
+    gpu_energy: float
+    ram_energy: float
+    energy_consumed: float
+    duration: int
+    emissions_rate_sum: float
+    emissions_rate_count: int
+
+    class Config:
+
+        schema_extra = {
+            "experiment_id": "943b2aa5-9e21-41a9-8a38-562505b4b2aa",
+            "timestamp": "2021-10-07T20:19:27.716693",
+            "name": "Code Carbon user test",
+            "description": "Code Carbon user test with default project",
+            "country_name": "France",
+            "country_iso_code": "FRA",
+            "region": "france",
+            "on_cloud": False,
+            "cloud_provider": None,
+            "cloud_region": None,
+            "emission": 152.28955200363455,
+            "cpu_power": 5760,
+            "gpu_power": 2983.9739999999993,
+            "ram_power": 806.0337192959997,
+            "cpu_energy": 191.8251863024175,
+            "gpu_energy": 140.01098718681496,
+            "ram_energy": 26.84332784201141,
+            "energy_consumed": 358.6795013312438,
+            "duration": 7673204,
+            "emissions_rate_sum": 1.0984556074701752,
+            "emissions_rate_count": 64,
+        }
+
+
 class ProjectBase(BaseModel):
     name: str
     description: str

--- a/carbonserver/carbonserver/api/usecases/experiment/project_global_sum_by_experiment.py
+++ b/carbonserver/carbonserver/api/usecases/experiment/project_global_sum_by_experiment.py
@@ -8,7 +8,13 @@ class ProjectGlobalSumsByExperimentUsecase:
         self._experiment_repository = experiment_repository
 
     def compute(self, project_id: str):
-        sum = self._experiment_repository.get_project_global_sums_by_experiment(
+        sums = self._experiment_repository.get_project_global_sums_by_experiment(
             project_id
         )
-        return sum
+        return sums
+
+    def compute_with_details(self, project_id: str):
+        sums = self._experiment_repository.get_project_detailed_sums_by_experiment(
+            project_id
+        )
+        return sums

--- a/carbonserver/carbonserver/api/usecases/experiment/project_global_sum_by_experiment.py
+++ b/carbonserver/carbonserver/api/usecases/experiment/project_global_sum_by_experiment.py
@@ -3,7 +3,7 @@ from carbonserver.api.infra.repositories.repository_experiments import (
 )
 
 
-class ProjectGlobalSumsByExperimentUsecase:
+class ProjectGlobalSumByExperimentUsecase:
     def __init__(self, experiment_repository: SqlAlchemyRepository) -> None:
         self._experiment_repository = experiment_repository
 
@@ -13,8 +13,10 @@ class ProjectGlobalSumsByExperimentUsecase:
         )
         return sums
 
-    def compute_with_details(self, project_id: str):
+    def compute_with_details(self, project_id: str, start_date, end_date):
         sums = self._experiment_repository.get_project_detailed_sums_by_experiment(
-            project_id
+            project_id,
+            start_date,
+            end_date,
         )
         return sums

--- a/carbonserver/carbonserver/api/usecases/experiment/project_global_sum_by_experiment.py
+++ b/carbonserver/carbonserver/api/usecases/experiment/project_global_sum_by_experiment.py
@@ -1,0 +1,14 @@
+from carbonserver.api.infra.repositories.repository_experiments import (
+    SqlAlchemyRepository,
+)
+
+
+class ProjectGlobalSumsByExperimentUsecase:
+    def __init__(self, experiment_repository: SqlAlchemyRepository) -> None:
+        self._experiment_repository = experiment_repository
+
+    def compute(self, project_id: str):
+        sum = self._experiment_repository.get_project_global_sums_by_experiment(
+            project_id
+        )
+        return sum

--- a/carbonserver/carbonserver/api/usecases/experiment/project_sum_by_experiment.py
+++ b/carbonserver/carbonserver/api/usecases/experiment/project_sum_by_experiment.py
@@ -1,13 +1,18 @@
+from typing import List
+
 from carbonserver.api.infra.repositories.repository_experiments import (
     SqlAlchemyRepository,
 )
+from carbonserver.api.schemas import ExperimentReport
 
 
 class ProjectSumsByExperimentUsecase:
     def __init__(self, experiment_repository: SqlAlchemyRepository) -> None:
         self._experiment_repository = experiment_repository
 
-    def compute_detailed_sum(self, project_id: str, start_date, end_date):
+    def compute_detailed_sum(
+        self, project_id: str, start_date, end_date
+    ) -> List[ExperimentReport]:
         sums = self._experiment_repository.get_project_detailed_sums_by_experiment(
             project_id,
             start_date,

--- a/carbonserver/carbonserver/api/usecases/experiment/project_sum_by_experiment.py
+++ b/carbonserver/carbonserver/api/usecases/experiment/project_sum_by_experiment.py
@@ -3,17 +3,11 @@ from carbonserver.api.infra.repositories.repository_experiments import (
 )
 
 
-class ProjectGlobalSumByExperimentUsecase:
+class ProjectSumsByExperimentUsecase:
     def __init__(self, experiment_repository: SqlAlchemyRepository) -> None:
         self._experiment_repository = experiment_repository
 
-    def compute(self, project_id: str):
-        sums = self._experiment_repository.get_project_global_sums_by_experiment(
-            project_id
-        )
-        return sums
-
-    def compute_with_details(self, project_id: str, start_date, end_date):
+    def compute_detailed_sum(self, project_id: str, start_date, end_date):
         sums = self._experiment_repository.get_project_detailed_sums_by_experiment(
             project_id,
             start_date,

--- a/carbonserver/container.py
+++ b/carbonserver/container.py
@@ -18,6 +18,9 @@ from carbonserver.api.services.run_service import RunService
 from carbonserver.api.services.signup_service import SignUpService
 from carbonserver.api.services.team_service import TeamService
 from carbonserver.api.services.user_service import UserService
+from carbonserver.api.usecases.experiment.project_global_sum_by_experiment import (
+    ProjectGlobalSumsByExperimentUsecase,
+)
 from carbonserver.config import settings
 
 
@@ -66,6 +69,11 @@ class ServerContainer(containers.DeclarativeContainer):
 
     experiment_service = providers.Factory(
         ExperimentService,
+        experiment_repository=experiment_repository,
+    )
+
+    project_global_sum_by_experiment_usecase = providers.Factory(
+        ProjectGlobalSumsByExperimentUsecase,
         experiment_repository=experiment_repository,
     )
 

--- a/carbonserver/container.py
+++ b/carbonserver/container.py
@@ -19,7 +19,7 @@ from carbonserver.api.services.signup_service import SignUpService
 from carbonserver.api.services.team_service import TeamService
 from carbonserver.api.services.user_service import UserService
 from carbonserver.api.usecases.experiment.project_global_sum_by_experiment import (
-    ProjectGlobalSumsByExperimentUsecase,
+    ProjectGlobalSumByExperimentUsecase,
 )
 from carbonserver.config import settings
 
@@ -73,7 +73,7 @@ class ServerContainer(containers.DeclarativeContainer):
     )
 
     project_global_sum_by_experiment_usecase = providers.Factory(
-        ProjectGlobalSumsByExperimentUsecase,
+        ProjectGlobalSumByExperimentUsecase,
         experiment_repository=experiment_repository,
     )
 

--- a/carbonserver/container.py
+++ b/carbonserver/container.py
@@ -18,8 +18,8 @@ from carbonserver.api.services.run_service import RunService
 from carbonserver.api.services.signup_service import SignUpService
 from carbonserver.api.services.team_service import TeamService
 from carbonserver.api.services.user_service import UserService
-from carbonserver.api.usecases.experiment.project_global_sum_by_experiment import (
-    ProjectGlobalSumByExperimentUsecase,
+from carbonserver.api.usecases.experiment.project_sum_by_experiment import (
+    ProjectSumsByExperimentUsecase,
 )
 from carbonserver.config import settings
 
@@ -72,8 +72,8 @@ class ServerContainer(containers.DeclarativeContainer):
         experiment_repository=experiment_repository,
     )
 
-    project_global_sum_by_experiment_usecase = providers.Factory(
-        ProjectGlobalSumByExperimentUsecase,
+    project_sums_by_experiment_usecase = providers.Factory(
+        ProjectSumsByExperimentUsecase,
         experiment_repository=experiment_repository,
     )
 

--- a/carbonserver/docker/README.md
+++ b/carbonserver/docker/README.md
@@ -11,3 +11,11 @@ This is to start using `docker-compose` to run the carbonserver app.
 ```
 
 > Access the app on port `8008` instead of default `8000`, see `ports` in `docker-compose.yml`.
+
+## Run command in container
+
+You could run a command in the running container, for example to run test on API:
+
+```
+docker exec -e CODECARBON_API_URL=http://localhost:8000  codecarbon_carbonserver_1 python3 -m pytest tests/api/integration/test_api_black_box.py
+```

--- a/carbonserver/docker/README.md
+++ b/carbonserver/docker/README.md
@@ -17,5 +17,5 @@ This is to start using `docker-compose` to run the carbonserver app.
 You could run a command in the running container, for example to run test on API:
 
 ```
-docker exec -e CODECARBON_API_URL=http://localhost:8000  codecarbon_carbonserver_1 python3 -m pytest tests/api/integration/test_api_black_box.py
+docker exec -e CODECARBON_API_URL=http://localhost:8000  codecarbon_carbonserver_1 python3 -m pytest -v tests/api/integration/test_api_black_box.py
 ```

--- a/carbonserver/requirements-dev.txt
+++ b/carbonserver/requirements-dev.txt
@@ -4,6 +4,7 @@ dependency-injector
 fastapi
 pydantic[email]
 psycopg2-binary
+python-dateutil
 requests
 sqlalchemy
 tox

--- a/carbonserver/requirements-test.txt
+++ b/carbonserver/requirements-test.txt
@@ -1,5 +1,6 @@
 alembic
 bcrypt
+python-dateutil
 dependency-injector
 fastapi
 pydantic[email]

--- a/carbonserver/requirements.txt
+++ b/carbonserver/requirements.txt
@@ -1,5 +1,6 @@
 alembic
 bcrypt
+python-dateutil
 dependency-injector
 fastapi
 pydantic[email]

--- a/carbonserver/tests/api/integration/test_api_black_box.py
+++ b/carbonserver/tests/api/integration/test_api_black_box.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 
 import pytest
 import requests
@@ -18,6 +19,11 @@ org_name = org_description = org_new_id = None
 team_name = team_description = team_new_id = emission_id = None
 USER_PASSWORD = "Secret1!îstring"
 USER_EMAIL = "user@integration.test"
+
+
+def get_datetime():
+    t = datetime.timestamp(datetime.now())
+    return str(datetime.fromtimestamp(t).isoformat())
 
 
 def del_test_user():
@@ -215,7 +221,7 @@ def test_api18_experiment_create():
     payload = {
         "name": "Run on Premise",
         "description": "Premise API for Code Carbon",
-        "timestamp": "2021-04-04T08:43:00+02:00",
+        "timestamp": get_datetime(),
         "country_name": "France",
         "country_iso_code": "FRA",
         "region": "france",
@@ -245,7 +251,7 @@ def test_api20_experiment_list():
 def test_api21_run_create():
     global run_id
     payload = {
-        "timestamp": "2021-04-04T08:43:00+02:00",
+        "timestamp": get_datetime(),
         "experiment_id": experiment_id,
         "os": "macOS-10.15.7-x86_64-i386-64bit",
         "python_version": "3.8.0",
@@ -286,7 +292,7 @@ def test_api24_runs_for_team_list():
 
 def test_api25_emission_create():
     payload = {
-        "timestamp": "2021-04-04T08:43:00+02:00",
+        "timestamp": get_datetime(),
         "run_id": run_id,
         "duration": 98745,
         "emissions_sum": 1544.54,
@@ -329,8 +335,6 @@ def test_api29_experiment_read_detailed_sums():
     url = f"{URL}/experiments/{project_id}/detailed_sums/"
     r = requests.get(url, timeout=2)
     assert r.status_code == 200
-    print("project_id=", project_id)
-    print("JSON=", r.json())
     assert len(r.json()) > 0
-    assert r.json()["experiment_id"] == experiment_id
-    assert r.json()[0]["duration"] == 50
+    assert r.json()[0]["experiment_id"] == experiment_id
+    assert r.json()[0]["duration"] == 98745.0

--- a/carbonserver/tests/api/integration/test_api_black_box.py
+++ b/carbonserver/tests/api/integration/test_api_black_box.py
@@ -324,15 +324,8 @@ def test_api27_emission_read():
     assert r.json()["run_id"] == run_id
 
 
-def test_api28_experiment_read_global_sums():
-    r = requests.get(url=f"{URL}/experiments/{project_id}/global_sums/", timeout=2)
-    assert r.status_code == 200
-    assert r.json()[0]["experiment_id"] == experiment_id
-    assert r.json()[0]["duration"] == 98745.0
-
-
 def test_api29_experiment_read_detailed_sums():
-    url = f"{URL}/experiments/{project_id}/detailed_sums/"
+    url = f"{URL}/experiments/{project_id}/sums/"
     r = requests.get(url, timeout=2)
     assert r.status_code == 200
     assert len(r.json()) > 0

--- a/carbonserver/tests/api/routers/test_experiments.py
+++ b/carbonserver/tests/api/routers/test_experiments.py
@@ -1,17 +1,17 @@
 from unittest import mock
 
 import pytest
-from carbonserver.api.infra.repositories.repository_experiments import (
-    SqlAlchemyRepository,
-)
-from carbonserver.api.schemas import Experiment
 from container import ServerContainer
 from fastapi import FastAPI
 from fastapi_pagination import add_pagination
 from starlette import status
-
-from carbonserver.api.routers import experiments
 from starlette.testclient import TestClient
+
+from carbonserver.api.infra.repositories.repository_experiments import (
+    SqlAlchemyRepository,
+)
+from carbonserver.api.routers import experiments
+from carbonserver.api.schemas import Experiment
 
 PROJECT_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
 
@@ -68,6 +68,30 @@ EXPERIMENT_2 = {
     "cloud_provider": "AWS",
     "cloud_region": "eu-west-1",
     "project_id": PROJECT_ID,
+}
+
+EXPERIMENT_WITH_DETAILS = {
+    "experiment_id": "943b2aa5-9e21-41a9-8a38-562505b4b2aa",
+    "timestamp": "2021-10-07T20:19:27.716693",
+    "name": "Code Carbon user test",
+    "description": "Code Carbon user test with default project",
+    "country_name": "France",
+    "country_iso_code": "FRA",
+    "region": "france",
+    "on_cloud": False,
+    "cloud_provider": None,
+    "cloud_region": None,
+    "emission": 152.28955200363455,
+    "cpu_power": 5760,
+    "gpu_power": 2983.9739999999993,
+    "ram_power": 806.0337192959997,
+    "cpu_energy": 191.8251863024175,
+    "gpu_energy": 140.01098718681496,
+    "ram_energy": 26.84332784201141,
+    "energy_consumed": 358.6795013312438,
+    "duration": 7673204,
+    "emissions_rate_sum": 1.0984556074701752,
+    "emissions_rate_count": 64,
 }
 
 

--- a/carbonserver/tests/api/routers/test_experiments.py
+++ b/carbonserver/tests/api/routers/test_experiments.py
@@ -1,0 +1,162 @@
+from unittest import mock
+
+import pytest
+from carbonserver.api.infra.repositories.repository_experiments import (
+    SqlAlchemyRepository,
+)
+from carbonserver.api.schemas import Experiment
+from container import ServerContainer
+from fastapi import FastAPI
+from fastapi_pagination import add_pagination
+from starlette import status
+
+from carbonserver.api.routers import experiments
+from starlette.testclient import TestClient
+
+PROJECT_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
+
+EXPERIMENT_ID = "10276e58-6df7-42cf-abb8-429773a35eb5"
+EXPERIMENT_ID_2 = "e52fe339-164d-4c2b-a8c0-f562dfce066d"
+EXPERIMENT_ID_3 = "c13e851f-5c2f-403d-98d0-51fe15df3bc3"
+
+EXPERIMENT_GLOBAL_SUM = {
+    "id": EXPERIMENT_ID,
+    "timestamp": "2021-04-04T06:43:00",
+    "name": "Run on Premise",
+    "description": "Premise API for Code Carbon",
+    "emission_sum": 1544.54,
+    "energy_consumed": 57.21874,
+    "duration": 98745,
+}
+
+EXPERIMENT_TO_CREATE = {
+    "timestamp": "2021-04-04T06:43:00",
+    "name": "Run on Premise",
+    "description": "Premise API for Code Carbon",
+    "country_name": "France",
+    "country_iso_code": "FRA",
+    "region": "france",
+    "on_cloud": True,
+    "cloud_provider": "Premise",
+    "cloud_region": "Premise",
+    "project_id": PROJECT_ID,
+}
+
+EXPERIMENT_1 = {
+    "id": EXPERIMENT_ID,
+    "timestamp": "2021-04-04T06:43:00",
+    "name": "Run on Premise",
+    "description": "Premise API for Code Carbon",
+    "country_name": "France",
+    "country_iso_code": "FRA",
+    "region": "france",
+    "on_cloud": True,
+    "cloud_provider": "Premise",
+    "cloud_region": "Premise",
+    "project_id": PROJECT_ID,
+}
+
+EXPERIMENT_2 = {
+    "id": EXPERIMENT_ID_2,
+    "timestamp": "2021-04-04T06:43:00",
+    "name": "Run on AWS",
+    "description": "AWS Run for test",
+    "country_name": "France",
+    "country_iso_code": "FRA",
+    "region": "france",
+    "on_cloud": True,
+    "cloud_provider": "AWS",
+    "cloud_region": "eu-west-1",
+    "project_id": PROJECT_ID,
+}
+
+
+@pytest.fixture
+def custom_test_server():
+    container = ServerContainer()
+    container.wire(modules=[experiments])
+    app = FastAPI()
+    app.container = container
+    app.include_router(experiments.router)
+    add_pagination(app)
+    yield app
+
+
+@pytest.fixture
+def client(custom_test_server):
+    yield TestClient(custom_test_server)
+
+
+def test_add_experiment(client, custom_test_server):
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_expriment = EXPERIMENT_1
+    repository_mock.add_experiment.return_value = Experiment(**EXPERIMENT_1)
+
+    with custom_test_server.container.experiment_repository.override(repository_mock):
+        response = client.post("/experiment", json=EXPERIMENT_TO_CREATE)
+        actual_experiment = response.json()
+    print(actual_experiment)
+    print(type(actual_experiment))
+    assert response.status_code == status.HTTP_201_CREATED
+    assert actual_experiment == expected_expriment
+
+
+def test_get_experiment_by_id_returns_correct_experiment(client, custom_test_server):
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_experiment = EXPERIMENT_1
+    repository_mock.get_one_experiment.return_value = Experiment(**EXPERIMENT_1)
+
+    with custom_test_server.container.experiment_repository.override(repository_mock):
+        response = client.get(
+            "/experiment/read_experiment/", params={"experiment_id": EXPERIMENT_ID}
+        )
+        actual_experiment = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert actual_experiment == expected_experiment
+
+
+def test_get_experiment_of_project_retrieves_all_experiments_of_project(
+    client, custom_test_server
+):
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_experiments_id_list = [EXPERIMENT_ID, EXPERIMENT_ID_2]
+    repository_mock.get_experiments_from_project.return_value = [
+        Experiment(**EXPERIMENT_1),
+        Experiment(**EXPERIMENT_2),
+    ]
+
+    with custom_test_server.container.experiment_repository.override(repository_mock):
+        response = client.get(
+            "/experiments/project/read_project_experiments/",
+            params={"project_id": PROJECT_ID},
+        )
+        actual_experiments_list = response.json()
+        print(actual_experiments_list)
+        actual_experiments_ids_list = [
+            experiment["id"] for experiment in actual_experiments_list
+        ]
+        diff = set(actual_experiments_ids_list) ^ set(expected_experiments_id_list)
+
+    assert not diff
+    assert len(actual_experiments_ids_list) == len(set(actual_experiments_ids_list))
+    assert EXPERIMENT_ID_3 not in actual_experiments_ids_list
+
+
+def test_compute_project_sums_by_experiment_returns_correct_sums(
+    client, custom_test_server
+):
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_global_sums = [EXPERIMENT_GLOBAL_SUM]
+    repository_mock.get_project_global_sums_by_experiment.return_value = [
+        EXPERIMENT_GLOBAL_SUM
+    ]
+
+    with custom_test_server.container.experiment_repository.override(repository_mock):
+        response = client.get(
+            "/experiments/{project_id}/global_sums/".format(project_id=PROJECT_ID)
+        )
+        actual_global_sum = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert actual_global_sum == expected_global_sums

--- a/carbonserver/tests/api/routers/test_experiments.py
+++ b/carbonserver/tests/api/routers/test_experiments.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -21,7 +22,7 @@ EXPERIMENT_ID_3 = "c13e851f-5c2f-403d-98d0-51fe15df3bc3"
 
 EXPERIMENT_GLOBAL_SUM = {
     "id": EXPERIMENT_ID,
-    "timestamp": "2021-04-04T06:43:00",
+    "timestamp": datetime.now().isoformat(),
     "name": "Run on Premise",
     "description": "Premise API for Code Carbon",
     "emission_sum": 1544.54,
@@ -156,7 +157,6 @@ def test_get_experiment_of_project_retrieves_all_experiments_of_project(
             params={"project_id": PROJECT_ID},
         )
         actual_experiments_list = response.json()
-        print(actual_experiments_list)
         actual_experiments_ids_list = [
             experiment["id"] for experiment in actual_experiments_list
         ]
@@ -165,22 +165,3 @@ def test_get_experiment_of_project_retrieves_all_experiments_of_project(
     assert not diff
     assert len(actual_experiments_ids_list) == len(set(actual_experiments_ids_list))
     assert EXPERIMENT_ID_3 not in actual_experiments_ids_list
-
-
-def test_compute_project_sums_by_experiment_returns_correct_sums(
-    client, custom_test_server
-):
-    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
-    expected_global_sums = [EXPERIMENT_GLOBAL_SUM]
-    repository_mock.get_project_global_sums_by_experiment.return_value = [
-        EXPERIMENT_GLOBAL_SUM
-    ]
-
-    with custom_test_server.container.experiment_repository.override(repository_mock):
-        response = client.get(
-            "/experiments/{project_id}/global_sums/".format(project_id=PROJECT_ID)
-        )
-        actual_global_sum = response.json()
-
-    assert response.status_code == status.HTTP_200_OK
-    assert actual_global_sum == expected_global_sums

--- a/carbonserver/tests/api/service/test_experiments_service.py
+++ b/carbonserver/tests/api/service/test_experiments_service.py
@@ -41,6 +41,19 @@ EXPERIMENT_2 = Experiment(
     project_id=PROJECT_ID,
 )
 
+EXPERIMENT_CREATE = ExperimentCreate(
+    name="Experiment",
+    description="Description",
+    timestamp="2021-04-04T08:43:00+02:00",
+    country_name="France",
+    country_iso_code="France",
+    region="Berry",
+    on_cloud=True,
+    cloud_provider="AWS",
+    cloud_region="aws-east-1",
+    project_id=PROJECT_ID,
+)
+
 
 @mock.patch("uuid.uuid4", return_value=EXPERIMENT_ID)
 def test_emission_service_creates_correct_emission(_):
@@ -49,18 +62,7 @@ def test_emission_service_creates_correct_emission(_):
     experiment_service: ExperimentService = ExperimentService(repository_mock)
     repository_mock.add_experiment.return_value = EXPERIMENT_ID
 
-    experiment_to_create = ExperimentCreate(
-        name="Experiment",
-        description="Description",
-        timestamp="2021-04-04T08:43:00+02:00",
-        country_name="France",
-        country_iso_code="France",
-        region="Berry",
-        on_cloud=True,
-        cloud_provider="AWS",
-        cloud_region="aws-east-1",
-        project_id=PROJECT_ID,
-    )
+    experiment_to_create = EXPERIMENT_CREATE
 
     actual_saved_emission_id = experiment_service.add_experiment(experiment_to_create)
 

--- a/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
+++ b/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
@@ -7,9 +7,15 @@ from carbonserver.api.usecases.experiment.project_global_sum_by_experiment impor
     ProjectGlobalSumsByExperimentUsecase,
 )
 
+EXPERIMENT_ID = "10276e58-6df7-42cf-abb8-429773a35eb5"
+EXPERIMENT_WITH_DETAILS_ID = "943b2aa5-9e21-41a9-8a38-562505b4b2aa"
+
+EMISSIONS_SUM = 1544.54
+EMISSIONS_SUM_WITH_DETAILS = 152.28955200363455
+
 PROJECT_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
 EXPERIMENT_GLOBAL_SUM = {
-    "id": "10276e58-6df7-42cf-abb8-429773a35eb5",
+    "id": EXPERIMENT_ID,
     "timestamp": "2021-04-04T06:43:00",
     "name": "Run on Premise",
     "description": "Premise API for Code Carbon",
@@ -18,14 +24,56 @@ EXPERIMENT_GLOBAL_SUM = {
     "duration": 98745,
 }
 
+EXPERIMENT_WITH_DETAILS = {
+    "experiment_id": EXPERIMENT_WITH_DETAILS_ID,
+    "timestamp": "2021-10-07T20:19:27.716693",
+    "name": "Code Carbon user test",
+    "description": "Code Carbon user test with default project",
+    "country_name": "France",
+    "country_iso_code": "FRA",
+    "region": "france",
+    "on_cloud": False,
+    "cloud_provider": None,
+    "cloud_region": None,
+    "emission": 152.28955200363455,
+    "cpu_power": 5760,
+    "gpu_power": 2983.9739999999993,
+    "ram_power": 806.0337192959997,
+    "cpu_energy": 191.8251863024175,
+    "gpu_energy": 140.01098718681496,
+    "ram_energy": 26.84332784201141,
+    "energy_consumed": 358.6795013312438,
+    "duration": 7673204,
+    "emissions_rate_sum": 1.0984556074701752,
+    "emissions_rate_count": 64,
+}
+
 
 def test_global_sum_computes_for_project_id():
     repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
     project_id = PROJECT_ID
     project_global_sum_usecase = ProjectGlobalSumsByExperimentUsecase(repository_mock)
-    expected_emission_sum = 1544.54
+
+    expected_emission_sum = EMISSIONS_SUM
     repository_mock.get_project_global_sums_by_experiment.return_value = [
         EXPERIMENT_GLOBAL_SUM
+    ]
+
+    actual_project_global_sum_by_experiment = project_global_sum_usecase.compute(
+        project_id
+    )
+
+    assert actual_project_global_sum_by_experiment.emission_sum == expected_emission_sum
+
+
+def test_detailed_sum_computes_for_project_id():
+    repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
+    project_id = PROJECT_ID
+    project_global_sum_usecase = ProjectGlobalSumsByExperimentUsecase(repository_mock)
+
+    expected_emission_sum = EMISSIONS_SUM_WITH_DETAILS
+    repository_mock.get_project_global_sums_by_experiment.return_value = [
+        EXPERIMENT_WITH_DETAILS
     ]
 
     actual_project_global_sum_by_experiment = project_global_sum_usecase.compute(

--- a/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
+++ b/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
@@ -4,7 +4,7 @@ from carbonserver.api.infra.repositories.repository_experiments import (
     SqlAlchemyRepository,
 )
 from carbonserver.api.usecases.experiment.project_global_sum_by_experiment import (
-    ProjectGlobalSumsByExperimentUsecase,
+    ProjectGlobalSumByExperimentUsecase,
 )
 
 EXPERIMENT_ID = "10276e58-6df7-42cf-abb8-429773a35eb5"
@@ -52,7 +52,7 @@ EXPERIMENT_WITH_DETAILS = {
 def test_global_sum_computes_for_project_id():
     repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
     project_id = PROJECT_ID
-    project_global_sum_usecase = ProjectGlobalSumsByExperimentUsecase(repository_mock)
+    project_global_sum_usecase = ProjectGlobalSumByExperimentUsecase(repository_mock)
 
     expected_emission_sum = EMISSIONS_SUM
     repository_mock.get_project_global_sums_by_experiment.return_value = [
@@ -69,7 +69,7 @@ def test_global_sum_computes_for_project_id():
 def test_detailed_sum_computes_for_project_id():
     repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
     project_id = PROJECT_ID
-    project_global_sum_usecase = ProjectGlobalSumsByExperimentUsecase(repository_mock)
+    project_global_sum_usecase = ProjectGlobalSumByExperimentUsecase(repository_mock)
 
     expected_emission_sum = EMISSIONS_SUM_WITH_DETAILS
     repository_mock.get_project_global_sums_by_experiment.return_value = [

--- a/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
+++ b/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
@@ -64,8 +64,10 @@ def test_detailed_sum_computes_for_project_id():
         EXPERIMENT_WITH_DETAILS
     ]
 
-    actual_project_global_sum_by_experiment = project_global_sum_usecase.compute_detailed_sum(
-        project_id, START_DATE, END_DATE
+    actual_project_global_sum_by_experiment = (
+        project_global_sum_usecase.compute_detailed_sum(
+            project_id, START_DATE, END_DATE
+        )
     )
 
     assert actual_project_global_sum_by_experiment.emission_sum == expected_emission_sum

--- a/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
+++ b/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
@@ -1,14 +1,19 @@
+from datetime import datetime
 from unittest import mock
 
+import dateutil
 from carbonserver.api.infra.repositories.repository_experiments import (
     SqlAlchemyRepository,
 )
-from carbonserver.api.usecases.experiment.project_global_sum_by_experiment import (
-    ProjectGlobalSumByExperimentUsecase,
+from carbonserver.api.usecases.experiment.project_sum_by_experiment import (
+    ProjectSumsByExperimentUsecase,
 )
 
 EXPERIMENT_ID = "10276e58-6df7-42cf-abb8-429773a35eb5"
 EXPERIMENT_WITH_DETAILS_ID = "943b2aa5-9e21-41a9-8a38-562505b4b2aa"
+END_DATE = datetime.timestamp(datetime.now())
+START_DATE = END_DATE - dateutil.relativedelta.relativedelta(months=3)
+
 
 EMISSIONS_SUM = 1544.54
 EMISSIONS_SUM_WITH_DETAILS = 152.28955200363455
@@ -49,35 +54,18 @@ EXPERIMENT_WITH_DETAILS = {
 }
 
 
-def test_global_sum_computes_for_project_id():
-    repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
-    project_id = PROJECT_ID
-    project_global_sum_usecase = ProjectGlobalSumByExperimentUsecase(repository_mock)
-
-    expected_emission_sum = EMISSIONS_SUM
-    repository_mock.get_project_global_sums_by_experiment.return_value = [
-        EXPERIMENT_GLOBAL_SUM
-    ]
-
-    actual_project_global_sum_by_experiment = project_global_sum_usecase.compute(
-        project_id
-    )
-
-    assert actual_project_global_sum_by_experiment.emission_sum == expected_emission_sum
-
-
 def test_detailed_sum_computes_for_project_id():
     repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
     project_id = PROJECT_ID
-    project_global_sum_usecase = ProjectGlobalSumByExperimentUsecase(repository_mock)
+    project_global_sum_usecase = ProjectSumsByExperimentUsecase(repository_mock)
 
     expected_emission_sum = EMISSIONS_SUM_WITH_DETAILS
     repository_mock.get_project_global_sums_by_experiment.return_value = [
         EXPERIMENT_WITH_DETAILS
     ]
 
-    actual_project_global_sum_by_experiment = project_global_sum_usecase.compute(
-        project_id
+    actual_project_global_sum_by_experiment = project_global_sum_usecase.compute_detailed_sum(
+        project_id, START_DATE, END_DATE
     )
 
     assert actual_project_global_sum_by_experiment.emission_sum == expected_emission_sum

--- a/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
+++ b/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
@@ -1,0 +1,35 @@
+from unittest import mock
+
+from carbonserver.api.infra.repositories.repository_experiments import (
+    SqlAlchemyRepository,
+)
+from carbonserver.api.usecases.experiment.project_global_sum_by_experiment import (
+    ProjectGlobalSumsByExperimentUsecase,
+)
+
+PROJECT_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
+EXPERIMENT_GLOBAL_SUM = {
+    "id": "10276e58-6df7-42cf-abb8-429773a35eb5",
+    "timestamp": "2021-04-04T06:43:00",
+    "name": "Run on Premise",
+    "description": "Premise API for Code Carbon",
+    "emission_sum": 1544.54,
+    "energy_consumed": 57.21874,
+    "duration": 98745,
+}
+
+
+def test_global_sum_computes_for_project_id():
+    repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
+    project_id = PROJECT_ID
+    project_global_sum_usecase = ProjectGlobalSumsByExperimentUsecase(repository_mock)
+    expected_emission_sum = 1544.54
+    repository_mock.get_project_global_sums_by_experiment.return_value = [
+        EXPERIMENT_GLOBAL_SUM
+    ]
+
+    actual_project_global_sum_by_experiment = project_global_sum_usecase.compute(
+        project_id
+    )
+
+    assert actual_project_global_sum_by_experiment.emission_sum == expected_emission_sum

--- a/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
+++ b/carbonserver/tests/api/usecase/experiment/test_project_global_sum_by_experiment_usecase.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from unittest import mock
 
 import dateutil
+
 from carbonserver.api.infra.repositories.repository_experiments import (
     SqlAlchemyRepository,
 )

--- a/carbonserver/tests/test_container.py
+++ b/carbonserver/tests/test_container.py
@@ -7,6 +7,8 @@ def test_container_exposes_correct_list_of_providers_at_initialisation():
         "db",
         "emission_repository",
         "experiment_repository",
+        "experiment_repository",
+        "project_global_sum_by_experiment_usecase",
         "project_repository",
         "team_repository",
         "organization_repository",

--- a/carbonserver/tests/test_container.py
+++ b/carbonserver/tests/test_container.py
@@ -7,7 +7,6 @@ def test_container_exposes_correct_list_of_providers_at_initialisation():
         "db",
         "emission_repository",
         "experiment_repository",
-        "experiment_repository",
         "project_global_sum_by_experiment_usecase",
         "project_repository",
         "team_repository",
@@ -27,6 +26,5 @@ def test_container_exposes_correct_list_of_providers_at_initialisation():
     actual_providers = ServerContainer().providers.keys()
     diff = set(expected_providers) ^ set(actual_providers)
 
-    # Then
     assert not diff
     assert len(expected_providers) == len(actual_providers)

--- a/codecarbon/viz/carbonboard_on_api.py
+++ b/codecarbon/viz/carbonboard_on_api.py
@@ -8,7 +8,7 @@ from dash.dependencies import Input, Output
 
 from codecarbon.viz.components import Components
 from codecarbon.viz.data import Data
-
+from codecarbon.core.config import get_hierarchical_config
 
 def render_app(df: pd.DataFrame):
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.COSMO])
@@ -270,7 +270,8 @@ def render_app(df: pd.DataFrame):
 
 
 def viz(port: int = 8051, debug: bool = False) -> None:
-    df = Data.get_data_from_api("http://localhost:8000")
+    conf = get_hierarchical_config()
+    df = Data.get_data_from_api(conf.get("api_endpoint", "http://localhost:8000"))
     app = render_app(df)
     app.run_server(port=port, debug=debug)
 

--- a/codecarbon/viz/carbonboard_on_api.py
+++ b/codecarbon/viz/carbonboard_on_api.py
@@ -1,0 +1,283 @@
+import dash
+import dash_bootstrap_components as dbc
+import dash_core_components as dcc
+import dash_table as dt
+import fire
+import pandas as pd
+from dash.dependencies import Input, Output
+
+from codecarbon.viz.components import Components
+from codecarbon.viz.data import Data
+
+
+def render_app(df: pd.DataFrame):
+    app = dash.Dash(__name__, external_stylesheets=[dbc.themes.COSMO])
+
+    components = Components()
+    header = components.get_header()
+    net_summary = components.get_net_summary()
+    project_dropdown = components.get_project_dropdown(df)
+    project_details = components.get_project_details()
+    exemplary_equivalents = components.get_exemplary_equivalents()
+    _hidden_project_data = components.get_hidden_project_data()
+    _hidden_project_summary = components.get_hidden_project_summary()
+    cloud_emissions_comparison = components.get_cloud_emissions_comparison()
+    global_comparison = components.get_global_comparison()
+    regional_comparison = components.get_regional_emissions_comparison()
+    project_time_series = components.get_project_time_series()
+    project_emissions_bar_chart = components.get_project_emissions_bar_chart()
+    references = components.get_references()
+
+    data = Data()
+
+    app.layout = dbc.Container(
+        [
+            header,
+            net_summary,
+            project_dropdown,
+            project_details,
+            exemplary_equivalents,
+            cloud_emissions_comparison,
+            global_comparison,
+            regional_comparison,
+            project_time_series,
+            project_emissions_bar_chart,
+            references,
+            _hidden_project_data,
+            _hidden_project_summary,
+        ],
+        style={"padding-top": "50px"},
+    )
+
+    @app.callback(
+        [
+            Output(component_id="hidden_project_data", component_property="children"),
+            Output(component_id="hidden_project_summary", component_property="data"),
+            Output(component_id="net_power_consumption", component_property="children"),
+            Output(component_id="net_carbon_equivalent", component_property="children"),
+            Output(
+                component_id="project_infrastructure_location",
+                component_property="children",
+            ),
+            Output(
+                component_id="project_power_consumption", component_property="children"
+            ),
+            Output(
+                component_id="project_carbon_equivalent", component_property="children"
+            ),
+            Output(
+                component_id="last_run_power_consumption", component_property="children"
+            ),
+            Output(
+                component_id="last_run_carbon_equivalent", component_property="children"
+            ),
+        ],
+        [Input(component_id="project_name", component_property="value")],
+    )
+    def update_project_data(project_name: str):
+        project_data = data.get_project_data(df, project_name)
+        project_summary = data.get_project_summary(project_data.data)
+        net_power_consumption = f"{'{:.1f}'.format(sum(df['energy_consumed']))} kWh"
+        net_carbon_equivalent = f"{'{:.1f}'.format(sum(df['emissions']))} kg"
+        if {project_summary["region"]} == "":
+            project_infrastructure_location = f"{project_summary['country_name']}"
+        else:
+            project_infrastructure_location = (
+                f"{project_summary['region']}, {project_summary['country_name']}"
+            )
+        project_power_consumption = (
+            f"{round(project_summary['total']['energy_consumed'],1)} kWh"
+        )
+        project_carbon_equivalent = (
+            f"{round(project_summary['total']['emissions'],1)} kg"
+        )
+        last_run_power_consumption = (
+            f"{project_summary['last_run']['energy_consumed']} kWh"
+        )
+        last_run_carbon_equivalent = f"{project_summary['last_run']['emissions']} kg"
+
+        return (
+            project_data,
+            project_summary,
+            net_power_consumption,
+            net_carbon_equivalent,
+            project_infrastructure_location,
+            project_power_consumption,
+            project_carbon_equivalent,
+            last_run_power_consumption,
+            last_run_carbon_equivalent,
+        )
+
+    @app.callback(
+        [
+            Output(component_id="house_icon", component_property="src"),
+            Output(component_id="car_icon", component_property="src"),
+            Output(component_id="tv_icon", component_property="src"),
+            Output(component_id="car_miles", component_property="children"),
+            Output(component_id="tv_time", component_property="children"),
+            Output(component_id="household_fraction", component_property="children"),
+        ],
+        [Input(component_id="hidden_project_summary", component_property="data")],
+    )
+    def update_exemplary_equivalents(hidden_project_summary: dcc.Store):
+        project_carbon_equivalent = hidden_project_summary["total"]["emissions"]
+        house_icon = app.get_asset_url("house_icon.png")
+        car_icon = app.get_asset_url("car_icon.png")
+        tv_icon = app.get_asset_url("tv_icon.png")
+        car_miles = f"{data.get_car_miles(project_carbon_equivalent)} miles"
+        tv_time = data.get_tv_time(project_carbon_equivalent)
+        household_fraction = (
+            f"{data.get_household_fraction(project_carbon_equivalent)} %"
+        )
+        return house_icon, car_icon, tv_icon, car_miles, tv_time, household_fraction
+
+    @app.callback(
+        [
+            Output(
+                component_id="global_emissions_choropleth", component_property="figure"
+            ),
+            Output(
+                component_id="global_energy_mix_choropleth", component_property="figure"
+            ),
+        ],
+        [
+            Input(component_id="hidden_project_summary", component_property="data"),
+            Input(component_id="energy_type", component_property="value"),
+        ],
+    )
+    def update_global_comparisons(hidden_project_summary: dcc.Store, energy_type: str):
+        net_energy_consumed = hidden_project_summary["total"]["energy_consumed"]
+        global_emissions_choropleth_data = data.get_global_emissions_choropleth_data(
+            net_energy_consumed
+        )
+
+        return (
+            components.get_global_emissions_choropleth_figure(
+                global_emissions_choropleth_data
+            ),
+            components.get_global_energy_mix_choropleth_figure(
+                energy_type, global_emissions_choropleth_data
+            ),
+        )
+
+    @app.callback(
+        Output(
+            component_id="regional_emissions_comparison_component",
+            component_property="style",
+        ),
+        [Input(component_id="hidden_project_summary", component_property="data")],
+    )
+    def update_show_regional_comparison(hidden_project_summary: dcc.Store):
+        country_iso_code = hidden_project_summary["country_iso_code"]
+        # add country codes here to render for different countries
+        if country_iso_code.upper() in ["USA", "CAN"]:
+            return {"display": "block"}
+        else:
+            return {"display": "none"}
+
+    @app.callback(
+        [
+            Output(component_id="country_name", component_property="children"),
+            Output(
+                component_id="regional_emissions_comparison_choropleth",
+                component_property="figure",
+            ),
+        ],
+        [Input(component_id="hidden_project_summary", component_property="data")],
+    )
+    def update_regional_comparison_choropleth(hidden_project_summary: dcc.Store):
+        country_name = hidden_project_summary["country_name"]
+        country_iso_code = hidden_project_summary["country_iso_code"]
+        net_energy_consumed = hidden_project_summary["total"]["energy_consumed"]
+        regional_emissions_choropleth_data = (
+            data.get_regional_emissions_choropleth_data(
+                net_energy_consumed, country_iso_code
+            )
+        )
+
+        return (
+            country_name,
+            components.get_regional_emissions_choropleth_figure(
+                regional_emissions_choropleth_data, country_iso_code
+            ),
+        )
+
+    @app.callback(
+        Output(component_id="project_time_series", component_property="figure"),
+        [Input(component_id="hidden_project_data", component_property="children")],
+    )
+    def update_project_time_series(hidden_project_data: dt.DataTable):
+        return components.get_project_time_series_figure(
+            hidden_project_data["props"]["data"]
+        )
+
+    @app.callback(
+        Output(component_id="project_emissions_bar_chart", component_property="figure"),
+        [Input(component_id="hidden_project_data", component_property="children")],
+    )
+    def update_project_bar_chart(hidden_project_data: dt.DataTable):
+        return components.get_project_emissions_bar_chart_figure(
+            hidden_project_data["props"]["data"]
+        )
+
+    @app.callback(
+        Output(
+            component_id="cloud_emissions_comparison_component",
+            component_property="style",
+        ),
+        [Input(component_id="hidden_project_summary", component_property="data")],
+    )
+    def update_on_cloud(hidden_project_summary: dcc.Store):
+        on_cloud = hidden_project_summary["on_cloud"]
+        if on_cloud == "Y":
+            return {"display": "block"}
+        else:
+            return {"display": "none"}
+
+    @app.callback(
+        [
+            Output(component_id="cloud_provider_name", component_property="children"),
+            Output(
+                component_id="cloud_emissions_barchart", component_property="figure"
+            ),
+            Output(component_id="cloud_recommendation", component_property="children"),
+        ],
+        [Input(component_id="hidden_project_summary", component_property="data")],
+    )
+    def update_cloud_emissions_barchart(hidden_project_summary: dcc.Store):
+        on_cloud = hidden_project_summary["on_cloud"]
+        net_energy_consumed = hidden_project_summary["total"]["energy_consumed"]
+        cloud_provider = hidden_project_summary["cloud_provider"]
+        cloud_region = hidden_project_summary["cloud_region"]
+        (
+            cloud_provider_name,
+            cloud_emissions_barchart_data,
+        ) = data.get_cloud_emissions_barchart_data(
+            net_energy_consumed, on_cloud, cloud_provider, cloud_region
+        )
+
+        return (
+            cloud_provider_name,
+            components.get_cloud_emissions_barchart_figure(
+                cloud_emissions_barchart_data
+            ),
+            components.get_cloud_recommendation(
+                on_cloud, cloud_provider_name, cloud_emissions_barchart_data
+            ),
+        )
+
+    return app
+
+
+def viz(port: int = 8051, debug: bool = False) -> None:
+    df = Data.get_data_from_api("http://localhost:8000")
+    app = render_app(df)
+    app.run_server(port=port, debug=debug)
+
+
+def main():
+    fire.Fire(viz)
+
+
+if __name__ == "__main__":
+    main()

--- a/codecarbon/viz/carbonboard_on_api.py
+++ b/codecarbon/viz/carbonboard_on_api.py
@@ -6,9 +6,10 @@ import fire
 import pandas as pd
 from dash.dependencies import Input, Output
 
+from codecarbon.core.config import get_hierarchical_config
 from codecarbon.viz.components import Components
 from codecarbon.viz.data import Data
-from codecarbon.core.config import get_hierarchical_config
+
 
 def render_app(df: pd.DataFrame):
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.COSMO])


### PR DESCRIPTION
In order to build reports that will populate the front end, a first endpoint to compute sums, by experiment, at the project level.

As the domain logic & the front end API usages begins to emerge, this PR introduces use case abstraction, which should replace generic services as currently implemented. In this pattern, the basic domain logic should return to domain and its entity objects, and more complex interactions with the infra should be implemented as use cases.

- Raise the number of entries returned by `/emissions/run/{run_id}` to up to 10 000
- Add a CarbonBoard that use the api: `python3 codecarbon/viz/carbonboard_on_api.py --debug`

 Todo :
- [x] Add use case custom return types as Report types to be able to share them with the front end application
- [x] Add new entries in functional testing
- [x] Make http://localhost:8000/experiments/225904ca-f741-477c-83f5-d61587d6286c/detailed_sums/ work