### PR TITLE
Scheduler replacement

### DIFF
--- a/.conda/py36/meta.yaml
+++ b/.conda/py36/meta.yaml
@@ -20,7 +20,6 @@ requirements:
   run:
     - python=3.6.*
     - arrow
-    - apscheduler
     - dash
     - dash-bootstrap-components
     - dataclasses

--- a/.conda/py37-plus/meta.yaml
+++ b/.conda/py37-plus/meta.yaml
@@ -20,7 +20,6 @@ requirements:
   run:
     - python>=3.7
     - arrow
-    - apscheduler
     - dash
     - dash-bootstrap-components
     - fire

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ docs/_build/
 # local database
 code_carbon.db
 .clever.json
+
+# Local file
+emissions*.csv*
+tests/test_data/rapl/*

--- a/codecarbon/external/scheduler.py
+++ b/codecarbon/external/scheduler.py
@@ -1,0 +1,62 @@
+from threading import Lock, Timer
+
+from codecarbon.external.logger import logger
+
+
+class PeriodicScheduler(object):
+    """
+    A periodic task running in threading.Timers
+    From https://stackoverflow.com/a/18906292/14541668
+    """
+
+    def __init__(self, interval, function, *args, **kwargs):
+        """
+        Init the scheduler. You have to call with autostart=True
+        if ou want to start it without having to calling start().
+        ::interval:: interval in seconds to run the function.
+        ::function:: function to run.
+        ::args:: args to pass to the function.
+        ::kwargs:: kwargs to pass to the function.
+        """
+        self._lock = Lock()
+        self._timer = None
+        self.function = function
+        self.interval = interval
+        self.args = args
+        self.kwargs = kwargs
+        self._stopped = True
+        if kwargs.pop("autostart", True):
+            self.start()
+            msg = f"PeriodicScheduler is ready to run {self.function} in {self.interval} seconds."
+        else:
+            msg += " You have to call .start() before."
+        logger.debug(msg)
+
+    def start(self, from_run=False):
+        """
+        Start the scheduler.
+        ::from_run:: For internal purposes to allow re-scheduling
+        Please do not use from_run=True until you know what you do !
+        """
+        # logger.debug(f"In PeriodicScheduler.start()")
+        self._lock.acquire()
+        if from_run or self._stopped:
+            self._stopped = False
+            self._timer = Timer(self.interval, self._run)
+            self._timer.start()
+        self._lock.release()
+
+    def _run(self):
+        # logger.debug(f"In PeriodicScheduler._run()")
+        self.start(from_run=True)
+        # logger.debug(f"PeriodicScheduler run {self.function}")
+        self.function(*self.args, **self.kwargs)
+
+    def stop(self):
+        """
+        Stop the scheduler.
+        """
+        self._lock.acquire()
+        self._stopped = True
+        self._timer.cancel()
+        self._lock.release()

--- a/codecarbon/viz/carbonboard.py
+++ b/codecarbon/viz/carbonboard.py
@@ -1,4 +1,3 @@
-import dash
 import dash_bootstrap_components as dbc
 import dash_core_components as dcc
 import dash_table as dt
@@ -6,6 +5,7 @@ import fire
 import pandas as pd
 from dash.dependencies import Input, Output
 
+import dash
 from codecarbon.viz.components import Components
 from codecarbon.viz.data import Data
 

--- a/docs/_sources/installation.rst.txt
+++ b/docs/_sources/installation.rst.txt
@@ -39,7 +39,6 @@ The following pip packages are used by the CodeCarbon package, and will be insta
 
 .. code-block::  bash
 
-    APScheduler
     dash
     dash_bootstrap_components
     dataclasses

--- a/docs/edit/installation.rst
+++ b/docs/edit/installation.rst
@@ -39,7 +39,6 @@ The following pip packages are used by the CodeCarbon package, and will be insta
 
 .. code-block::  bash
 
-    APScheduler
     dash
     dash_bootstrap_components
     dataclasses

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -201,7 +201,7 @@
 <div class="section" id="pip">
 <h3>pip<a class="headerlink" href="#pip" title="Permalink to this headline">¶</a></h3>
 <p>The following pip packages are used by the CodeCarbon package, and will be installed along with the package itself:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>APScheduler
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>
 dash
 dash_bootstrap_components
 dataclasses

--- a/examples/api_call_debug.py
+++ b/examples/api_call_debug.py
@@ -6,7 +6,6 @@ from codecarbon.external.logger import logger
 
 
 @track_emissions(
-    api_endpoint="http://localhost:8008",
     measure_power_secs=30,
     api_call_interval=4,
     api_key="12aaaaaa-0b23-1234-1234-abcdef123456",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 arrow
-APScheduler
 black
 dash
 dash_bootstrap_components

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 DEPENDENCIES = [
     "arrow",
-    "APScheduler",
     "dash",
     "dash_bootstrap_components",
     "dataclasses;python_version<'3.7'",


### PR DESCRIPTION
The Advanced Python Scheduler (APScheduler) seems a robust solution but #252 show that it is not so good.

This PR is an attempt to switch to the Timer included in Python to close #252.