### PR TITLE
Improve types annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+mypy-check:
+	mypy -m codecarbon \
+	--ignore-missing-imports \
+	--no-strict-optional \
+	--disable-error-code attr-defined \
+	--disable-error-code assignment

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,5 @@ mypy-check:
 	--ignore-missing-imports \
 	--no-strict-optional \
 	--disable-error-code attr-defined \
-	--disable-error-code assignment
+	--disable-error-code assignment \
+	--disable-error-code misc \

--- a/codecarbon/core/cloud.py
+++ b/codecarbon/core/cloud.py
@@ -37,7 +37,7 @@ def postprocess_gcp_cloud_metadata(cloud_metadata):
     return cloud_metadata
 
 
-CLOUD_METADATA_MAPPING = {
+CLOUD_METADATA_MAPPING: Dict[str, Dict[str, Any]] = {
     "AWS": {
         "url": "http://169.254.169.254/latest/dynamic/instance-identity/document",
         "headers": {},

--- a/codecarbon/core/co2_signal.py
+++ b/codecarbon/core/co2_signal.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import requests
 
 from codecarbon.core.units import EmissionsPerKWh, Energy
@@ -8,6 +10,7 @@ CO2_SIGNAL_API_TIMEOUT = 30
 
 
 def get_emissions(energy: Energy, geo: GeoMetadata, co2_signal_api_token: str = ""):
+    params: Dict[str, Any]
     if geo.latitude:
         params = {"lat": geo.latitude, "lon": geo.longitude}
     else:

--- a/codecarbon/core/config.py
+++ b/codecarbon/core/config.py
@@ -1,6 +1,7 @@
 import configparser
 import os
 from pathlib import Path
+from typing import List
 
 
 def clean_env_key(k: str) -> str:
@@ -41,7 +42,7 @@ def parse_env_config() -> dict:
     }
 
 
-def parse_gpu_ids(gpu_ids_str):
+def parse_gpu_ids(gpu_ids_str: str) -> List[int]:
     """
     Transforms the potential gpu_ids string into a list of int values
 

--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import time
 import warnings
-from typing import Dict, Union
+from typing import Dict, Tuple
 
 import pandas as pd
 
@@ -327,7 +327,7 @@ class TDP:
     def _get_max_idxs(ratios: list, max_ratio: int) -> list:
         return [idx for idx, ratio in enumerate(ratios) if ratio == max_ratio]
 
-    def _main(self) -> Union[str, int]:
+    def _main(self) -> Tuple[str, int]:
         """
         Get CPU power from constant mode
 

--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -127,7 +127,7 @@ class IntelPowerGadget:
             )
         return
 
-    def get_cpu_details(self) -> Dict:
+    def get_cpu_details(self, **kwargs) -> Dict:
         """
         Fetches the CPU Power Details by fetching values from a logged csv file
         in _log_values function
@@ -206,7 +206,7 @@ class IntelRAPL:
                     )
         return
 
-    def get_cpu_details(self, delay: float) -> Dict:
+    def get_cpu_details(self, delay: float, **kwargs) -> Dict:
         """
         Fetches the CPU Energy Deltas by fetching values from RAPL files
         """

--- a/codecarbon/core/emissions.py
+++ b/codecarbon/core/emissions.py
@@ -139,7 +139,7 @@ class Emissions:
                 geo.country_iso_code.lower()
             )
             region_energy_mix_data = country_energy_mix_data[geo.region]
-            emissions_per_kWh: EmissionsPerKWh = self._energy_mix_to_emissions_rate(
+            emissions_per_kWh = self._energy_mix_to_emissions_rate(
                 region_energy_mix_data
             )
 

--- a/codecarbon/core/rapl.py
+++ b/codecarbon/core/rapl.py
@@ -10,7 +10,7 @@ class RAPLFile:
     energy_reading: Energy = Energy(0)  # kWh
     energy_delta: Energy = Energy(0)  # kWh
 
-    def _get_value(self) -> float:
+    def _get_value(self) -> Energy:
         """
         Reads the value in the file at the path
         """

--- a/codecarbon/core/util.py
+++ b/codecarbon/core/util.py
@@ -25,7 +25,7 @@ def suppress(*exceptions):
         pass
 
 
-def resolve_path(path: Union[str, Path]) -> None:
+def resolve_path(path: Union[str, Path]) -> Path:
 
     """
     Fully resolve a path:

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -617,7 +617,7 @@ class OfflineEmissionsTracker(BaseEmissionsTracker):
 
         if self._region is not None:
             assert isinstance(self._region, str)
-            self._region = self._region.lower()
+            self._region: str = self._region.lower()
 
         if self._cloud_provider:
             if self._cloud_region is None:
@@ -654,7 +654,7 @@ class OfflineEmissionsTracker(BaseEmissionsTracker):
 
         if self._country_2letter_iso_code:
             assert isinstance(self._country_2letter_iso_code, str)
-            self._country_2letter_iso_code = self._country_2letter_iso_code.upper()
+            self._country_2letter_iso_code: str = self._country_2letter_iso_code.upper()
 
         super().__init__(*args, **kwargs)
 

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -444,7 +444,7 @@ class BaseEmissionsTracker(ABC):
         total_emissions = EmissionsData(
             timestamp=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
             project_name=self._project_name,
-            run_id=self.run_id,
+            run_id=str(self.run_id),
             duration=duration.seconds,
             emissions=emissions,
             emissions_rate=emissions * 1000 / duration.seconds,

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -233,7 +233,7 @@ class BaseEmissionsTracker(ABC):
         self._geo = None
 
         if isinstance(self._gpu_ids, str):
-            self._gpu_ids = parse_gpu_ids(self._gpu_ids)
+            self._gpu_ids: List[int] = parse_gpu_ids(self._gpu_ids)
             self._conf["gpu_ids"] = self._gpu_ids
             self._conf["gpu_count"] = len(self._gpu_ids)
 

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -238,8 +238,9 @@ class BaseEmissionsTracker(ABC):
             self._conf["gpu_count"] = len(self._gpu_ids)
 
         logger.info("[setup] RAM Tracking...")
-        self._hardware = [RAM(tracking_mode=self._tracking_mode)]
-        self._conf["ram_total_size"] = self._hardware[0].machine_memory_GB
+        ram = RAM(tracking_mode=self._tracking_mode)
+        self._conf["ram_total_size"] = ram.machine_memory_GB
+        self._hardware: List[Union[RAM, CPU, GPU]] = [ram]
 
         # Hardware detection
         logger.info("[setup] GPU Tracking...")

--- a/codecarbon/output.py
+++ b/codecarbon/output.py
@@ -128,7 +128,7 @@ class FileOutput(BaseOutput):
                 df = df.append(dict(data.values), ignore_index=True)
             elif len(df_run) > 1:
                 logger.warning(
-                    f"CSV contains more than 1 ({len(len(df_run))})"
+                    f"CSV contains more than 1 ({len(df_run)})"
                     + f" rows with current run ID ({data.run_id})."
                     + "Appending instead of updating."
                 )


### PR DESCRIPTION
The idea is to get rid of some of the most critical mypy errors in the codecarbon module.
First I added a make file with a rather permissive mypy configuration rule and then made the necessary changes to have this command not return any errors.
