### PR TITLE
Separate viz dependencies as extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ conda activate codecarbon
 ```
 pip install codecarbon
 ```
-
+or
+```
+pip install codecarbon[viz]
+```
+if you wish to use the built-in visualization tool described below.
 #### Install from Conda repository
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 DEPENDENCIES = [
     "arrow",
-    "dash",
-    "dash_bootstrap_components",
     "dataclasses;python_version<'3.7'",
-    "fire",
     "pandas",
     "pynvml",
     "requests",
@@ -31,6 +28,7 @@ setuptools.setup(
     ),
     install_requires=DEPENDENCIES,
     tests_require=TEST_DEPENDENCIES,
+    extras_require={"viz": ["dash", "dash_bootstrap_components", "fire"]},
     classifiers=[
         "Natural Language :: English",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Related issue: https://github.com/mlco2/codecarbon/issues/93
This separates the dependencies that are used only by the visualization as extras in the PyPi package.
