### PR TITLE
FIX: Add missing `carbon_intensity_per_source.json` file to `package_data` list in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setuptools.setup(
             "data/hardware/cpu_power.csv",
             "data/private_infra/2016/usa_emissions.json",
             "data/private_infra/2016/canada_energy_mix.json",
+            "data/private_infra/carbon_intensity_per_source.json"
             "data/private_infra/global_energy_mix.json",
             "viz/assets/*.png",
         ],


### PR DESCRIPTION
Dear community,

After trying to install `codecarbon` from the master branch to test the latest features, I got the following error:

```output
FileNotFoundError: [Errno 2] No such file or directory: '/Applications/miniconda3/envs/pymialsrtk-env/lib/python3.7/site-packages/codecarbon/data/private_infra/carbon_intensity_per_source.json'
```

It appears that this file does not appear in the `package_data` list of the `setup.py`. This PR addresses this.