### PR TITLE
set default value for rapl_dir

### DIFF
--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -206,7 +206,7 @@ class IntelRAPL:
                     )
         return
 
-    def get_cpu_details(self, delay: float, **kwargs) -> Dict:
+    def get_cpu_details(self, delay: float = 0.01, **kwargs) -> Dict:
         """
         Fetches the CPU Energy Deltas by fetching values from RAPL files
         """

--- a/codecarbon/external/hardware.py
+++ b/codecarbon/external/hardware.py
@@ -92,7 +92,12 @@ class GPU(BaseHardware):
 @dataclass
 class CPU(BaseHardware):
     def __init__(
-        self, output_dir: str, mode: str, model: str, tdp: int, rapl_dir: str = None
+        self,
+        output_dir: str,
+        mode: str,
+        model: str,
+        tdp: int,
+        rapl_dir: str = "/sys/class/powercap/intel-rapl",
     ):
         self._output_dir = output_dir
         self._mode = mode

--- a/examples/api_call_debug.py
+++ b/examples/api_call_debug.py
@@ -16,10 +16,10 @@ def train_model():
     This function will do nothing during (occurrence * delay) seconds.
     The Code Carbon API will be called every (measure_power_secs * api_call_interval) seconds.
     """
-    occurence = 60 * 24 * 365 * 100  # Run for 100 years !
+    occurrence = 60 * 24 * 365 * 100  # Run for 100 years !
     delay = 60  # Seconds
-    for i in range(occurence):
-        print(f"{occurence * delay - i * delay} seconds before ending script...")
+    for i in range(occurrence):
+        print(f"{occurrence * delay - i * delay} seconds before ending script...")
         time.sleep(delay)
 
 

--- a/examples/api_call_debug.py
+++ b/examples/api_call_debug.py
@@ -13,7 +13,7 @@ from codecarbon.external.logger import logger
 )
 def train_model():
     """
-    This function will do nothing during (occurence * delay) seconds.
+    This function will do nothing during (occurrence * delay) seconds.
     The Code Carbon API will be called every (measure_power_secs * api_call_interval) seconds.
     """
     occurence = 60 * 24 * 365 * 100  # Run for 100 years !


### PR DESCRIPTION
Fix error with `None` `rapl_dir` in `hardware.CPU(...)` init

Fix error with no default `delay` value in `IntelRAPL.get_cpu_details`