### PR TITLE
Add server-monitor

### DIFF
--- a/.conda/py36/meta.yaml
+++ b/.conda/py36/meta.yaml
@@ -12,6 +12,9 @@ build:
   number: 0
   string: py36
   script: python -m pip install --no-deps --ignore-installed .
+  entry_points:
+    - carbonboard = codecarbon.viz.carbonboard:main
+    - codecarbon = codecarbon.cli.main:codecarbon
 
 requirements:
   host:
@@ -20,6 +23,7 @@ requirements:
   run:
     - python=3.6.*
     - arrow
+    - click
     - dash
     - dash-bootstrap-components
     - dataclasses

--- a/.conda/py37-plus/meta.yaml
+++ b/.conda/py37-plus/meta.yaml
@@ -12,6 +12,9 @@ build:
   number: 0
   string: py37_plus
   script: python -m pip install --no-deps --ignore-installed .
+  entry_points:
+    - carbonboard = codecarbon.viz.carbonboard:main
+    - codecarbon = codecarbon.cli.main:codecarbon
 
 requirements:
   host:
@@ -20,6 +23,7 @@ requirements:
   run:
     - python>=3.7
     - arrow
+    - click
     - dash
     - dash-bootstrap-components
     - fire

--- a/README.md
+++ b/README.md
@@ -13,12 +13,26 @@ Estimate and track carbon emissions from your compute, quantify and analyze thei
 
 - [About CodeCarbon 💡](#about-codecarbon-)
 - [Installation :battery:](#installation-battery)
+      - [Install from PyPI repository](#install-from-pypi-repository)
+      - [Install from Conda repository](#install-from-conda-repository)
 - [Quickstart 🚀](#quickstart-)
+    - [Online mode](#online-mode)
+      - [Code Carbon API (ALPHA)](#code-carbon-api-alpha)
+    - [Offline mode](#offline-mode)
+    - [Flush data when running](#flush-data-when-running)
+    - [Using comet.ml](#using-cometml)
+    - [Configuration](#configuration)
 - [Examples 🐤](#examples-)
 - [Built-in Visualization Tool :heart_eyes:](#built-in-visualization-tool-heart_eyes)
 - [Comet Integration 🥂](#comet-integration-)
 - [Report your emissions: LateX template 📻](#report-your-emissions-latex-template-)
+    - [Citing CodeCarbon](#citing-codecarbon)
 - [Infrastructure Support 🖥️](#infrastructure-support-️)
+    - [GPU](#gpu)
+    - [CPU](#cpu)
+      - [On Windows and Mac](#on-windows-and-mac)
+      - [On Linux](#on-linux)
+      - [On all platforms](#on-all-platforms)
 - [Data Sources 🗒️](#data-sources-️)
 - [Contributing 🤝](#contributing-)
 - [Build Documentation 🖨️](#build-documentation-️)
@@ -111,7 +125,12 @@ codecarbon init
 
 It will ask the API for an experiment_id on the default project and save it to `.codecarbon.config` for you.
 
-Then, you could tell Code Carbon to use the API in your code:
+Then, you could tell Code Carbon to monitor your machine:
+```
+codecarbon monitor
+```
+
+Or use the API in your code:
 
 ```python
 from codecarbon import track_emissions

--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -1,4 +1,5 @@
 import click
+import time
 
 from codecarbon.cli.cli_utils import (
     get_api_endpoint,
@@ -7,6 +8,7 @@ from codecarbon.cli.cli_utils import (
 )
 from codecarbon.core.api_client import ApiClient, get_datetime_with_timezone
 from codecarbon.core.schemas import ExperimentCreate
+from codecarbon import EmissionsTracker
 
 DEFAULT_PROJECT_ID = "e60afa92-17b7-4720-91a0-1ae91e409ba1"
 
@@ -53,3 +55,15 @@ def init():
             + click.style("./.codecarbon.config", fg="bright_blue")
             + "\n"
         )
+
+@codecarbon.command()
+def monitor():
+    init()
+    click.echo("CodeCarbon is going in an infinite loop to monitor this machine.")
+    with EmissionsTracker(
+        measure_power_secs=10,
+        api_call_interval=30,
+        save_to_api=True) as tracker:
+        # Infinite loop
+        while True:
+            time.sleep(300)

--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -61,14 +61,19 @@ def init():
 @codecarbon.command(
     "monitor", short_help="Run an infinite loop to monitor this machine."
 )
-def monitor():
+@click.option("--measure_power_secs", default=10)
+@click.option("--api_call_interval", default=30)
+@click.option("--api/--no-api", default=True)
+def monitor(measure_power_secs, api_call_interval, api):
     experiment_id = get_existing_local_exp_id()
-    if experiment_id is None:
+    if api and experiment_id is None:
         click.echo("ERROR: No experiment id, call with init option first.")
         exit(1)
     click.echo("CodeCarbon is going in an infinite loop to monitor this machine.")
     with EmissionsTracker(
-        measure_power_secs=10, api_call_interval=30, save_to_api=True
+        measure_power_secs=measure_power_secs,
+        api_call_interval=api_call_interval,
+        save_to_api=api,
     ):
         # Infinite loop
         while True:

--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -61,13 +61,21 @@ def init():
 @codecarbon.command(
     "monitor", short_help="Run an infinite loop to monitor this machine."
 )
-@click.option("--measure_power_secs", default=10)
-@click.option("--api_call_interval", default=30)
-@click.option("--api/--no-api", default=True)
+@click.option(
+    "--measure_power_secs", default=10, help="Interval between two measures. (10)"
+)
+@click.option(
+    "--api_call_interval",
+    default=30,
+    help="Number of measures before calling API. (30).",
+)
+@click.option(
+    "--api/--no-api", default=True, help="Choose to call Code Carbon API or not. (yes)"
+)
 def monitor(measure_power_secs, api_call_interval, api):
     experiment_id = get_existing_local_exp_id()
     if api and experiment_id is None:
-        click.echo("ERROR: No experiment id, call with init option first.")
+        click.echo("ERROR: No experiment id, call 'codecarbon init' first.")
         exit(1)
     click.echo("CodeCarbon is going in an infinite loop to monitor this machine.")
     with EmissionsTracker(

--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -1,6 +1,8 @@
-import click
 import time
 
+import click
+
+from codecarbon import EmissionsTracker
 from codecarbon.cli.cli_utils import (
     get_api_endpoint,
     get_existing_local_exp_id,
@@ -8,7 +10,6 @@ from codecarbon.cli.cli_utils import (
 )
 from codecarbon.core.api_client import ApiClient, get_datetime_with_timezone
 from codecarbon.core.schemas import ExperimentCreate
-from codecarbon import EmissionsTracker
 
 DEFAULT_PROJECT_ID = "e60afa92-17b7-4720-91a0-1ae91e409ba1"
 
@@ -18,7 +19,7 @@ def codecarbon():
     pass
 
 
-@codecarbon.command()
+@codecarbon.command("init", short_help="Create an experiment id in a public project.")
 def init():
     experiment_id = get_existing_local_exp_id()
     new_local = False
@@ -56,14 +57,19 @@ def init():
             + "\n"
         )
 
-@codecarbon.command()
+
+@codecarbon.command(
+    "monitor", short_help="Run an infinite loop to monitor this machine."
+)
 def monitor():
-    init()
+    experiment_id = get_existing_local_exp_id()
+    if experiment_id is None:
+        click.echo("ERROR: No experiment id, call with init option first.")
+        exit(1)
     click.echo("CodeCarbon is going in an infinite loop to monitor this machine.")
     with EmissionsTracker(
-        measure_power_secs=10,
-        api_call_interval=30,
-        save_to_api=True) as tracker:
+        measure_power_secs=10, api_call_interval=30, save_to_api=True
+    ):
         # Infinite loop
         while True:
             time.sleep(300)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ DEPENDENCIES = [
     "psutil",
     "py-cpuinfo",
     "fuzzywuzzy",
+    "click",
 ]
 
 TEST_DEPENDENCIES = ["mock", "pytest", "responses", "tox", "numpy", "requests-mock"]


### PR DESCRIPTION
Add an option to the cli to monitor a machine it makes it as easy as:
```
pip install codecarbon
codecarbon init
codecarbon monitor
```
Don't need any single line of code !

Will close #278 