### PR TITLE
Package only for master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,3 @@ jobs:
         env:
           # The hostname used to communicate with the PostgreSQL service container
           DATABASE_URL: postgresql://codecarbon-user:supersecret@localhost:5480/codecarbon_db
-
-
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build package & server
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,9 +3,9 @@ name: package
 on: [push, pull_request]
 
 jobs:
-    build:
+    build-package:
         runs-on: ubuntu-latest
-
+        if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,6 +1,9 @@
 name: package
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
     build-package:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,41 +1,39 @@
 name: package
 
 on:
-  pull_request:
   push:
     branches: [master]
 
 jobs:
     build-package:
-        runs-on: ubuntu-latest
-        if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
-        steps:
-            - uses: actions/checkout@v2
-            - name: Set up Python 3.8
-              uses: actions/setup-python@v1
-              with:
-                  python-version: 3.8
-            - name: Build pip package
-              run: |
-                  pip install -U pip wheel
-                  python setup.py sdist bdist_wheel
-            - name: Archive Pypi artifacts
-              uses: actions/upload-artifact@v1
-              with:
-                  name: pypi_dist
-                  path: dist
-            - uses: s-weigand/setup-conda@v1
-              with:
-                  activate-conda: true
-                  conda-channels: conda-forge
-            - name: Build conda package
-              run: |
-                  conda install conda-build conda-verify
-                  mkdir -p conda_dist
-                  conda build --python 3.6 .conda/py36/ -c conda-forge --output-folder conda_dist
-                  conda build --python 3.8 .conda/py37-plus/ -c conda-forge --output-folder conda_dist
-            - name: Archive Conda artifacts
-              uses: actions/upload-artifact@v1
-              with:
-                  name: conda_dist
-                  path: conda_dist
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Set up Python 3.8
+          uses: actions/setup-python@v1
+          with:
+              python-version: 3.8
+        - name: Build pip package
+          run: |
+              pip install -U pip wheel
+              python setup.py sdist bdist_wheel
+        - name: Archive Pypi artifacts
+          uses: actions/upload-artifact@v1
+          with:
+              name: pypi_dist
+              path: dist
+        - uses: s-weigand/setup-conda@v1
+          with:
+              activate-conda: true
+              conda-channels: conda-forge
+        - name: Build conda package
+          run: |
+              conda install conda-build conda-verify
+              mkdir -p conda_dist
+              conda build --python 3.6 .conda/py36/ -c conda-forge --output-folder conda_dist
+              conda build --python 3.8 .conda/py37-plus/ -c conda-forge --output-folder conda_dist
+        - name: Archive Conda artifacts
+          uses: actions/upload-artifact@v1
+          with:
+              name: conda_dist
+              path: conda_dist

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    needs: [ build-package ]
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5.7.0


### PR DESCRIPTION
I suggest that we don't package at every push to limit the carbon emission of Code Carbon :wink: 

Only package when we merge to master.

Bonus : I've also removed duplicate run, to save more carbon and time !