### PR TITLE
Release version 2.0.0a2

### DIFF
--- a/.conda/py36/meta.yaml
+++ b/.conda/py36/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.0a1" %}
+{% set version = "2.0.0a2" %}
 
 package:
   name: codecarbon

--- a/.conda/py37-plus/meta.yaml
+++ b/.conda/py37-plus/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.0a1" %}
+{% set version = "2.0.0a2" %}
 
 package:
   name: codecarbon

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,8 +15,8 @@ jobs:
               python-version: 3.8
         - name: Build pip package
           run: |
-              pip install -U pip wheel
-              python setup.py sdist bdist_wheel
+              pip install -U pip build
+              python3 -m build
         - name: Archive Pypi artifacts
           uses: actions/upload-artifact@v1
           with:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ TEST_DEPENDENCIES = ["mock", "pytest", "responses", "tox", "numpy", "requests-mo
 
 setuptools.setup(
     name="codecarbon",
-    version="2.0.0a1",
+    version="2.0.0a2",
     author="Mila, DataForGood, BCG GAMMA, Comet.ml, Haverford College",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
 - [Add missing __init__.py](https://github.com/mlco2/codecarbon/commit/ec178326ba0368499e2a83e7e80505c854222153) to include the CLI
 - Switch the build from `wheel` to [build](https://packaging.python.org/en/latest/tutorials/packaging-projects/)