### PR TITLE
Fix duration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v2

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -519,6 +519,7 @@ class BaseEmissionsTracker(ABC):
 
         for hardware in self._hardware:
             h_time = time.time()
+            last_duration = time.time() - self._last_measured_time
             power, energy = hardware.measure_power_and_energy(
                 last_duration=last_duration
             )
@@ -554,6 +555,7 @@ class BaseEmissionsTracker(ABC):
         logger.info(
             f"{self._total_energy.kWh:.6f} kWh of electricity used since the begining."
         )
+        last_duration = time.time() - self._last_measured_time
         self._last_measured_time = time.time()
         self._measure_occurrence += 1
         if self._cc_api__out is not None and self._api_call_interval != -1:

--- a/codecarbon/external/hardware.py
+++ b/codecarbon/external/hardware.py
@@ -160,9 +160,7 @@ class CPU(BaseHardware):
         for metric, value in all_cpu_details.items():
             if re.match(r"^Processor Energy Delta_\d", metric):
                 energy += value
-                logger.debug(f"_get_energy_from_cpus - MATCH {metric} : {value}")
-            else:
-                logger.debug(f"_get_energy_from_cpus - DONT MATCH {metric} : {value}")
+                # logger.debug(f"_get_energy_from_cpus - MATCH {metric} : {value}")
         return Energy.from_energy(energy)
 
     def total_power(self) -> Power:

--- a/codecarbon/output.py
+++ b/codecarbon/output.py
@@ -22,7 +22,7 @@ from codecarbon.external.logger import logger
 @dataclass
 class EmissionsData:
     """
-    Output object containg experiment data
+    Output object containg run data
     """
 
     timestamp: str

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 DEPENDENCIES = [
     "arrow",
-    "dataclasses;python_version<'3.7'",
     "pandas",
     "pynvml",
     "requests",
@@ -20,7 +19,7 @@ TEST_DEPENDENCIES = ["mock", "pytest", "responses", "tox", "numpy", "requests-mo
 
 setuptools.setup(
     name="codecarbon",
-    version="2.0.0a3",
+    version="2.0.0a4",
     author="Mila, DataForGood, BCG GAMMA, Comet.ml, Haverford College",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38
+envlist = py37, py38, py39
 
 [testenv]
 deps =
@@ -27,6 +27,6 @@ recreate =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
+    3.9: py39


### PR DESCRIPTION
- Remove support for Python 3.6 as it reached its end of life in December 2021.
- Fix duration measurement : The last_duration was computed before making measurement, and the _last_measured_time was set after, so we "lost" some time. Measurement on Windows Intel Power Gadget could take up to 1.6 seconds. For GPU on Linux up to 0.07 second.
