### PR TITLE
Add max_energy_range_uj to deal with RAPL wraparound

### DIFF
--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -200,12 +200,19 @@ class IntelRAPL:
                 if "package" in name:
                     name = f"Processor Energy Delta_{i}(kWh)"
                     i += 1
+                # RAPL file to take measurement from
                 rapl_file = os.path.join(self._lin_rapl_dir, file, "energy_uj")
+                # RAPL file containing maximum possible value of energy_uj above which it wraps
+                rapl_file_max = os.path.join(
+                    self._lin_rapl_dir, file, "max_energy_range_uj"
+                )
                 try:
                     # Try to read the file to be sure we can
                     with open(rapl_file, "r") as f:
                         _ = float(f.read())
-                    self._rapl_files.append(RAPLFile(name=name, path=rapl_file))
+                    self._rapl_files.append(
+                        RAPLFile(name=name, path=rapl_file, max_path=rapl_file_max)
+                    )
                     logger.debug(f"We will read Intel RAPL files at {rapl_file}")
                 except PermissionError as e:
                     logger.error(

--- a/codecarbon/core/rapl.py
+++ b/codecarbon/core/rapl.py
@@ -6,15 +6,20 @@ from codecarbon.external.logger import logger
 
 @dataclass
 class RAPLFile:
-    name: str
-    path: str
-    energy_reading: Energy = Energy(0)  # kWh
-    energy_delta: Energy = Energy(0)  # kWh
-    power: Power = Power(0)
-    last_energy = 0
+    name: str  # RAPL device being measured
+    path: str  # Path to file containing RAPL reading
+    max_path: str  # Path to corresponding file containing maximum possible RAPL reading
+    energy_delta: Energy = Energy(0)  # Energy consumed in kWh
+    power: Power = Power(0)  # Power based on reading
+    last_energy: Energy = Energy(0)  # Last energy reading in kWh
+    max_energy_reading: Energy = Energy(0)  # Max value energy can hold before it wraps
 
     def __post_init__(self):
         self.last_energy = self._get_value()
+        with open(self.max_path, "r") as f:
+            max_micro_joules = float(f.read())
+
+            self.max_energy_reading = Energy.from_ujoules(max_micro_joules)
 
     def _get_value(self) -> Energy:
         """
@@ -27,7 +32,6 @@ class RAPLFile:
             return e
 
     def start(self) -> None:
-        self.energy_reading = self._get_value()
         self.last_energy = self._get_value()
         return
 
@@ -35,19 +39,16 @@ class RAPLFile:
         """
         Compute the energy used since last call.
         """
-        energy = self._get_value()
+        new_last_energy = energy = self._get_value()
         if self.last_energy > energy:
-            logger.error(
-                f"In RAPLFile : Current energy value ({energy}) is lower than previous value ({self.last_energy}) ! Source file : {self.path}"
+            logger.debug(
+                f"In RAPLFile : Current energy value ({energy}) is lower than previous value ({self.last_energy}). Assuming wrap-around! Source file : {self.path}"
             )
-            self.power = Power(0)
-            self.energy_delta = Energy(0)
-            return
-        else:
-            self.power = self.power.from_energies_and_delay(
-                energy, self.last_energy, duration
-            )
-            self.energy_delta = energy - self.last_energy
-            self.last_energy = energy
+            energy = energy + self.max_energy_reading
+        self.power = self.power.from_energies_and_delay(
+            energy, self.last_energy, duration
+        )
+        self.energy_delta = energy - self.last_energy
+        self.last_energy = new_last_energy
 
-            return
+        return

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -66,12 +66,20 @@ class TestIntelRAPL(unittest.TestCase):
                 f.write("package-0")
             with open(os.path.join(self.rapl_dir, "intel-rapl:0/energy_uj"), "w") as f:
                 f.write("52649883221")
+            with open(
+                os.path.join(self.rapl_dir, "intel-rapl:0/max_energy_range_uj"), "w"
+            ) as f:
+                f.write("262143328850")
 
             os.makedirs(os.path.join(self.rapl_dir, "intel-rapl:1"), exist_ok=True)
             with open(os.path.join(self.rapl_dir, "intel-rapl:1/name"), "w") as f:
                 f.write("psys")
             with open(os.path.join(self.rapl_dir, "intel-rapl:1/energy_uj"), "w") as f:
                 f.write("117870082040")
+            with open(
+                os.path.join(self.rapl_dir, "intel-rapl:1/max_energy_range_uj"), "w"
+            ) as f:
+                f.write("262143328850")
 
     @unittest.skipUnless(sys.platform.lower().startswith("lin"), "requires Linux")
     def test_intel_rapl(self):

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -12,20 +12,31 @@ class TestEnergy(unittest.TestCase):
         self.path = path.join(
             path.dirname(os.path.abspath(__file__)), "test_data/mock_rapl_data.txt"
         )
+        self.max_path = path.join(
+            path.dirname(os.path.abspath(__file__)), "test_data/mock_rapl_data_max.txt"
+        )
 
         # Setup the RAPL File with a high energy level
         with open(self.path, "w") as f:
             f.write("100")
+        # Setup the RAPL maximum value to be the energy level where we wrap
+        with open(self.max_path, "w") as f:
+            f.write("105")
 
-    def test_negative_delta_writes_no_delta(self):
+    def test_wraparound_delta_correct_value(self):
         first_rapl_measure = RAPLFile(
-            name=self.mock_energy_data_filename, path=self.path
+            name=self.mock_energy_data_filename, path=self.path, max_path=self.max_path
         )
 
+        # Read the initial state
+        first_rapl_measure.start()
         # Write a cumulated value lower than the initial one
         with open(self.path, "w") as f:
             f.write("10")
+        # Update state
         first_rapl_measure.delta(Time(seconds=1))
 
-        # Assert the delta didn't write a negative delta value
-        self.assertEqual(Energy(0), first_rapl_measure.energy_delta)
+        # Assert the delta has given the correct value from wraparound (reading + max_value - previous_value)
+        self.assertAlmostEqual(
+            Energy.from_ujoules(15).kWh, first_rapl_measure.energy_delta.kWh
+        )


### PR DESCRIPTION
When we detect a negative delta from RAPL energy usage then assume we have wrapped around and add max_energy_range_uj to it. According to Intel docs this should happen about every 60 secs under a heavy load. Fixes #322