### PR TITLE
Update methodology.rst

### DIFF
--- a/docs/edit/methodology.rst
+++ b/docs/edit/methodology.rst
@@ -18,14 +18,15 @@ Carbon Intensity
 Carbon Intensity of the electricity consumed is calculated as a weighted average of the emissions from different
 energy sources that are used to generate electricity, including fossil fuels and renewables. In this toolkit, the fossil fuels coal, petroleum, and natural gas are associated with specific carbon intensities: a known amount of carbon dioxide is emitted for each kilowatt-hour of electricity generated. Renewable or low-carbon fuels include solar power, hydroelectricity, biomass, geothermal, and more. The nearby energy grid contains a mixture of fossil fuels and low-carbon energy sources, called the Energy Mix. Based on the mix of energy sources in the local grid, this package calculates the Carbon Intensity of the electricity consumed.
 
-Carbon Intensity of each individual fossil fuel source (e.g., coal, petroleum, natural gas) is based on measured carbon dioxide output and power generation in the United States. These values were applied worldwide: electricity from coal generation in Germany is assigned the same Carbon Intensity as electricity from coal generation in Japan.
-
 .. image:: ./images/grid_energy_mix.png
             :align: center
             :alt: Grid Energy Mix
             :height: 300px
             :width: 350px
 
+When aviable, CodeCarbon use global carbon intensity of electricity per cloud providers ( `here <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/cloud/impact.csv>`_ ) or per countries ( `here <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/private_infra/eu-carbon-intensity-electricity.csv>`_ ).
+
+If we don't have the global carbon intensity or electricity of a country but we have it's electricity mix, we calculate the carbon intensity of electricity using this table :
 
 .. list-table:: Carbon Intensity Across Energy Sources
    :widths: 50 50
@@ -35,33 +36,36 @@ Carbon Intensity of each individual fossil fuel source (e.g., coal, petroleum, n
    * - Energy Source
      - Carbon Intensity (kg/MWh)
    * - Coal
-     - 996
+     - 995
    * - Petroleum
-     - 817
+     - 816
    * - Natural Gas
-     - 744
-   * - Renewable (hydroelectricity, wind power, solar, etc.)
-     - 0
+     - 743
+   * - Geothermal
+     - 38
+   * - Hydroelectricity
+     - 26
+   * - Nuclear
+     - 29
+   * - Solar 
+     - 48
+   * - Wind
+     - 26
+   
+sources: 
+ -  `for fossil energies <https://github.com/responsibleproblemsolving/energy-usage#conversion-to-co2>`_ 
+ - `for renewables energies <http://www.world-nuclear.org/uploadedFiles/org/WNA/Publications/Working_Group_Reports/comparison_of_lifecycle.pdf>`_  
 
-In this analysis, we assigned low-carbon fuels (e.g., hydroelectricity, biomass) a Carbon Intensity of zero because the carbon footprint during electricity generation (for example, water flowing through a hydroelectric dam's turbine) approaches zero, but varies somewhat based on local variation in the type of low-carbon fuel used. There will be low, but distinct from one another, carbon dioxide emissions for biomass from wood combustion versus biomass from recycled landfill waste. Furthermore, these Carbon Intensities do not account for emissions from construction of electrical infrastructure and transport of fuels. If these factors were included, low-carbon fuels would have a nonzero Carbon Intensity—-but fossil fuel Carbon Intensities would be significantly higher than the values used here. We therefore consider low-carbon fuels' direct carbon emissions to be zero for the purposes of our project.
 
-
-Localization
-------------
-
-The local energy mix is based on the specific location where code is run. In the included visualizations, global benchmarks can be seen. Once a location is determined, the amount of electricity from fossil fuel and renewable sources is used to define the local Energy Mix.
-
-For example, in case the Energy Mix of the Grid Electricity is 25% Coal, 35% Petroleum, 26% Natural Gas and 14% Renewable:
+Then if for example, in case the Energy Mix of the Grid Electricity is 25% Coal, 35% Petroleum, 26% Natural Gas and 14% Nuclear:
 
 .. code-block:: text
 
-    Net Carbon Intensity = 0.25 * 996 + 0.35 * 817 + 0.26 * 744 + 0.14 * 0 = 728.39 kgCO₂/MWh
+    Net Carbon Intensity = 0.25 * 995 + 0.35 * 816 + 0.26 * 743 + 0.14 * 29 = 731.59 kgCO₂/kWh
 
-We derive the international energy mixes from the most recent year available in the United States' Energy Information Administration's Emissions & Generation Resource Integrated Database (eGRID; 2016). We approximate the energy mixes by examining the share of total primary energy produced and consumed for each country in the dataset and determining the proportion of energy derived from fossil fuel and low-carbon sources. However, because total primary energy includes sources other than electricity generation, this may marginally overstate carbon emissions by overemphasizing fossil fuels' contribution to the electrical grid in countries that use fossil fuels in other, non-energy sectors. Our estimate approximates values reported in other publications, however, because petroleum as a source of electrical generation will frequently have a higher Carbon Intensity than our average parameter (817 kgCO₂/MWh). Thus, the default CodeCarbon dataset produces global coverage of carbon emissions from electricity generation at the expense of some precision in the calculation.
+If ever we have neither the global carbon intensity of a country nor it's electricity mix, we apply a world avarage of 475 gCO2.eq/KWh ( `source <https://www.iea.org/reports/global-energy-co2-status-report-2019/emissions>`_ )
 
-We plan to refine and improve this approach in the future. First, we plan to update our default file to the most recent information available from eGRID (2017–2018) and will continue to refine this dataset as additional information is released. Second, we plan to add a more precise data layer that includes recent, specific information regarding countries' energy grid, including a verified source for that information. Combining these approaches will allow CodeCarbon to continue to provide global coverage while making more precise estimates of the carbon footprint of calculations made on the local electricity grid.
-
-Potential collaborations on this aspect of CodeCarbon's methodology are welcome: if you would like to contribute data, techniques, or expertise, please contact us.
+As you can see, we try to be as accurate as possible estimating carbon intensity of electricity. Still there is room for improvement and all contribution are welcome.
 
 
 Power Usage

--- a/docs/edit/methodology.rst
+++ b/docs/edit/methodology.rst
@@ -26,7 +26,7 @@ energy sources that are used to generate electricity, including fossil fuels and
 
 When aviable, CodeCarbon use global carbon intensity of electricity per cloud providers ( `here <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/cloud/impact.csv>`_ ) or per countries ( `here <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/private_infra/eu-carbon-intensity-electricity.csv>`_ ).
 
-If we don't have the global carbon intensity or electricity of a country but we have it's electricity mix, we calculate the carbon intensity of electricity using this table :
+If we don't have the global carbon intensity or electricity of a country but we have it's electricity mix, we compute the carbon intensity of electricity using this table :
 
 .. list-table:: Carbon Intensity Across Energy Sources
    :widths: 50 50

--- a/docs/edit/methodology.rst
+++ b/docs/edit/methodology.rst
@@ -24,7 +24,7 @@ energy sources that are used to generate electricity, including fossil fuels and
             :height: 300px
             :width: 350px
 
-When aviable, CodeCarbon use global carbon intensity of electricity per cloud providers ( `here <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/cloud/impact.csv>`_ ) or per countries ( `here <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/private_infra/eu-carbon-intensity-electricity.csv>`_ ).
+When available, CodeCarbon uses global carbon intensity of electricity per cloud providers ( `here <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/cloud/impact.csv>`_ ) or per countries ( `here <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/private_infra/eu-carbon-intensity-electricity.csv>`_ ).
 
 If we don't have the global carbon intensity or electricity of a country but we have it's electricity mix, we compute the carbon intensity of electricity using this table :
 


### PR DESCRIPTION
Add the new way to calculate carbon intensity of electricity.
 - using global carbon intensity of electricity when aviable
- using an improved from electricity mix calculation