### PR TITLE
Adding TDP for Intel Xeon Gold 6230N

### DIFF
--- a/codecarbon/data/hardware/cpu_power.csv
+++ b/codecarbon/data/hardware/cpu_power.csv
@@ -2047,6 +2047,7 @@ Intel Xeon E7-8890 v3,165
 Intel Xeon E7-8891 v3,165
 Intel Xeon E7-8893 v3,140
 Intel Xeon Gold 6154,200
+Intel Xeon Gold 6230N,125
 Intel Xeon L5506,60
 Intel Xeon L5508,38
 Intel Xeon L5518,60


### PR DESCRIPTION
TDP, see https://ark.intel.com/content/www/us/en/ark/products/192450/intel-xeon-gold-6230n-processor-27-5m-cache-2-30-ghz.html Relates to #300.