### PR TITLE
Added missing bash command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ Install from sources in development mode :
 
 ```bash
 git clone https://github.com/mlco2/codecarbon
+cd codecarbon
 pip install -e .
 ```
 


### PR DESCRIPTION
In the `CONTRIBUTING.md` file there was a bash command step missing (changing into the `codecarbon` directory) after cloning the repository.
This step is required for installing the repository with the `pip install -e .` command.