### PR TITLE
Added info for Intel Xeon E5-2680 v4

### DIFF
--- a/codecarbon/data/hardware/cpu_power.csv
+++ b/codecarbon/data/hardware/cpu_power.csv
@@ -2014,6 +2014,7 @@ Intel Xeon E5-2667 v2,130
 Intel Xeon E5-2670 v2,115
 Intel Xeon E5-2673 v3,110
 Intel Xeon E5-2680 v2,115
+Intel Xeon E5-2680 v4,120
 Intel Xeon E5-2687W v2,130
 Intel Xeon E5-2690 v2,130
 Intel Xeon E5-2692 v2,100


### PR DESCRIPTION
https://ark.intel.com/content/www/us/en/ark/products/91754/intel-xeon-processor-e52680-v4-35m-cache-2-40-ghz.html