### PR TITLE
Monitor subprocess

### DIFF
--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -1,14 +1,13 @@
 import sys
-import time
 
 import click
 
-from codecarbon import EmissionsTracker
 from codecarbon.cli.cli_utils import (
     get_api_endpoint,
     get_existing_local_exp_id,
     write_local_exp_id,
 )
+from codecarbon.cli.monitor import monitor_infinite_loop
 from codecarbon.core.api_client import ApiClient, get_datetime_with_timezone
 from codecarbon.core.schemas import ExperimentCreate
 
@@ -79,11 +78,4 @@ def monitor(measure_power_secs, api_call_interval, api):
         click.echo("ERROR: No experiment id, call 'codecarbon init' first.")
         sys.exit(1)
     click.echo("CodeCarbon is going in an infinite loop to monitor this machine.")
-    with EmissionsTracker(
-        measure_power_secs=measure_power_secs,
-        api_call_interval=api_call_interval,
-        save_to_api=api,
-    ):
-        # Infinite loop
-        while True:
-            time.sleep(300)
+    monitor_infinite_loop(measure_power_secs, api_call_interval, api)

--- a/codecarbon/cli/monitor.py
+++ b/codecarbon/cli/monitor.py
@@ -1,7 +1,10 @@
 """
 Implementations of the ``codecarbon monitor`` subcommand.
 """
+import os
+import subprocess as sp
 import time
+from typing import Sequence
 
 from codecarbon import EmissionsTracker
 
@@ -14,6 +17,26 @@ def monitor_infinite_loop(measure_power_secs, api_call_interval, api):
         measure_power_secs=measure_power_secs,
         api_call_interval=api_call_interval,
         save_to_api=api,
+        tracking_mode="machine",
     ):
         while True:
             time.sleep(300)
+
+
+def monitor_subprocess(
+    measure_power_secs, api_call_interval, api, cmd: Sequence[str | os.PathLike]
+) -> int:
+    """
+    Run and monitor a subprocess.
+
+    :return: return code of the subprocess.
+    """
+
+    with EmissionsTracker(
+        measure_power_secs=measure_power_secs,
+        api_call_interval=api_call_interval,
+        save_to_api=api,
+        tracking_mode="process",
+    ):
+        proc = sp.run(cmd)
+    return proc.returncode

--- a/codecarbon/cli/monitor.py
+++ b/codecarbon/cli/monitor.py
@@ -1,0 +1,19 @@
+"""
+Implementations of the ``codecarbon monitor`` subcommand.
+"""
+import time
+
+from codecarbon import EmissionsTracker
+
+
+def monitor_infinite_loop(measure_power_secs, api_call_interval, api):
+    """
+    Monitor all activity on the system until a user presses CTRL-C.
+    """
+    with EmissionsTracker(
+        measure_power_secs=measure_power_secs,
+        api_call_interval=api_call_interval,
+        save_to_api=api,
+    ):
+        while True:
+            time.sleep(300)


### PR DESCRIPTION
Resolves https://github.com/mlco2/codecarbon/issues/382

This PR adds functionality to the `codecarbon monitor` command.

When you run `codecarbon monitor`, the previous behavior is kept the same.

When you run `codecarbon monitor -- some positional --arguments -lah`, the positional arguments are ran as a subprocess and monitored with the option `tracking_mode="process"`.