### PR TITLE
Fix *_Twh key names

### DIFF
--- a/codecarbon/core/emissions.py
+++ b/codecarbon/core/emissions.py
@@ -211,7 +211,7 @@ class Emissions:
         """
         Convert a mix of electricity sources into emissions per kWh.
         :param energy_mix: A dictionary that breaks down the electricity produced into
-            energy sources, with a total value. Format will vary, but must have keys for "total_TWh"
+            energy sources, with a total value. Format will vary, but must have keys for "total_Twh"
         :return: an EmissionsPerKwh object representing the average emissions rate
             in Kgs.CO2 / kWh
         """
@@ -225,16 +225,16 @@ class Emissions:
             DataSource().get_carbon_intensity_per_source_data()
         )
         carbon_intensity = 0
-        energy_sum = energy_mix["total_TWh"]
+        energy_sum = energy_mix["total_Twh"]
         energy_sum_computed = 0
         # Iterate through each source of energy in the country
         for energy_type, energy_per_year in energy_mix.items():
-            if "_TWh" in energy_type:
+            if "_Twh" in energy_type:
                 # Compute the carbon intensity ratio of this source for this country
                 carbon_intensity_for_type = carbon_intensity_per_source.get(
-                    energy_type[: -len("_TWh")]
+                    energy_type[: -len("_Twh")]
                 )
-                if carbon_intensity_for_type:  # to ignore "total_TWh"
+                if carbon_intensity_for_type:  # to ignore "total_Twh"
                     carbon_intensity += (
                         energy_per_year / energy_sum
                     ) * carbon_intensity_for_type

--- a/codecarbon/viz/components.py
+++ b/codecarbon/viz/components.py
@@ -427,7 +427,6 @@ class Components:
                                 id="energy_type",
                                 options=[
                                     {"label": "Fossil", "value": "fossil"},
-                                    {"label": "Geothermal", "value": "geothermal"},
                                     {
                                         "label": "Hydroelectricity",
                                         "value": "hydroelectricity",
@@ -480,7 +479,6 @@ class Components:
                 "country",
                 "emissions",
                 "fossil",
-                "geothermal",
                 "hydroelectricity",
                 "nuclear",
                 "solar",
@@ -491,7 +489,6 @@ class Components:
                 "emissions": "Carbon Equivalent (kg)",
                 "iso_code": "Country Code",
                 "fossil": "Fossil Energy(%)",
-                "geothermal": "Geothermal Energy (%)",
                 "hydroelectricity": "Hydroelectricity Energy (%)",
                 "nuclear": "Nuclear Energy (%)",
                 "solar": "Solar Energy (%)",
@@ -505,7 +502,6 @@ class Components:
     def get_global_energy_mix_choropleth_figure(self, energy_type, choropleth_data):
         energy_labels = {
             "fossil": "Fossil Energy(%)",
-            "geothermal": "Geothermal Energy (%)",
             "hydroelectricity": "Hydroelectricity Energy (%)",
             "nuclear": "Nuclear Energy (%)",
             "solar": "Solar Energy (%)",

--- a/codecarbon/viz/data.py
+++ b/codecarbon/viz/data.py
@@ -128,9 +128,6 @@ class Data:
                         "fossil": formatted_energy_percentage(
                             global_energy_mix[country_iso_code]["fossil_Twh"], total
                         ),
-                        "geothermal": formatted_energy_percentage(
-                            global_energy_mix[country_iso_code]["geothermal_Twh"], total
-                        ),
                         "hydroelectricity": formatted_energy_percentage(
                             global_energy_mix[country_iso_code]["hydroelectricity_Twh"],
                             total,

--- a/codecarbon/viz/data.py
+++ b/codecarbon/viz/data.py
@@ -119,30 +119,30 @@ class Data:
                         country_name=country_name, country_iso_code=country_iso_code
                     ),
                 )
-                total = global_energy_mix[country_iso_code]["total_TWh"]
+                total = global_energy_mix[country_iso_code]["total_Twh"]
                 choropleth_data.append(
                     {
                         "iso_code": country_iso_code,
                         "emissions": country_emissions,
                         "country": country_name,
                         "fossil": formatted_energy_percentage(
-                            global_energy_mix[country_iso_code]["fossil_TWh"], total
+                            global_energy_mix[country_iso_code]["fossil_Twh"], total
                         ),
                         "geothermal": formatted_energy_percentage(
-                            global_energy_mix[country_iso_code]["geothermal_TWh"], total
+                            global_energy_mix[country_iso_code]["geothermal_Twh"], total
                         ),
                         "hydroelectricity": formatted_energy_percentage(
-                            global_energy_mix[country_iso_code]["hydroelectricity_TWh"],
+                            global_energy_mix[country_iso_code]["hydroelectricity_Twh"],
                             total,
                         ),
                         "nuclear": formatted_energy_percentage(
-                            global_energy_mix[country_iso_code]["nuclear_TWh"], total
+                            global_energy_mix[country_iso_code]["nuclear_Twh"], total
                         ),
                         "solar": formatted_energy_percentage(
-                            global_energy_mix[country_iso_code]["solar_TWh"], total
+                            global_energy_mix[country_iso_code]["solar_Twh"], total
                         ),
                         "wind": formatted_energy_percentage(
-                            global_energy_mix[country_iso_code]["wind_TWh"], total
+                            global_energy_mix[country_iso_code]["wind_Twh"], total
                         ),
                     }
                 )


### PR DESCRIPTION
The schema of the data added in https://github.com/mlco2/codecarbon/commit/4949003f1599c2b7a5b29c5571ffcc9adcdde7dc is different from before, breaking untyped code.

- `_TWh` suffixes was changed to `_Twh`
- `geothermal_TWh` data is no longer provided

While I fixed what was necessary to get things working, I did not bother fixing https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/private_infra/our_world_in_data-2021_data.ipynb which is now out-of-date and misleading.