### PR TITLE
docs: fix various typos & grammar mistakes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ conda create --name codecarbon python=3.8
 conda activate codecarbon
 ```
 
-Install from sources in development mode :
+Install from sources in development mode:
 
 ```bash
 git clone https://github.com/mlco2/codecarbon
@@ -64,19 +64,19 @@ Make sure that the [`tox` package](https://tox.readthedocs.io/en/latest/example/
 pip install tox
 ```
 
-You can run tests by simply entering tox in the terminal when in the root package directory, and it will run the unit tests.
+You can run the unit tests by simply entering tox in the terminal when in the root package directory.
 
 ```
 tox
 ```
 
-This will not run test that may failed because of your environment (no CO2 Signal API token, no PowerGadget...), if you want to run all package tests :
+This will not run test that may fail because of your environment (no CO2 Signal API token, no PowerGadget...). If you want to run all package tests:
 
 ```
 tox -e all
 ```
 
-You can also test your specific test in an isolated fashion to develop and debug them:
+You can also run your specific test in isolation to develop and debug them:
 
 ```
 $ python -m unittest tests.test_your_feature
@@ -89,20 +89,20 @@ $ python -m unittest tests.test_your_feature.YourTestCase.test_function
 To test the API, see [how to deploy it](#local_deployement) first.
 
 
-Core & external classes are unit tested, with one test file per class. Mosts pull-requests are expected to contains new tests or test update, if you are unusure what to test / how to test it, please put it in the pull-request description and the maintainers will help you.
+Core and external classes are unit tested, with one test file per class. Most pull requests are expected to contain either new tests or test updates. If you are unusure what to test / how to test it, please put it in the pull request description and the maintainers will help you.
 
 ### Stress your computer
 
-To test CodeCarbon it is usefull to stress your computer to make it use his full power :
-- 7Zip is often already on your computer, running it with `7z b` make a quick CPU test.
+To test CodeCarbon, it is useful to stress your computer to make it use its full power:
+- 7Zip is often already installed, running it with `7z b` makes a quick CPU test.
 - [GPU-burn](https://github.com/wilicc/gpu-burn) will load test the GPU for a configurable duration.
 
-`nvidia-smi` is a usefull tool to see the metrics of the GPU and compare it with CodeCarbon.
+`nvidia-smi` is a useful tool to see the metrics of the GPU and compare it with CodeCarbon.
 
-### Versionning
+### Versioning
 
 
-To add a new feature to codecarbon, the following workflow is applied :
+To add a new feature to codecarbon, the apply the following workflow:
 - Master branch is protected
 - To contribute to an already [prioritized](https://github.com/orgs/mlco2/projects/1) feature, you can create a branch from master and open a draft PR
 - Documenting the intent & the limits of a contribution in a dedicated issue or in the pull request helps the review
@@ -182,7 +182,7 @@ Then, click on the url displayed in the terminal.
 
 ### Coding style && Linting
 
-The coding style and linting rules are automatically applied and enforce by [pre-commit](https://pre-commit.com/). This tool helps to maintain the same code style across the code-base to ease the review and collaboration process. Once installed ([https://pre-commit.com/#installation](https://pre-commit.com/#installation)), you can install a Git hook to automatically run pre-commit (and all configured linters/auto-formatters) before doing a commit with `pre-commit install`. Then once you tried to commit, the linters/formatters will run automatically. It should display something similar to:
+The coding style and linting rules are automatically applied and enforce by [pre-commit](https://pre-commit.com/). This tool helps to maintain the same code style across the code-base and to ease the review and collaboration process. Once installed ([https://pre-commit.com/#installation](https://pre-commit.com/#installation)), you can install a Git hook to automatically run pre-commit (and all configured linters/auto-formatters) before doing a commit with `pre-commit install`. Then once you tried to commit, the linters/formatters will run automatically. It should display something similar to:
 
 ```
 [INFO] Initializing environment for https://github.com/psf/black.
@@ -204,7 +204,7 @@ black....................................................................Passed
 flake8...................................................................Passed
 ```
 
-If any of the linters/formatters failed, check the difference with `git diff`, add the differences if there is no behavior changes (isort and black might have change some coding style or import order, this is expected it is their jobs) with `git add` and finally try to commit again `git commit ...`.
+If any of the linters/formatters fail, check the difference with `git diff`, add the differences if there is no behavior changes (isort and black might have change some coding style or import order, this is expected it is their job) with `git add` and finally try to commit again `git commit ...`.
 
 You can also run `pre-commit` with `pre-commit run -v` if you have some changes staged but you are not ready yet to commit.
 
@@ -216,12 +216,12 @@ Dependencies are defined in three different places:
 - In [setup.py](setup.py#L7), those are the dependencies for the Pypi package.
 - In [.conda/meta.yaml](.conda/meta.yaml#L21), those are the dependencies for the Conda pacakge targeting Python 3.7 and higher versions.
 
-We drop support of Python 3.6 since version 2.0.0 of CodeCarbon.
+We have dropped support of Python 3.6 since version 2.0.0 of CodeCarbon.
 
 ### Alternative ways of contributing
 
 
-You have a cool idea, but do not know know if it fits with Code Carbon ? You can create an issue to share :
+You have a cool idea, but do not know know if it fits with Code Carbon? You can create an issue to share:
 - the code, via the Github repo or [Binder](https://mybinder.org/), to share executable notebooks
 - a webapp, using [Voilà](https://github.com/voila-dashboards/voila), [Dash](https://github.com/plotly/dash) or [Streamlit](https://github.com/streamlit/streamlit)
 - ideas for improvement about the tool or its documentation
@@ -272,15 +272,15 @@ Inside the docker container, run:
 
 ### API
 
-To run the API locally, the easiest way is Docker. Launch this command in the project directory:
+The easiest way to run the API locally is with Docker. Launch this command in the project directory:
 ```
 docker-compose up -d
 ```
 Please see [Docker specific documentation](./docker/README.md) for more informations.
-When up, the API documentation is locally available at the following URL : http://localhost:8008/redoc and can be used for testing.
+When up, the API documentation is available locally at the following URL: http://localhost:8008/redoc and can be used for testing.
 
 
-In order to connect make codecarbon automatically connect to the local API, create a file `.codecarbon.config` with the content:
+In order to make codecarbon automatically connect to the local API, create a file `.codecarbon.config` with contents:
 ```
 [codecarbon]
 api_endpoint = http://localhost:8008
@@ -303,11 +303,11 @@ python examples/api_call_debug.py
 
 ##### API
 
-The API is availiable to everyone from https://api.codecarbon.io but if you want to deploy it for yourself, here is the instructions.
+The API is availiable to everyone from https://api.codecarbon.io, but if you want to deploy it for yourself, here are the instructions.
 
-To deploy the API we use [Clever Cloud](https://www.clever-cloud.com/) , an IT Automation platform. They manage all the hard ops work while we focus on the Code Carbon value.
+To deploy the API we use [Clever Cloud](https://www.clever-cloud.com/), an IT Automation platform. They manage all the hard ops work while we focus on the Code Carbon value.
 
-Here is the Clever Cloud configuration if you want to reproduce it :
+Here is the Clever Cloud configuration if you want to reproduce it:
 ```
 APP_FOLDER="carbonserver"
 CC_PIP_REQUIREMENTS_FILE="requirements.txt"
@@ -325,7 +325,7 @@ To deploy,
 git remote add deploy git+ssh://git@push-n2-par-clevercloud-customers.services.clever-cloud.com/app_<secret_do_not_share>.git
 git push deploy master:master
 ```
-Yeah, no so hard, isn't it ?
+Yeah, not so hard, is it?
 
 See (the doc)[https://www.clever-cloud.com/doc/getting-started/quickstart/] for more informations.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ To test CodeCarbon, it is useful to stress your computer to make it use its full
 ### Versioning
 
 
-To add a new feature to codecarbon, the apply the following workflow:
+To add a new feature to codecarbon, apply the following workflow:
 - Master branch is protected
 - To contribute to an already [prioritized](https://github.com/orgs/mlco2/projects/1) feature, you can create a branch from master and open a draft PR
 - Documenting the intent & the limits of a contribution in a dedicated issue or in the pull request helps the review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ Then, click on the url displayed in the terminal.
 
 ### Coding style && Linting
 
-The coding style and linting rules are automatically applied and enforce by [pre-commit](https://pre-commit.com/). This tool helps to maintain the same code style across the code-base and to ease the review and collaboration process. Once installed ([https://pre-commit.com/#installation](https://pre-commit.com/#installation)), you can install a Git hook to automatically run pre-commit (and all configured linters/auto-formatters) before doing a commit with `pre-commit install`. Then once you tried to commit, the linters/formatters will run automatically. It should display something similar to:
+The coding style and linting rules are automatically applied and enforced by [pre-commit](https://pre-commit.com/). This tool helps to maintain the same code style across the code-base such to ease the review and collaboration process. Once installed ([https://pre-commit.com/#installation](https://pre-commit.com/#installation)), you can install a Git hook to automatically run pre-commit (and all configured linters/auto-formatters) before doing a commit with `pre-commit install`. Then once you tried to commit, the linters/formatters will run automatically. It should display something similar to:
 
 ```
 [INFO] Initializing environment for https://github.com/psf/black.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install codecarbon
 ```python
 conda install -c conda-forge codecarbon
 ```
-To see more installation options please refer to the documentation : [**Installation**](https://mlco2.github.io/codecarbon/installation.html#)
+To see more installation options please refer to the documentation: [**Installation**](https://mlco2.github.io/codecarbon/installation.html#)
 
 ## Start to estimate your impact 📏
 

--- a/carbonserver/README.md
+++ b/carbonserver/README.md
@@ -3,14 +3,14 @@
 ## Code Carbon architecture
 ![Code Carbon architecture](Images/code_carbon_archi.png)
 
-Documentation :
+Documentation:
 
 - Routers handling: https://fastapi.tiangolo.com/tutorial/bigger-applications/
 - Security: https://fastapi.tiangolo.com/tutorial/security/
 - SQL: https://fastapi.tiangolo.com/tutorial/sql-databases/
-- Alembic : https://youtu.be/36yw8VC3KU8
-- Deploy a full stack FastAPI / Vue.js app : https://github.com/tiangolo/full-stack-fastapi-postgresql
-- FastAPI + PG on docker : https://testdriven.io/blog/fastapi-docker-traefik
+- Alembic: https://youtu.be/36yw8VC3KU8
+- Deploy a full stack FastAPI / Vue.js app: https://github.com/tiangolo/full-stack-fastapi-postgresql
+- FastAPI + PG on docker: https://testdriven.io/blog/fastapi-docker-traefik
 - FastAPI db dependency injection: https://python-dependency-injector.ets-labs.org/examples/fastapi-sqlalchemy.html
 
 ## Schema of the database
@@ -18,16 +18,16 @@ Documentation :
 
 
 
-Container Dependencies injection : 
+Container Dependencies injection: 
 
 
 
-Database is a core part of the application, used with 2 different usages :
+Database is a core part of the application, used with 2 different usages:
 - Administration, with alembic to create / populate tables.
 - Data persistence, for users data, through the HTTP layer.
 
 The load of data would not be the same for those 2 usages, thus we must define 2 types of database connections for them.
 To handle properly the connexion / session, we could define it as part of the infrastructure & keep in the database 
 folder the high level functions that manipulates tested session building.
-A software based on dependency injector : 
+A software based on dependency injector: 
 - https://github.com/bentoml/BentoML

--- a/carbonserver/tests/TESTING.md
+++ b/carbonserver/tests/TESTING.md
@@ -10,11 +10,11 @@ To test the interface exposed by entities, in memory repositories can be used to
 
 ### Infrastructure
 
-- Testing SqlRepositories :
-    - Spawn a test database :
+- Testing SqlRepositories:
+    - Spawn a test database:
         - Use docker compose to launch a Postgres instance from project root
         ```bash
-        docker compose up -d postgres pgadmin
+        docker-compose up -d postgres pgadmin
         ```
         - Use [alembic](carbonserver/carbonserver/database/alembic/README.md) to inject last version of database schema
         ```bash
@@ -39,15 +39,15 @@ A Postman collection of requests is available: ```carbonserver/tests/postman/Tes
 
 
 ### Integration
-- Database : in the CI, a prod-like database can be used to test features on real data (TODO)
-- Code Carbon package : Launch a train scenario (TODO)
+- Database: in the CI, a prod-like database can be used to test features on real data (TODO)
+- Code Carbon package: Launch a train scenario (TODO)
 
 
-## Running the tests :
+## Running the tests:
 
 ### Install the test setup
 
-In a virtual environment, install and build the api package :
+In a virtual environment, install and build the api package:
 ```bash
 git clone git@github.com:mlco2/codecarbon.git
 git checkout api
@@ -65,7 +65,7 @@ tox -e integration # Integration tests
 ```
 
 
-To test the HTTP layer, you can also deploy a local instance :
+To test the HTTP layer, you can also deploy a local instance:
 
 ```bash
 cd carbonserver/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.8
 WORKDIR /opt
 
 WORKDIR /opt/codecarbon
-# Tips : relative path is from root project folder as we use context in docker-compose
+# Tips: relative path is from root project folder as we use context in docker-compose
 #COPY ./docker/.env.docker .env
 COPY setup.py .
 RUN python3 setup.py install
 COPY . .
-# TODO : install codecarbon package ?
+# TODO: install codecarbon package?

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,13 +1,13 @@
 # Usage of CodeCarbon with Docker
 
-## Pre-requisis
+## Prerequisites
 
 Clone the project
 ```sh
 git clone https://github.com/mlco2/codecarbon/codecarbon.git
 ```
 
-Prepare configuration :
+Prepare configuration:
 ```sh
 cd codecarbon
 cp docker/docker.env .env

--- a/docs/edit/faq.rst
+++ b/docs/edit/faq.rst
@@ -9,7 +9,7 @@ Frequently Asked Questions
 * **What are the sources of your energy carbon intensity data?**
 	We use the following sources:
 
-		For cloud computing :
+		For cloud computing:
 
 		- Google publish carbon intensity of electricity for `Google Cloud Plateform <https://cloud.google.com/sustainability/region-carbon?hl=fr>`_.
 
@@ -18,7 +18,7 @@ Frequently Asked Questions
 		- Microsoft has a Sustainability Calculator that helps enterprises analyze the carbon emissions of their IT infrastructure. But does not publish datacenter carbon intensity.
 
 
-		For private infra :
+		For private infra:
 
 		- When available we use data from `ourworld in data <https://ourworldindata.org/grapher/carbon-intensity-electricity?tab=table>`_
 

--- a/docs/edit/methodology.rst
+++ b/docs/edit/methodology.rst
@@ -26,7 +26,7 @@ energy sources that are used to generate electricity, including fossil fuels and
 
 When available, CodeCarbon uses global carbon intensity of electricity per cloud provider ( `here <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/cloud/impact.csv>`_ ) or per country ( `here <https://github.com/mlco2/codecarbon/blob/master/codecarbon/data/private_infra/eu-carbon-intensity-electricity.csv>`_ ).
 
-If we don't have the global carbon intensity or electricity of a country, but we have its electricity mix, we compute the carbon intensity of electricity using this table :
+If we don't have the global carbon intensity or electricity of a country, but we have its electricity mix, we compute the carbon intensity of electricity using this table:
 
 .. list-table:: Carbon Intensity Across Energy Sources
    :widths: 50 50

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,5 +11,5 @@ pip install -r requirements-examples.txt
 * [mnist_decorator.py](mnist_decorator.py): Using the `@track_co2` decorator.
 * [mnist_callback.py](mnist_callback.py): Using Keras callbacks to save emissions after each epoch.
 * [mnist-comet.py](mnist-comet.py): Using `CO2Tracker` with [`Comet`](https://www.comet.ml/site) for automatic experiment and emissions tracking.
-* [api_call_demo.py](api_call_demo.py) : Simplest demo to send computer emissions to CodeCarbon API.
-* [api_call_debug.py](api_call_debug.py) : Script to send computer emissions to CodeCarbon API. Made for debugging : debug log and send data every 20 seconds.
+* [api_call_demo.py](api_call_demo.py): Simplest demo to send computer emissions to CodeCarbon API.
+* [api_call_debug.py](api_call_debug.py): Script to send computer emissions to CodeCarbon API. Made for debugging: debug log and send data every 20 seconds.

--- a/examples/api_call_debug.py
+++ b/examples/api_call_debug.py
@@ -16,7 +16,7 @@ def train_model():
     This function will do nothing during (occurrence * delay) seconds.
     The Code Carbon API will be called every (measure_power_secs * api_call_interval) seconds.
     """
-    occurrence = 60 * 24 * 365 * 100  # Run for 100 years !
+    occurrence = 60 * 24 * 365 * 100  # Run for 100 years!
     delay = 60  # Seconds
     for i in range(occurrence):
         print(f"{occurrence * delay - i * delay} seconds before ending script...")

--- a/examples/logging_to_file.py
+++ b/examples/logging_to_file.py
@@ -10,7 +10,7 @@ def train_model():
     This function will do nothing during (occurrence * delay) seconds.
     The Code Carbon API will be called every (measure_power_secs * api_call_interval) seconds.
     """
-    occurrence = 60 * 24 * 365 * 100  # Run for 100 years !
+    occurrence = 60 * 24 * 365 * 100  # Run for 100 years!
     delay = 60  # Seconds
     for i in range(occurrence):
         print(f"{occurrence * delay - i * delay} seconds before ending script...")

--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -83,7 +83,7 @@
    ],
    "source": [
     "try:\n",
-    "    # Compute intensive code goes here\n",
+    "    # Compute-intensive code goes here\n",
     "    for i in range(10,1):\n",
     "        print(i)\n",
     "finally:\n",

--- a/examples/prometheus_call.py
+++ b/examples/prometheus_call.py
@@ -15,7 +15,7 @@ def train_model():
     This function will do nothing during (occurrence * delay) seconds.
     The Code Carbon API will be called every (measure_power_secs * api_call_interval) seconds.
     """
-    occurrence = 60 * 24 * 365 * 100  # Run for 100 years !
+    occurrence = 60 * 24 * 365 * 100  # Run for 100 years!
     delay = 60  # Seconds
     for i in range(occurrence):
         print(f"{occurrence * delay - i * delay} seconds before ending script...")
@@ -24,7 +24,7 @@ def train_model():
 
 if __name__ == "__main__":
     logger.setLevel(logging.DEBUG)
-    # create file handler which logs even debug messages
+    # create a file handler which logs even debug messages
     fh = logging.FileHandler("codecarbon.log")
     fh.setLevel(logging.DEBUG)
     formatter = logging.Formatter(

--- a/examples/pytorch-multigpu-example.py
+++ b/examples/pytorch-multigpu-example.py
@@ -28,13 +28,13 @@ class CNN(nn.Module):
             nn.ReLU(),
             nn.MaxPool2d(2),
         )
-        # fully connected layer, output 10 classes
+        # Fully connected layer, output 10 classes
         self.out = nn.Linear(32 * 7 * 7, 10)
 
     def forward(self, x):
         x = self.conv1(x)
         x = self.conv2(x)
-        # flatten the output of conv2 to (batch_size, 32 * 7 * 7)
+        # Flatten the output of conv2 to (batch_size, 32 * 7 * 7)
         x = x.view(x.size(0), -1)
         output = self.out(x)
         return output
@@ -104,7 +104,7 @@ try:
 
     for epoch in range(10):
         cnn.train()
-        # train for 1 epoch
+        # Train for 1 epoch
         for _, (image, label) in enumerate(loaders["train"]):
             print(f"\rBatch {bidx} | Epoch {epoch}", end="")
             bidx += 1


### PR DESCRIPTION
Rectifying a small number of spelling and grammatical issues across the documentation.
Also added consistent comment formatting to [examples/pytorch-multigpu-example.py](https://github.com/mlco2/codecarbon/compare/master...DomAlexRod:codecarbon:master#diff-f7448b41f72dedfe1bb6725327338be0dc3b38261837e09ff6bd79ce44fee7fe). Comments now start with a captial letter as per PEP 8 standard.
