### PR TITLE
Changed the output type of stop_task to EmissionsData

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -458,11 +458,11 @@ class BaseEmissionsTracker(ABC):
         )
         self._active_task = task_name
 
-    def stop_task(self, task_name: str = None) -> float:
+    def stop_task(self, task_name: str = None) -> EmissionsData:
         """
         Stop tracking a dedicated execution task. Delta energy is computed by task, to isolate its contribution to total
         emissions.
-        :return: None
+        :return: EmissionsData
         """
         task_name = task_name if task_name else self._active_task
         self._measure_power_and_energy()


### PR DESCRIPTION
As mentioned in Issue #446, the output type of the stop_task function should be EmissionsData.