### PR TITLE
Removed depricated Jumbotron element

### DIFF
--- a/codecarbon/viz/components.py
+++ b/codecarbon/viz/components.py
@@ -29,15 +29,20 @@ class Components:
 
     @staticmethod
     def get_header():
-        return dbc.Jumbotron(
-            [
-                html.H1("Carbon Footprint", style={"textAlign": "center"}),
-                html.P(
-                    "Measure Compute Emissions",
-                    style={"textAlign": "center", "paddingLeft": "0.5%"},
-                    className="lead",
-                ),
-            ]
+        return html.Div(
+            dbc.Container(
+                [
+                    html.H1("Carbon Footprint", style={"textAlign": "center"}),
+                    html.P(
+                        "Measure Compute Emissions",
+                        style={"textAlign": "center", "paddingLeft": "0.5%"},
+                        className="lead",
+                    ),
+                ],
+                fluid=True,
+                className="py-3",
+            ),
+            className="p-3 mb-5 bg-light rounded-5",
         )
 
     @staticmethod


### PR DESCRIPTION
I tried starting up the Dash dashboard, but ran into an issues regarding the [depricated Jumbotron element](https://dash-bootstrap-components.opensource.faculty.ai/docs/components/jumbotron/).

I switched it out for a separate Container and Div with appropriate padding so the code now runs again.