### PR TITLE
feat(output): composite output handling

### DIFF
--- a/tests/test_custom_handler.py
+++ b/tests/test_custom_handler.py
@@ -28,7 +28,6 @@ class CustomOutput(BaseOutput):
 class TestCarbonCustomHandler(unittest.TestCase):
     def setUp(self) -> None:
         self.project_name = "project_TestCarbonCustomHandler"
-        self.emissions_logfile = "emissions-test-TestCarbonCustomHandler.log"
 
     def test_carbon_tracker_custom_handler(self):
         handler_0 = CustomOutput()
@@ -45,8 +44,8 @@ class TestCarbonCustomHandler(unittest.TestCase):
         assert isinstance(emissions, float)
         self.assertNotEqual(emissions, 0.0)
         self.assertAlmostEqual(emissions, 6.262572537957655e-05, places=2)
-        self.verify_logging_output(handler_0)
-        self.verify_logging_output(handler_1)
+        self.verify_custom_handler_state(handler_0)
+        self.verify_custom_handler_state(handler_1)
 
     def test_decorator_flush(self):
         handler_0 = CustomOutput()
@@ -60,14 +59,13 @@ class TestCarbonCustomHandler(unittest.TestCase):
         )
         def dummy_train_model():
             heavy_computation(run_time_secs=1)
-            # I don't know how to call flush() in decorator mode
             return 42
 
         dummy_train_model()
-        self.verify_logging_output(handler_0)
-        self.verify_logging_output(handler_1)
+        self.verify_custom_handler_state(handler_0)
+        self.verify_custom_handler_state(handler_1)
 
-    def verify_logging_output(self, handler: CustomOutput, expected_lines=1) -> None:
+    def verify_custom_handler_state(self, handler: CustomOutput, expected_lines=1) -> None:
         assert len(handler.log) == expected_lines
         results = handler.log[0]
         self.assertEqual(results.project_name, self.project_name)

--- a/tests/test_custom_handler.py
+++ b/tests/test_custom_handler.py
@@ -1,0 +1,75 @@
+import time
+import unittest
+from typing import List
+
+from codecarbon.emissions_tracker import (
+    EmissionsTracker,
+    track_emissions,
+)
+from codecarbon.output import (
+    BaseOutput, EmissionsData,
+)
+
+
+def heavy_computation(run_time_secs: int = 3):
+    end_time: float = time.time() + run_time_secs  # Run for `run_time_secs` seconds
+    while time.time() < end_time:
+        pass
+
+
+class CustomOutput(BaseOutput):
+    def __init__(self):
+        self.log: List[EmissionsData] = list()
+
+    def out(self, data: EmissionsData):
+        self.log.append(data)
+
+
+class TestCarbonCustomHandler(unittest.TestCase):
+    def setUp(self) -> None:
+        self.project_name = "project_TestCarbonCustomHandler"
+        self.emissions_logfile = "emissions-test-TestCarbonCustomHandler.log"
+
+    def test_carbon_tracker_custom_handler(self):
+        handler_0 = CustomOutput()
+        handler_1 = CustomOutput()
+        tracker = EmissionsTracker(
+            project_name=self.project_name,
+            output_handlers=[handler_0, handler_1],
+            api_call_interval=1,
+        )
+        tracker.start()
+        heavy_computation(run_time_secs=1)
+        emissions = tracker.stop()
+
+        assert isinstance(emissions, float)
+        self.assertNotEqual(emissions, 0.0)
+        self.assertAlmostEqual(emissions, 6.262572537957655e-05, places=2)
+        self.verify_logging_output(handler_0)
+        self.verify_logging_output(handler_1)
+
+    def test_decorator_flush(self):
+        handler_0 = CustomOutput()
+        handler_1 = CustomOutput()
+
+        @track_emissions(
+            project_name=self.project_name,
+            save_to_logger=True,
+            output_handlers=[handler_0, handler_1],
+            api_call_interval=1,
+        )
+        def dummy_train_model():
+            heavy_computation(run_time_secs=1)
+            # I don't know how to call flush() in decorator mode
+            return 42
+
+        dummy_train_model()
+        self.verify_logging_output(handler_0)
+        self.verify_logging_output(handler_1)
+
+    def verify_logging_output(self, handler: CustomOutput, expected_lines=1) -> None:
+        assert len(handler.log) == expected_lines
+        results = handler.log[0]
+        self.assertEqual(results.project_name, self.project_name)
+        self.assertNotEqual(results.emissions, 0.0)
+        self.assertAlmostEqual(results.emissions, 6.262572537957655e-05, places=2)


### PR DESCRIPTION
Hi there,

This one needs some context as to what is being attempted, because from what I could tell our use-case didn't quite fit anywhere in the code base as it currently stand.

We are considering using codecarbon for systematic carbon measurements in a model serving context. The gist of it is we have fleets of BentoML-based applications and we would like to make it so all of them measure their carbon emissions and expose them in quasi-real-time through their `/metrics` prometheus endpoint (which exists by default for all BentoML apps).

From what I could gather from the codebase, there already is a "Prometheus integration" in codecarbon but it works with a push gateway, which we absolutely do *not* want to introduce as it would turn the carbon emission tracking from an opt-out, to an opt-in with additional deployment requirements. Basically, we want the carbon footprint to be tied to existing performance metrics that *will* be collected for typical monitoring needs.

So, working on how to integrate codecarbon measurements with BentoML metrics reporting, I found that while there is a `BaseOutput` contract that can be extended, the tracker implementations do not allow much in the way of composition.

What I did here is naively introduce an arbitrary list of `BaseOutput` implementations expected to be triggered at the same time the API calls are triggered. This way, we can plug a custom output implementation that performs whatever is needed with BentoML's implementations of metric counters, gauge, etc. But, from what *I* can tell this isn't quite in the spirit of the current codebase.

So, what do you think?

From my point of view the more abstract composition model is preferable in every scenario, but I understand it would break compatibility with earlier versions to simply drop the current settings for API and Prometheus. Adding generic composition on top of the current settings looks odd, but at least it's transparent.