### PR TITLE
Do not count *.ipynb example files in the git stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.ipynb linguist-vendored
+*.json linguist-vendored
+*.csv linguist-vendored


### PR DESCRIPTION
# The issue
This is a **purely cosmetic** change.

Jupyter notebook appears as the primary language of CodeCarbon
![image](https://github.com/mlco2/codecarbon/assets/49730431/d9720fb4-d744-4006-83fb-4006db8f2c51)

This is misleading, since someone new arriving to the project, might think that this is mainly jupyter scripts.

# The solution
I added this `.gitattributes` file to not count the *.ipynb files in the git stats.
> Source: https://proandroiddev.com/removing-noise-from-your-github-language-stats-e96113f8183d