### PR TITLE
Fixed name redefining of backup function

### DIFF
--- a/codecarbon/core/util.py
+++ b/codecarbon/core/util.py
@@ -61,14 +61,14 @@ def backup(file_path: Union[str, Path], ext: Optional[str] = ".bak") -> None:
     idx = 0
     parent = file_path.parent
     file_name = f"{file_path.name}{ext}"
-    backup = parent / file_name
+    backup_path = parent / file_name
 
-    while backup.exists():
+    while backup_path.exists():
         file_name = f"{file_path.name}_{idx}{ext}"
-        backup = parent / file_name
+        backup_path = parent / file_name
         idx += 1
 
-    file_path.rename(backup)
+    file_path.rename(backup_path)
 
 
 def detect_cpu_model() -> str:


### PR DESCRIPTION
Variable in the inner scope of the `backup` function was also called `backup` and did redefine the name within the scope.

I changed the variable name to `backup_path` as it is the result of `parent / file_name`.

This change is proposed to omit the linter error:
`Redefining name 'backup' from outer scope (line 48)Pylint[W0621:redefined-outer-name](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/redefined-outer-name.html)`
