### PR TITLE
Draft: Fixed wrong return type hint and updated doc string

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -471,11 +471,11 @@ class BaseEmissionsTracker(ABC):
         )
         self._active_task = task_name
 
-    def stop_task(self, task_name: str = None) -> float:
+    def stop_task(self, task_name: str = None) -> EmissionsData:
         """
         Stop tracking a dedicated execution task. Delta energy is computed by task, to isolate its contribution to total
         emissions.
-        :return: None
+        :return: EmissionData for an execution task
         """
         task_name = task_name if task_name else self._active_task
         self._measure_power_and_energy()
@@ -492,6 +492,7 @@ class BaseEmissionsTracker(ABC):
         self._tasks[task_name].emissions_data = task_emission_data
         self._tasks[task_name].is_active = False
         self._active_task = None
+
         return task_emission_data
 
     @suppress(Exception)


### PR DESCRIPTION
Hi, I made some changes to the `stop_task(...)` function of the `BaseEmissionTracker` class.

I changed the return type from `float` to the actual return type `EmissionsData`. 
This was probably an oversight, as in almost every other function the return type is a `float`.

I also changed the return type in the doc-string from `None` to the actual one.