### PR TITLE
Added return type hints and removed redunant return statements in cpu.py

### DIFF
--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -204,8 +204,7 @@ class IntelRAPL:
         """
 
         # consider files like `intel-rapl:$i`
-        files = list(filter(lambda x: ":" in x,
-                     os.listdir(self._lin_rapl_dir)))
+        files = list(filter(lambda x: ":" in x, os.listdir(self._lin_rapl_dir)))
 
         i = 0
         for file in files:
@@ -227,11 +226,9 @@ class IntelRAPL:
                     with open(rapl_file, "r") as f:
                         _ = float(f.read())
                     self._rapl_files.append(
-                        RAPLFile(name=name, path=rapl_file,
-                                 max_path=rapl_file_max)
+                        RAPLFile(name=name, path=rapl_file, max_path=rapl_file_max)
                     )
-                    logger.debug(
-                        f"We will read Intel RAPL files at {rapl_file}")
+                    logger.debug(f"We will read Intel RAPL files at {rapl_file}")
                 except PermissionError as e:
                     raise PermissionError(
                         "Unable to read Intel RAPL files for CPU power, we will use a constant for your CPU power."


### PR DESCRIPTION
Hi!

I modified a few things in the `cpu.py` file.
First, I either added or changed the return type hints of function signatures depending on the actual return type possible, `Optional[some type]`, if the return type might be `None` in some cases.

Next, a few dangling `return` keywords were at the end of a function definition. As they do not serve any purpose, I removed them.