### PR TITLE
feat: accept list of ints in gpu_ids param

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,6 +38,8 @@ class TestConfig(unittest.TestCase):
             ("1", [1]),
             ("0", [0]),
             ("", []),
+            ([], []),
+            ([1, 2, 3], [1, 2, 3]),
             (1, 1),
         ]:
             self.assertEqual(parse_gpu_ids(ids), target)


### PR DESCRIPTION
Allow users to specify a list of ints for the gpu_ids parameter
Closes #518 

# Before this PR
```
tracker = EmissionsTracker(gpu_ids="1,3,5")
```
# After this PR
```
tracker = EmissionsTracker(gpu_ids="1,3,5")
```
or
```
tracker = EmissionsTracker(gpu_ids=[1,3,5])
```