### PR TITLE
Fix CPU database compare

### DIFF
--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -337,6 +337,10 @@ class TDP:
         if direct_match:
             return direct_match[0]
 
+        model_raw = model_raw.replace("(R)", "")
+        start_cpu = model_raw.find(" CPU @ ")
+        if start_cpu > 0:
+            model_raw = model_raw[0:start_cpu]
         indirect_matches = process.extract(
             model_raw,
             cpu_df["Name"],

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -188,6 +188,12 @@ class TestTDP(unittest.TestCase):
             "Intel Core i7-8850H",
         )
 
+        model = "Intel(R) Xeon(R) Gold 6330N CPU @ 2.20Ghz"
+        self.assertEqual(
+            tdp._get_matching_cpu(model, cpu_data, greedy=False),
+            "Intel Xeon Gold 6330N",
+        )
+
         # Does not match when missing part replaced by (here wrong) other part.
         # Which here is good. Could happen if Intel creates a model with the
         # same name than AMD ("5800K"), but only AMD exists in our cpu list.


### PR DESCRIPTION
In some case the fuzzy matching did not work on Intel CPU, this PR is fixing that, at least for _"Intel(R) Xeon(R) Gold 6330N CPU @ 2.20Ghz"_ that was not matching _"Intel Xeon Gold 6330N"_.

Will close #547 