### PR TITLE
fix: warning invalid gpus format

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -271,18 +271,19 @@ class BaseEmissionsTracker(ABC):
         self._tasks: Dict[str, Task] = {}
         self._active_task: Optional[str] = None
 
-        # If _gpu_ids is a string or a list of int, parse it to a list of ints
-        if isinstance(self._gpu_ids, str) or (
-            isinstance(self._gpu_ids, list)
-            and all(isinstance(gpu_id, int) for gpu_id in self._gpu_ids)
-        ):
-            self._gpu_ids: List[int] = parse_gpu_ids(self._gpu_ids)
-            self._conf["gpu_ids"] = self._gpu_ids
-            self._conf["gpu_count"] = len(self._gpu_ids)
-        else:
-            logger.warning(
-                "Invalid gpu_ids format. Expected a string or a list of ints."
-            )
+        if self._gpu_ids:
+            # If _gpu_ids is a string or a list of int, parse it to a list of ints
+            if isinstance(self._gpu_ids, str) or (
+                isinstance(self._gpu_ids, list)
+                and all(isinstance(gpu_id, int) for gpu_id in self._gpu_ids)
+            ):
+                self._gpu_ids: List[int] = parse_gpu_ids(self._gpu_ids)
+                self._conf["gpu_ids"] = self._gpu_ids
+                self._conf["gpu_count"] = len(self._gpu_ids)
+            else:
+                logger.warning(
+                    "Invalid gpu_ids format. Expected a string or a list of ints."
+                )
 
         logger.info("[setup] RAM Tracking...")
         ram = RAM(tracking_mode=self._tracking_mode)


### PR DESCRIPTION
Closes #557 
Goal is to log the warning only if gpu_ids is defined.
# Logs before this PR
```
[codecarbon INFO @ 21:24:39] offline tracker init
[codecarbon WARNING @ 21:24:39] Invalid gpu_ids format. Expected a string or a list of ints.
[codecarbon INFO @ 21:24:39] [setup] RAM Tracking...
[codecarbon INFO @ 21:24:39] [setup] GPU Tracking...
[codecarbon INFO @ 21:24:39] Tracking Nvidia GPU via pynvml
...
```
# Logs after this PR
```
[codecarbon INFO @ 21:19:24] offline tracker init
[codecarbon INFO @ 21:19:24] [setup] RAM Tracking...
[codecarbon INFO @ 21:19:24] [setup] GPU Tracking...
...
```