### PR TITLE
logging: log the path of the file where emissions are saved

### DIFF
--- a/codecarbon/output_methods/file.py
+++ b/codecarbon/output_methods/file.py
@@ -23,6 +23,9 @@ class FileOutput(BaseOutput):
             )
         self.on_csv_write: str = on_csv_write
         self.save_file_path: str = save_file_path
+        logger.info(
+            f"Saving emissions data to file {os.path.abspath(self.save_file_path)}"
+        )
 
     def has_valid_headers(self, data: EmissionsData):
         with open(self.save_file_path) as csv_file:


### PR DESCRIPTION
This is useful to know where the `codecarbon` instance is storing the emissions data.

Example of log:
```
[codecarbon INFO @ 17:13:34] Saving emissions data to file /home/inigo/codecarbon/emissions.csv
```