### PR TITLE
feat: ensure only one instance of codecarbon is run per machine

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -33,6 +33,7 @@ from codecarbon.external.logger import logger, set_logger_format, set_logger_lev
 from codecarbon.external.scheduler import PeriodicScheduler
 from codecarbon.external.task import Task
 from codecarbon.input import DataSource
+from codecarbon.lock import acquire_lock
 from codecarbon.output import (
     BaseOutput,
     CodeCarbonAPIOutput,
@@ -232,6 +233,9 @@ class BaseEmissionsTracker(ABC):
 
         # logger.info("base tracker init")
         self._external_conf = get_hierarchical_config()
+        # Acquire lock file to prevent multiple instances of codecarbon running
+        # at the same time
+        acquire_lock()
 
         self._set_from_conf(api_call_interval, "api_call_interval", 8, int)
         self._set_from_conf(api_endpoint, "api_endpoint", "https://api.codecarbon.io")

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -236,7 +236,7 @@ class BaseEmissionsTracker(ABC):
         # logger.info("base tracker init")
         self._external_conf = get_hierarchical_config()
         self._set_from_conf(prevent_multiple_runs, "prevent_multiple_runs", False, bool)
-        if prevent_multiple_runs:
+        if self._prevent_multiple_runs:
             # Acquire lock file to prevent multiple instances of codecarbon running
             # at the same time
             acquire_lock()

--- a/codecarbon/lock.py
+++ b/codecarbon/lock.py
@@ -21,7 +21,7 @@ def acquire_lock():
     try:
         _create_lock_file()
     except FileExistsError as e:
-        logger.error(e)
+        logger.debug("Error:", e)
         logger.error(
             "Error: Another instance of codecarbon is already running. Turn off the other instance to be able to run this one. Exiting."
         )

--- a/codecarbon/lock.py
+++ b/codecarbon/lock.py
@@ -1,0 +1,58 @@
+"""
+Ensures that only one instance of codecarbon is running at a time.
+It creates a lock file in /tmp/.codecarbon.lock and removes it on exit.
+If the lock file already exists, it exits the program.
+"""
+
+import atexit
+import errno
+import os
+import sys
+
+from codecarbon.external.logger import logger
+
+LOCKFILE = "/tmp/.codecarbon.lock"
+
+lock_file_created_by_this_process = False
+
+
+def acquire_lock():
+    """Acquires a lock to ensure only one instance of codecarbon is running."""
+    try:
+        _create_lock_file()
+    except FileExistsError as e:
+        logger.error(e)
+        logger.error(
+            "Error: Another instance of codecarbon is already running. Turn off the other instance to be able to run this one. Exiting."
+        )
+        sys.exit(1)
+
+
+def _create_lock_file():
+    """Creates a lock file and ensures it's the only instance running."""
+    global lock_file_created_by_this_process
+    # Attempt to create the lock file
+    try:
+        with open(LOCKFILE, "x") as _:
+            lock_file_created_by_this_process = True
+    except FileExistsError:
+        logger.debug(
+            f"Lock file already exists. Path: {LOCKFILE}. This usually means another instance of codecarbon is running."
+        )
+        raise
+
+
+def _remove_lock_file():
+    """Removes the lock file on exit."""
+    global lock_file_created_by_this_process
+    # Only remove the lock file if this process created it
+    if lock_file_created_by_this_process:
+        try:
+            os.remove(LOCKFILE)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+
+# Register the cleanup function to be called on program exit
+atexit.register(_remove_lock_file)

--- a/codecarbon/lock.py
+++ b/codecarbon/lock.py
@@ -8,10 +8,12 @@ import atexit
 import errno
 import os
 import sys
+import tempfile
 
 from codecarbon.external.logger import logger
 
-LOCKFILE = "/tmp/.codecarbon.lock"
+# We use tempfile.gettempdir() to get the system's temporary directory (linux: /tmp, windows: C:\Users\username\AppData\Local\Temp)
+LOCKFILE = os.path.join(tempfile.gettempdir(), ".codecarbon.lock")
 
 lock_file_created_by_this_process = False
 

--- a/examples/logging_to_file_exclusive_run.py
+++ b/examples/logging_to_file_exclusive_run.py
@@ -1,5 +1,5 @@
 """
-Similar to logging_to_file.py, but with the `prevent_multiple_runs` parameter set to True.
+Similar to logging_to_file.py, but with the `allow_multiple_runs` parameter set to False (which is the default).
 This will prevent multiple instances of codecarbon from running at the same time.
 We run 5 instances of codecarbon. 4 wil fail and only one will succeed
 
@@ -28,7 +28,7 @@ def worker():
         country_iso_code="FRA",
         measure_power_secs=30,
         project_name="ultra_secret",
-        prevent_multiple_runs=True,
+        # allow_multiple_runs=True,    # Set this to True to allow multiple instances of codecarbon to run at the same time
     )
 
     tracker.start()

--- a/examples/logging_to_file_exclusive_run.py
+++ b/examples/logging_to_file_exclusive_run.py
@@ -1,0 +1,44 @@
+"""
+Similar to logging_to_file.py, but with the `prevent_multiple_runs` parameter set to True.
+This will prevent multiple instances of codecarbon from running at the same time.
+We run 5 instances of codecarbon. 4 wil fail and only one will succeed
+
+"""
+
+import multiprocessing
+import time
+
+from codecarbon import OfflineEmissionsTracker
+
+
+def train_model():
+    """
+    This function will do nothing during (occurrence * delay) seconds.
+    The Code Carbon API will be called every (measure_power_secs * api_call_interval) seconds.
+    """
+    occurrence = 60 * 24 * 365 * 100  # Run for 100 years!
+    delay = 60  # Seconds
+    for i in range(occurrence):
+        print(f"{occurrence * delay - i * delay} seconds before ending script...")
+        time.sleep(delay)
+
+
+def worker():
+    tracker = OfflineEmissionsTracker(
+        country_iso_code="FRA",
+        measure_power_secs=30,
+        project_name="ultra_secret",
+        prevent_multiple_runs=True,
+    )
+
+    tracker.start()
+    try:
+        train_model()
+    finally:
+        tracker.stop()
+
+
+if __name__ == "__main__":
+    for _ in range(5):
+        p = multiprocessing.Process(target=worker)
+        p.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,8 @@ dependencies = [
 ]
 
 [tool.hatch.envs.test.scripts]
-package = 'pytest -vv -m "not integ_test" tests/'
-package-integ = 'python -m pytest -vv tests/'
+package = 'CODECARBON_ALLOW_MULTIPLE_RUNS=True pytest -vv -m "not integ_test" tests/'
+package-integ = 'CODECARBON_ALLOW_MULTIPLE_RUNS=True python -m pytest -vv tests/'
 
 [[tool.hatch.envs.test.matrix]]
 # Python 3.7 does not works with pip-tools, but CodeCarbon could run in 3.7

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,7 +55,13 @@ class TestConfig(unittest.TestCase):
     def test_parse_env_config(self):
         self.assertDictEqual(
             parse_env_config(),
-            {"codecarbon": {"test": "test-VALUE", "test_key": "this_other_value"}},
+            {
+                "codecarbon": {
+                    "allow_multiple_runs": "True",
+                    "test": "test-VALUE",
+                    "test_key": "this_other_value",
+                }
+            },
         )
 
     def test_read_confs(self):
@@ -80,6 +86,7 @@ class TestConfig(unittest.TestCase):
         ):
             conf = dict(get_hierarchical_config())
             target = {
+                "allow_multiple_runs": "True",
                 "no_overwrite": "path/to/somewhere",
                 "local_overwrite": "SUCCESS:overwritten",
                 "syntax_test_key": "no/space= problem2",
@@ -119,6 +126,7 @@ class TestConfig(unittest.TestCase):
         ):
             conf = dict(get_hierarchical_config())
             target = {
+                "allow_multiple_runs": "True",
                 "no_overwrite": "path/to/somewhere",
                 "local_overwrite": "SUCCESS:overwritten",
                 "env_overwrite": "SUCCESS:overwritten",
@@ -136,7 +144,9 @@ class TestConfig(unittest.TestCase):
             "builtins.open", new_callable=get_custom_mock_open(global_conf, local_conf)
         ):
             conf = dict(get_hierarchical_config())
-            target = {}
+            target = {
+                "allow_multiple_runs": "True"
+            }  # allow_multiple_runs is a default value
             self.assertDictEqual(conf, target)
 
     @mock.patch.dict(

--- a/tests/test_lock,py
+++ b/tests/test_lock,py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch, mock_open
+import codecarbon.lock as lock
+
+class TestLock(unittest.TestCase):
+    @patch('lock.os.remove')
+    @patch('lock.open', new_callable=mock_open)
+    def test_acquire_lock_creates_lock_file(self, mock_file, mock_remove):
+        lock.lock_file_created_by_this_process = False
+        lock.acquire_lock()
+        mock_file.assert_called_once_with(lock.LOCKFILE, 'x')
+        self.assertTrue(lock.lock_file_created_by_this_process)
+
+    @patch('lock.os.remove')
+    @patch('lock.open', new_callable=mock_open, side_effect=FileExistsError)
+    def test_acquire_lock_exits_when_lock_file_exists(self, mock_file, mock_remove):
+        with self.assertRaises(SystemExit):
+            lock.acquire_lock()
+
+    @patch('lock.os.remove')
+    @patch('lock.open', new_callable=mock_open)
+    def test_remove_lock_file_removes_lock_file(self, mock_file, mock_remove):
+        lock.lock_file_created_by_this_process = True
+        lock._remove_lock_file()
+        mock_remove.assert_called_once_with(lock.LOCKFILE)
+
+    @patch('lock.os.remove')
+    @patch('lock.open', new_callable=mock_open)
+    def test_remove_lock_file_does_not_remove_lock_file_when_not_created_by_this_process(self, mock_file, mock_remove):
+        lock.lock_file_created_by_this_process = False
+        lock._remove_lock_file()
+        mock_remove.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,35 +1,41 @@
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
+
 import codecarbon.lock as lock
 
+
 class TestLock(unittest.TestCase):
-    @patch('lock.os.remove')
-    @patch('lock.open', new_callable=mock_open)
+    @patch("codecarbon.lock.os.remove")
+    @patch("codecarbon.lock.open", new_callable=mock_open)
     def test_acquire_lock_creates_lock_file(self, mock_file, mock_remove):
         lock.lock_file_created_by_this_process = False
         lock.acquire_lock()
-        mock_file.assert_called_once_with(lock.LOCKFILE, 'x')
+        mock_file.assert_called_once_with(lock.LOCKFILE, "x")
         self.assertTrue(lock.lock_file_created_by_this_process)
 
-    @patch('lock.os.remove')
-    @patch('lock.open', new_callable=mock_open, side_effect=FileExistsError)
+    @patch("codecarbon.lock.os.remove")
+    @patch("codecarbon.lock.open", new_callable=mock_open)
     def test_acquire_lock_exits_when_lock_file_exists(self, mock_file, mock_remove):
+        mock_file.side_effect = FileExistsError
         with self.assertRaises(SystemExit):
             lock.acquire_lock()
 
-    @patch('lock.os.remove')
-    @patch('lock.open', new_callable=mock_open)
+    @patch("codecarbon.lock.os.remove")
+    @patch("codecarbon.lock.open", new_callable=mock_open)
     def test_remove_lock_file_removes_lock_file(self, mock_file, mock_remove):
         lock.lock_file_created_by_this_process = True
         lock._remove_lock_file()
         mock_remove.assert_called_once_with(lock.LOCKFILE)
 
-    @patch('lock.os.remove')
-    @patch('lock.open', new_callable=mock_open)
-    def test_remove_lock_file_does_not_remove_lock_file_when_not_created_by_this_process(self, mock_file, mock_remove):
+    @patch("codecarbon.lock.os.remove")
+    @patch("codecarbon.lock.open", new_callable=mock_open)
+    def test_remove_lock_file_does_not_remove_lock_file_when_not_created_by_this_process(
+        self, mock_file, mock_remove
+    ):
         lock.lock_file_created_by_this_process = False
         lock._remove_lock_file()
         mock_remove.assert_not_called()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Imagine I open 2 clis and run `codecarbon monitor` in each of them. This will result on both of them outputing very similar data to the same output. Now imagine I have multiple instances of codecarbon (e.g. a python script, some cli, some script somewhere that I forgot it is running...). This could become complex rapidly.

# Goal of this PR
By default it will allow only one instance per machine to measure at the same time. 
This is regulated via the parameter `allow_multiple_runs`.

-  If true --> multiple runs of codecarbon can be done in the same machine.
- If false --> only one at the same time.

Default is `false`.

# How to test this

## Option 1:  using 2 consoles
Open 2 consoles and run `hatch run python examples/logging_to_file.py` on both of them.

- Output of Console 1: Normal behavior
- Output of Console 2: 
```
[codecarbon ERROR @ 18:17:11] Error: Another instance of codecarbon is already running. Turn off the other instance to be able to run this one. Exiting.
```

## Option 2:  multiprocess
I have added an example of exclusive run using multiprocess.
Run it via `hatch run python examples/logging_to_file_exclusive_run.py`
Example of output:
```bash
~/codecarbon$ hatch run python examples/logging_to_file_exclusive_run.py 
[codecarbon INFO @ 09:43:43] offline tracker init
[codecarbon INFO @ 09:43:43] offline tracker init
[codecarbon INFO @ 09:43:43] offline tracker init
[codecarbon INFO @ 09:43:43] offline tracker init
[codecarbon ERROR @ 09:43:43] Error: Another instance of codecarbon is already running. Turn off the other instance to be able to run this one. Exiting.
[codecarbon ERROR @ 09:43:43] Error: Another instance of codecarbon is already running. Turn off the other instance to be able to run this one. Exiting.
[codecarbon ERROR @ 09:43:43] Error: Another instance of codecarbon is already running. Turn off the other instance to be able to run this one. Exiting.
[codecarbon INFO @ 09:43:43] offline tracker init
[codecarbon ERROR @ 09:43:43] Error: Another instance of codecarbon is already running. Turn off the other instance to be able to run this one. Exiting.
[codecarbon INFO @ 09:43:43] [setup] RAM Tracking...
[codecarbon INFO @ 09:43:43] [setup] GPU Tracking...
...
```
We see that 5 instances of `codecarbon` are started and 4 end up in error and exit.