### PR TITLE
Fix powermetrics test asking for password on Linux

### DIFF
--- a/codecarbon/core/powermetrics.py
+++ b/codecarbon/core/powermetrics.py
@@ -25,6 +25,14 @@ def is_powermetrics_available():
 
 
 def _has_powermetrics_sudo():
+    if shutil.which("sudo") is None:
+        logger.debug("sudo not available, we won't use Apple PowerMetrics.")
+        return False
+    if shutil.which("powermetrics") is None:
+        logger.info(
+            "Apple PowerMetrics not available. Please install it if you are using an Apple product."
+        )
+        return False
     process = subprocess.Popen(
         [
             "sudo",


### PR DESCRIPTION
Add tests to avoid asking for a password for Powermetrics when it doesn't exist.