### PR TITLE
chore(carbonserver) rework api endpoints and models

### DIFF
--- a/carbonserver/carbonserver/api/infra/database/sql_models.py
+++ b/carbonserver/carbonserver/api/infra/database/sql_models.py
@@ -111,14 +111,17 @@ class Project(Base):
     name = Column(String)
     description = Column(String)
     team_id = Column(UUID(as_uuid=True), ForeignKey("teams.id"))
+    organization_id = Column(UUID(as_uuid=True), ForeignKey("organizations.id"))
     experiments = relationship("Experiment", back_populates="project")
     team = relationship("Team", back_populates="projects")
+    organization = relationship("Organization", back_populates="projects")
 
     def __repr__(self):
         return (
             f'<Project(id="{self.id}", '
             f'name="{self.name}", '
             f'description="{self.description}", '
+            f'organization_id="{self.organization_id}", '
             f'team_id="{self.team_id}")>'
         )
 
@@ -149,6 +152,7 @@ class Organization(Base):
     description = Column(String)
     api_key = Column(String)
     teams = relationship("Team", back_populates="organization")
+    projects = relationship("Project", back_populates="organization")
 
     def __repr__(self):
         return (

--- a/carbonserver/carbonserver/api/infra/repositories/repository_projects.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_projects.py
@@ -22,6 +22,7 @@ class SqlAlchemyRepository(Projects):
             db_project = SqlModelProject(
                 name=project.name,
                 description=project.description,
+                organization_id=project.organization_id,
                 team_id=project.team_id,
             )
 
@@ -58,6 +59,21 @@ class SqlAlchemyRepository(Projects):
                 return []
             return [self.map_sql_to_schema(e) for e in res]
 
+    def get_projects_from_organization(self, organization_id) -> List[Project]:
+        """Find the list of projects from a organization in database and return it
+
+        :org_id: The id of the organization to retreive projects from.
+        :returns: List of Projects in pyDantic BaseModel format.
+        :rtype: List[schemas.Project]
+        """
+        with self.session_factory() as session:
+            res = session.query(SqlModelProject).filter(
+                SqlModelProject.organization_id == organization_id
+            )
+            if res.first() is None:
+                return []
+            return [self.map_sql_to_schema(e) for e in res]
+
     def get_project_detailed_sums(
         self, project_id, start_date, end_date
     ) -> ProjectReport:
@@ -76,6 +92,7 @@ class SqlAlchemyRepository(Projects):
                     SqlModelProject.id.label("project_id"),
                     SqlModelProject.name,
                     SqlModelProject.description,
+                    SqlModelProject.organization_id,
                     SqlModelProject.team_id,
                     func.sum(SqlModelEmission.emissions_sum).label("emissions"),
                     func.avg(SqlModelEmission.cpu_power).label("cpu_power"),
@@ -133,4 +150,5 @@ class SqlAlchemyRepository(Projects):
             name=project.name,
             description=project.description,
             team_id=str(project.team_id),
+            organization_id=str(project.organization_id),
         )

--- a/carbonserver/carbonserver/api/routers/projects.py
+++ b/carbonserver/carbonserver/api/routers/projects.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import List, Optional
 
 import dateutil.relativedelta
 from container import ServerContainer
@@ -80,3 +80,29 @@ def read_project_detailed_sums(
     return project_global_sum_usecase.compute_detailed_sum(
         project_id, start_date, end_date
     )
+
+
+@router.get(
+    "/organizations/{organization_id}/projects",
+    tags=PROJECTS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+)
+@inject
+def list_projects_nested(
+    organization_id: str,
+    project_service: ProjectService = Depends(Provide[ServerContainer.project_service]),
+) -> List[Project]:
+    return project_service.list_projects_from_organization(organization_id)
+
+
+@router.get(
+    "/projects",
+    tags=PROJECTS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+)
+@inject
+def list_projects(
+    organization: str,
+    project_service: ProjectService = Depends(Provide[ServerContainer.project_service]),
+) -> List[Project]:
+    return project_service.list_projects_from_organization(organization)

--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -235,6 +235,7 @@ class ProjectBase(BaseModel):
     name: str
     description: str
     team_id: UUID
+    organization_id: UUID
 
     class Config:
         schema_extra = {

--- a/carbonserver/carbonserver/api/services/project_service.py
+++ b/carbonserver/carbonserver/api/services/project_service.py
@@ -16,3 +16,6 @@ class ProjectService:
 
     def list_projects_from_team(self, team_id: str):
         return self._repository.get_projects_from_team(team_id)
+
+    def list_projects_from_organization(self, organization_id: str):
+        return self._repository.get_projects_from_organization(organization_id)

--- a/carbonserver/carbonserver/database/alembic/versions/3f64cdda4d67_added_organization_to_project.py
+++ b/carbonserver/carbonserver/database/alembic/versions/3f64cdda4d67_added_organization_to_project.py
@@ -1,0 +1,37 @@
+"""Added organization to project
+
+Revision ID: 3f64cdda4d67
+Revises: 298059b19bde
+Create Date: 2024-06-16 22:27:43.746807
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "3f64cdda4d67"
+down_revision = "298059b19bde"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "projects",
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        None, "projects", "organizations", ["organization_id"], ["id"]
+    )
+
+
+def downgrade():
+    op.add_column(
+        "users",
+        sa.Column(
+            "organization_id", postgresql.UUID(), autoincrement=False, nullable=True
+        ),
+    )
+    op.drop_constraint(None, "projects", type_="foreignkey")

--- a/carbonserver/tests/api/integration/test_api_black_box.py
+++ b/carbonserver/tests/api/integration/test_api_black_box.py
@@ -230,6 +230,7 @@ def test_api16_project_create():
     payload = {
         "name": "test_to_delete",
         "description": "Test to delete by test_api_black_box",
+        "organization_id": org_new_id,
         "team_id": team_new_id,
     }
     r = requests.post(url=URL + "/projects/", json=payload, timeout=2)

--- a/carbonserver/tests/api/routers/test_projects.py
+++ b/carbonserver/tests/api/routers/test_projects.py
@@ -15,11 +15,14 @@ PROJECT_ID_2 = "e52fe339-164d-4c2b-a8c0-f562dfce066d"
 TEAM_ID = "c13e851f-5c2f-403d-98d0-51fe15df3bc3"
 TEAM_ID_2 = "c13e851f-5c2f-403d-98d0-51fe15df3bc4"
 
+ORGANIZATION_ID = "c13e851f-5c2f-403d-98d0-51fe15df3bc3"
+ORGANIZATION_ID_2 = "c13e851f-5c2f-403d-98d0-51fe15df3bc4"
 
 PROJECT_TO_CREATE = {
     "name": "API Code Carbon",
     "description": "API for Code Carbon",
     "team_id": "c13e851f-5c2f-403d-98d0-51fe15df3bc3",
+    "organization_id": ORGANIZATION_ID,
 }
 
 PROJECT_1 = {
@@ -27,6 +30,7 @@ PROJECT_1 = {
     "name": "API Code Carbon",
     "description": "API for Code Carbon",
     "team_id": TEAM_ID,
+    "organization_id": ORGANIZATION_ID,
     "experiments": [],
 }
 
@@ -36,6 +40,7 @@ PROJECT_2 = {
     "name": "API Code Carbon",
     "description": "Calculates CO2 emissions of AI projects",
     "team_id": TEAM_ID_2,
+    "organization_id": ORGANIZATION_ID_2,
 }
 
 
@@ -90,6 +95,24 @@ def test_get_projects_from_team_returns_correct_project(client, custom_test_serv
 
     with custom_test_server.container.project_repository.override(repository_mock):
         response = client.get("/projects/team/" + TEAM_ID)
+        actual_project_list = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert actual_project_list == expected_project_list
+
+
+def test_get_projects_from_organization_returns_correct_project(
+    client, custom_test_server
+):
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_project = PROJECT_1
+    expected_project_list = [expected_project]
+    repository_mock.get_projects_from_organization.return_value = [
+        Project(**expected_project),
+    ]
+
+    with custom_test_server.container.project_repository.override(repository_mock):
+        response = client.get(f"/organizations/{ORGANIZATION_ID}/projects")
         actual_project_list = response.json()
 
     assert response.status_code == status.HTTP_200_OK

--- a/carbonserver/tests/api/service/test_project_service.py
+++ b/carbonserver/tests/api/service/test_project_service.py
@@ -7,10 +7,15 @@ from carbonserver.api.services.project_service import ProjectService
 
 PROJECT_ID = UUID("f52fe339-164d-4c2b-a8c0-f562dfce066d")
 
+ORGANIZATION_ID = UUID("e60afa92-17b7-4720-91a0-1ae91e409ba1")
 TEAM_ID = UUID("e52fe339-164d-4c2b-a8c0-f562dfce066d")
 
 PROJECT = Project(
-    id=PROJECT_ID, name="Project", description="Description", team_id=TEAM_ID
+    id=PROJECT_ID,
+    name="Project",
+    description="Description",
+    team_id=TEAM_ID,
+    organization_id=ORGANIZATION_ID,
 )
 
 
@@ -22,7 +27,10 @@ def test_project_service_creates_correct_project(_):
     repository_mock.add_project.return_value = PROJECT
 
     project_to_create = ProjectCreate(
-        name="Project", description="Description", team_id=TEAM_ID
+        name="Project",
+        description="Description",
+        team_id=TEAM_ID,
+        organization_id=ORGANIZATION_ID,
     )
 
     actual_saved_project_id = project_service.add_project(project_to_create)
@@ -40,6 +48,17 @@ def test_project_service_retrieves_correct_project_by_id():
 
     assert actual_saved_project.id == expected_project.id
     assert actual_saved_project.name == expected_project.name
+
+
+def test_project_service_retrieves__correct_project_by_organization_id():
+    repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
+    expected_organization_id = ORGANIZATION_ID
+    project_service: ProjectService = ProjectService(repository_mock)
+    repository_mock.get_projects_from_organization.return_value = [PROJECT]
+
+    actual_projects = project_service.list_projects_from_organization(ORGANIZATION_ID)
+
+    assert actual_projects[0].organization_id == expected_organization_id
 
 
 def test_project_service_retrieves__correct_project_by_team_id():


### PR DESCRIPTION
Add organization_id to Project
Rework project endpoints a bit.

issue: https://github.com/orgs/mlco2/projects/4/views/1?pane=issue&itemId=67359449

Context:
Rework API to have the following structure:
```
- Org
  - Project
    - Experiment
      - Run
        - Measure
- User
```


L'idée est de mettre un peu en évidence la hiérarchie des concepts sans compliquer les choses.
Avoir une URL de type runs/{id}/projects/<id>/experiments/<id>/runs/id>/measures
serait ingérable.
Mais avoir `/organizations/<id>/projects` permet de mettre en évidence les liens entre les structures

J'ai mis pour chaque item un accès à partir du parent ou par query  param.
Ex: les 2 chemins suivant reviennent au meme (uniquement pour lister les éléments pour ne pas avoir de duplication inutile):
- /organizations/{org_id}/projects
- /projects?organization={org_id}




