### PR TITLE
Handle TRES in Slurm

### DIFF
--- a/codecarbon/external/hardware.py
+++ b/codecarbon/external/hardware.py
@@ -309,6 +309,9 @@ class RAM(BaseHardware):
     def _parse_scontrol(self, scontrol_str):
         mem_matches = re.findall(r"AllocTRES=.*?,mem=(\d+[A-Z])", scontrol_str)
         if len(mem_matches) == 0:
+            # Try with TRES, see https://github.com/mlco2/codecarbon/issues/569#issuecomment-2167706145
+            mem_matches = re.findall(r"TRES=.*?,mem=(\d+[A-Z])", scontrol_str)
+        if len(mem_matches) == 0:
             logger.warning(
                 "Could not find mem= after running `scontrol show job $SLURM_JOB_ID` "
                 + "to count SLURM-available RAM. Using the machine's total RAM."

--- a/tests/test_ram.py
+++ b/tests/test_ram.py
@@ -82,3 +82,12 @@ class TestRAM(unittest.TestCase):
         ram = RAM(tracking_mode="slurm")
         ram_size = ram._parse_scontrol(scontrol_str)
         self.assertEqual(ram_size, "42K")
+
+        scontrol_str = dedent(
+            """\
+            TRES=cpu=64,mem=50000M,node=1,billing=40,gres/gpu=4
+            """
+        )
+        ram = RAM(tracking_mode="slurm")
+        ram_size = ram._parse_scontrol(scontrol_str)
+        self.assertEqual(ram_size, "50000M")


### PR DESCRIPTION
Some Slurm environment seems to do not publish `AllocTRES` but only `TRES`.

Will close #569 