### PR TITLE
feat(api): new user actions

### DIFF
--- a/carbonserver/carbonserver/api/routers/users.py
+++ b/carbonserver/carbonserver/api/routers/users.py
@@ -6,12 +6,10 @@ from fastapi import APIRouter, Depends, status
 
 from carbonserver.api.dependencies import get_token_header
 from carbonserver.api.schemas import OrganizationCreate, ProjectCreate, User, UserCreate
+from carbonserver.api.services.organization_service import OrganizationService
+from carbonserver.api.services.project_service import ProjectService
 from carbonserver.api.services.signup_service import SignUpService
 from carbonserver.api.services.user_service import UserService
-from carbonserver.carbonserver.api.services.organization_service import (
-    OrganizationService,
-)
-from carbonserver.carbonserver.api.services.project_service import ProjectService
 
 USERS_ROUTER_TAGS = ["Users"]
 

--- a/carbonserver/carbonserver/api/routers/users.py
+++ b/carbonserver/carbonserver/api/routers/users.py
@@ -5,9 +5,13 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, status
 
 from carbonserver.api.dependencies import get_token_header
-from carbonserver.api.schemas import User, UserCreate
+from carbonserver.api.schemas import OrganizationCreate, ProjectCreate, User, UserCreate
 from carbonserver.api.services.signup_service import SignUpService
 from carbonserver.api.services.user_service import UserService
+from carbonserver.carbonserver.api.services.organization_service import (
+    OrganizationService,
+)
+from carbonserver.carbonserver.api.services.project_service import ProjectService
 
 USERS_ROUTER_TAGS = ["Users"]
 
@@ -26,8 +30,17 @@ router = APIRouter(
 def create_user(
     user: UserCreate,
     user_service: UserService = Depends(Provide[ServerContainer.user_service]),
+    organization_service: OrganizationService = Depends(
+        Provide[ServerContainer.organization_service]
+    ),
+    project_service: ProjectService = Depends(Provide[ServerContainer.project_service]),
 ) -> User:
-    return user_service.create_user(user)
+    user_created = user_service.create_user(user)
+    if user_created is None:
+        return user_created
+
+    new_user_steps(user_created, organization_service, project_service)
+    return user_created
 
 
 @router.post(
@@ -69,3 +82,27 @@ def get_user_by_id(
     user_service: UserService = Depends(Provide[ServerContainer.user_service]),
 ) -> User:
     return user_service.get_user_by_id(user_id)
+
+
+def new_user_steps(
+    user: User,
+    organization_service: OrganizationService,
+    project_service: ProjectService,
+):
+    """
+    Steps to be run for every new user created
+    """
+    # TODO: Add a transaction to rollback if any of the following steps fail
+    # Create an organization for the user
+    organization = OrganizationCreate(
+        name=user.name, description="Default organization"
+    )
+    organization_created = organization_service.add_organization(organization)
+    # Create a project for the user
+    project = ProjectCreate(
+        name=user.name,
+        description="Default project",
+        organization_id=organization_created.id,
+    )
+    project_service.add_project(project)
+    # TODO: Add default flag to the generated project and organization and do not allow to delete them

--- a/carbonserver/tests/api/routers/test_users.py
+++ b/carbonserver/tests/api/routers/test_users.py
@@ -5,9 +5,24 @@ from container import ServerContainer
 from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
-from carbonserver.api.infra.repositories.repository_users import SqlAlchemyRepository
+from carbonserver.api.infra.repositories.repository_organizations import (
+    SqlAlchemyRepository as OrganizationsRepository,
+)
+from carbonserver.api.infra.repositories.repository_projects import (
+    SqlAlchemyRepository as ProjectsRepository,
+)
+from carbonserver.api.infra.repositories.repository_users import (
+    SqlAlchemyRepository as UsersRepository,
+)
 from carbonserver.api.routers import users
-from carbonserver.api.schemas import Project, User
+from carbonserver.api.schemas import (
+    Organization,
+    OrganizationCreate,
+    Project,
+    ProjectCreate,
+    User,
+    UserCreate,
+)
 
 API_KEY = "U5W0EUP9y6bBENOnZWJS0g"
 
@@ -52,10 +67,17 @@ ORGANIZATION_ID = "c13e851f-5c2f-403d-98d0-51fe15df3bc3"
 
 PROJECT_1 = {
     "id": PROJECT_ID,
-    "name": "API Code Carbon",
-    "description": "API for Code Carbon",
+    "name": "Gontran Bonheur",
+    "description": "Default project",
     "organization_id": ORGANIZATION_ID,
     "experiments": [],
+}
+
+ORG_1 = {
+    "id": ORGANIZATION_ID,
+    "api_key": API_KEY,
+    "name": "Gontran Bonheur",
+    "description": "Default organization",
 }
 ###
 
@@ -76,25 +98,41 @@ def client(custom_test_server):
 
 
 def test_create_user(client, custom_test_server):
-    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    repository_mock = mock.Mock(spec=UsersRepository)
     expected_user = USER_1
     repository_mock.create_user.return_value = User(**expected_user)
-    project_repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    project_repository_mock = mock.Mock(spec=ProjectsRepository)
     expected_project = PROJECT_1
-    repository_mock.create_user.return_value = Project(**expected_project)
+    project_repository_mock.add_project.return_value = Project(**expected_project)
+    organization_repository_mock = mock.Mock(spec=OrganizationsRepository)
+    expected_organization = ORG_1
+    organization_repository_mock.add_organization.return_value = Organization(
+        **expected_organization
+    )
 
     with custom_test_server.container.user_repository.override(
         repository_mock
     ) and custom_test_server.container.project_repository.override(
         project_repository_mock
     ) and custom_test_server.container.organization_repository.override(
-        repository_mock
+        organization_repository_mock
     ):
         response = client.post("/users", json=USER_TO_CREATE)
         actual_user = response.json()
 
     assert response.status_code == status.HTTP_201_CREATED
     assert actual_user == expected_user
+
+    # Check that the mocks have been called
+    repository_mock.create_user.assert_called_once()
+    project_repository_mock.add_project.assert_called_once()
+    organization_repository_mock.add_organization.assert_called_once()
+    # Check that the mocks have been called with the correct arguments
+    repository_mock.create_user.assert_called_with(UserCreate(**USER_TO_CREATE))
+    project_repository_mock.add_project.assert_called_with(ProjectCreate(**PROJECT_1))
+    organization_repository_mock.add_organization.assert_called_with(
+        OrganizationCreate(**ORG_1)
+    )
 
 
 def test_create_user_with_bad_email_fails_at_http_layer(client):
@@ -106,7 +144,7 @@ def test_create_user_with_bad_email_fails_at_http_layer(client):
 
 
 def test_list_users_list_all_existing_users_with_200(client, custom_test_server):
-    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    repository_mock = mock.Mock(spec=UsersRepository)
     expected_user = USER_1
     expected_user_2 = USER_2
     expected_user_list = [expected_user, expected_user_2]
@@ -126,7 +164,7 @@ def test_list_users_list_all_existing_users_with_200(client, custom_test_server)
 def test_get_user_by_id_returns_correct_user_with_correct_id(
     client, custom_test_server
 ):
-    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    repository_mock = mock.Mock(spec=UsersRepository)
     expected_user = USER_1
     repository_mock.get_user_by_id.return_value = User(**expected_user)
 

--- a/carbonserver/tests/api/routers/test_users.py
+++ b/carbonserver/tests/api/routers/test_users.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 
 from carbonserver.api.infra.repositories.repository_users import SqlAlchemyRepository
 from carbonserver.api.routers import users
-from carbonserver.api.schemas import User
+from carbonserver.api.schemas import Project, User
 
 API_KEY = "U5W0EUP9y6bBENOnZWJS0g"
 
@@ -44,6 +44,21 @@ USER_WITH_BAD_EMAIL = {
     "password": "pwd",
 }
 
+###
+#  Only needed for the steps after the creation of a user
+###
+PROJECT_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
+ORGANIZATION_ID = "c13e851f-5c2f-403d-98d0-51fe15df3bc3"
+
+PROJECT_1 = {
+    "id": PROJECT_ID,
+    "name": "API Code Carbon",
+    "description": "API for Code Carbon",
+    "organization_id": ORGANIZATION_ID,
+    "experiments": [],
+}
+###
+
 
 @pytest.fixture
 def custom_test_server():
@@ -64,8 +79,17 @@ def test_create_user(client, custom_test_server):
     repository_mock = mock.Mock(spec=SqlAlchemyRepository)
     expected_user = USER_1
     repository_mock.create_user.return_value = User(**expected_user)
+    project_repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    expected_project = PROJECT_1
+    repository_mock.create_user.return_value = Project(**expected_project)
 
-    with custom_test_server.container.user_repository.override(repository_mock):
+    with custom_test_server.container.user_repository.override(
+        repository_mock
+    ) and custom_test_server.container.project_repository.override(
+        project_repository_mock
+    ) and custom_test_server.container.organization_repository.override(
+        repository_mock
+    ):
         response = client.post("/users", json=USER_TO_CREATE)
         actual_user = response.json()
 


### PR DESCRIPTION
When a new user is created ==> Create an organization with their name and a project with their name.

> In the future we should distinguish somehow the default organization of each user + the default project of each organization, this can come in a future PR

# TODO
- [x] Api unit tests passing
- [x] Api integration tests passing