### PR TITLE
feat(api) add fief auth layer

### DIFF
--- a/carbonserver/carbonserver/api/routers/authenticate.py
+++ b/carbonserver/carbonserver/api/routers/authenticate.py
@@ -1,10 +1,25 @@
+import base64
+import random
+from dataclasses import dataclass
+from typing import Annotated, Optional
+
+import requests
 from container import ServerContainer
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends, HTTPException
-from starlette import status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi.responses import RedirectResponse
+from fastapi.security import (
+    APIKeyCookie,
+    HTTPAuthorizationCredentials,
+    HTTPBearer,
+    OAuth2AuthorizationCodeBearer,
+)
+from fief_client import FiefAsync, FiefUserInfo
+from fief_client.integrations.fastapi import FiefAuth
 
 from carbonserver.api.schemas import Token, UserAuthenticate
 from carbonserver.api.services.user_service import UserService
+from carbonserver.config import settings
 
 AUTHENTICATE_ROUTER_TAGS = ["Authenticate"]
 
@@ -29,3 +44,129 @@ def auth_user(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Incorrect password or email!",
     )
+
+
+fief = FiefAsync(
+    settings.fief_url, settings.fief_client_id, settings.fief_client_secret
+)
+
+
+@dataclass
+class FullUser:
+    db_user: dict
+    auth_user: dict
+
+
+SESSION_COOKIE_NAME = "user_session"
+scheme = OAuth2AuthorizationCodeBearer(
+    settings.fief_url + "/authorize",
+    settings.fief_url + "/api/token",
+    scopes={"openid": "openid", "offline_access": "offline_access"},
+    auto_error=False,
+)
+web_scheme = APIKeyCookie(name=SESSION_COOKIE_NAME, auto_error=False)
+auth = fief_auth = FiefAuth(fief, scheme)
+web_auth = FiefAuth(fief, web_scheme)
+api_auth = Annotated[HTTPAuthorizationCredentials, Depends(HTTPBearer())]
+
+
+class UserOrRedirectAuth(FiefAuth):
+    client: FiefAsync
+
+    async def get_unauthorized_response(self, request: Request, response: Response):
+        redirect_uri = request.url_for("auth_callback")
+        auth_url = await self.client.auth_url(
+            redirect_uri, scope=["openid", "offline_access"]
+        )
+
+        raise HTTPException(
+            status_code=status.HTTP_307_TEMPORARY_REDIRECT,
+            headers={"Location": str(auth_url)},
+        )
+
+
+web_auth_with_redirect = UserOrRedirectAuth(fief, web_scheme)
+
+
+class UserWithAuthDependency:
+    """
+    Used to reconciliate oauth and db sides for a user
+    """
+
+    def __init__(
+        self,
+        auth_user: Optional[FiefUserInfo] = Depends(
+            fief_auth.current_user(optional=True)
+        ),
+        api_key: HTTPAuthorizationCredentials = Depends(web_scheme),
+        user_service: UserService = Depends(Provide[ServerContainer.user_service]),
+    ):
+        self.user_service = user_service
+        self.auth_user = auth_user
+        try:
+            self.db_user = user_service.get_user_by_id(auth_user["sub"])
+        except Exception:
+            self.db_user = None
+
+
+@router.get("/auth/check", name="auth-check")
+def check_login(
+    user: FiefUserInfo = Depends(web_auth_with_redirect.current_user(optional=False)),
+):
+    """
+    return user data or redirect to login screen
+    """
+    return {"user": user}
+
+
+@router.get("/auth/user", name="auth-user")
+def check_user(
+    user: FiefUserInfo = Depends(web_auth.current_user(optional=True)),
+):
+    """
+    return user data
+    null value if not logged in
+    """
+    return {"user": user}
+
+
+@router.get("/auth/auth-callback", name="auth_callback")
+async def auth_callback(request: Request, response: Response, code: str = Query(...)):
+    redirect_uri = request.url_for("auth_callback")
+    tokens, _ = await fief.auth_callback(code, redirect_uri)
+    response = RedirectResponse(request.url_for("auth-user"))
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        tokens["access_token"],
+        max_age=tokens["expires_in"],
+        httponly=True,
+        secure=True,
+    )
+    return response
+
+
+@router.get("/auth/login", name="login")
+async def get_login(
+    request: Request, state: Optional[str] = None, code: Optional[str] = None
+):
+    """
+    login and redirect to frontend app with token
+    """
+    login_url = request.url_for("login")
+    if code:
+        res = requests.post(
+            f"{settings.fief_url}/api/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": login_url,
+                "client_id": settings.fief_client_id,
+                "client_secret": settings.fief_client_secret,
+            },
+        )
+        url = f"{request.base_url}/web/login#creds={base64.b64encode(res.content).decode()}"
+        return RedirectResponse(url=url)
+
+    state = str(int(random.random() * 1000))
+    url = f"{settings.fief_url}/authorize?response_type=code&client_id={settings.fief_client_id}&redirect_uri={login_url}&scope=openid offline_access&state={state}"
+    return RedirectResponse(url=url)

--- a/carbonserver/carbonserver/config.py
+++ b/carbonserver/carbonserver/config.py
@@ -6,6 +6,9 @@ class Settings(BaseSettings):
         "postgresql://codecarbon-user:supersecret@localhost:5432/codecarbon_db",
         env="DATABASE_URL",
     )
+    fief_client_id: str = Field("", env="FIEF_CLIENT_ID")
+    fief_client_secret: str = Field("", env="FIEF_CLIENT_SECRET")
+    fief_url: str = Field("https://fief.local/mytenant", env="FIEF_URL")
 
 
 settings = Settings()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ dependencies = [
     "python-dateutil<3.0.0",
     "dependency-injector<5.0.0",
     "fastapi<1.0.0",
+    "fief-client[fastapi]",
     "httpx",
     "pydantic[email]<2.0.0",
     "psycopg2-binary<3.0.0",

--- a/requirements/requirements-api.txt
+++ b/requirements/requirements-api.txt
@@ -6,6 +6,8 @@
 # - python-dateutil<3.0.0
 # - dependency-injector<5.0.0
 # - fastapi<1.0.0
+# - fief-client[fastapi]
+# - pyjwt
 # - httpx
 # - pydantic[email]<2.0.0
 # - psycopg2-binary<3.0.0
@@ -48,6 +50,8 @@ certifi==2024.7.4
     #   httpcore
     #   httpx
     #   requests
+cffi==1.16.0
+    # via cryptography
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
@@ -55,6 +59,8 @@ click==8.1.7
     #   hatch.envs.api
     #   typer
     #   uvicorn
+cryptography==42.0.8
+    # via jwcrypto
 dependency-injector==4.41.0
     # via hatch.envs.api
 dnspython==2.6.1
@@ -63,15 +69,15 @@ email-validator==2.2.0
     # via
     #   fastapi
     #   pydantic
-exceptiongroup==1.2.1
-    # via
-    #   anyio
-    #   pytest
 fastapi==0.111.0
-    # via hatch.envs.api
+    # via
+    #   hatch.envs.api
+    #   fief-client
 fastapi-cli==0.0.4
     # via fastapi
 fastapi-pagination==0.12.25
+    # via hatch.envs.api
+fief-client==0.19.0
     # via hatch.envs.api
 greenlet==3.0.3
     # via sqlalchemy
@@ -87,6 +93,7 @@ httpx==0.27.0
     # via
     #   hatch.envs.api
     #   fastapi
+    #   fief-client
 idna==3.7
     # via
     #   anyio
@@ -97,6 +104,10 @@ iniconfig==2.0.0
     # via pytest
 jinja2==3.1.4
     # via fastapi
+jwcrypto==1.5.6
+    # via fief-client
+makefun==1.15.3
+    # via fief-client
 mako==1.3.5
     # via alembic
 markdown-it-py==3.0.0
@@ -129,6 +140,8 @@ psycopg2-binary==2.9.9
     # via hatch.envs.api
 py-cpuinfo==9.0.0
     # via hatch.envs.api
+pycparser==2.22
+    # via cffi
 pydantic==1.10.16
     # via
     #   hatch.envs.api
@@ -136,6 +149,8 @@ pydantic==1.10.16
     #   fastapi-pagination
 pygments==2.18.0
     # via rich
+pyjwt==2.8.0
+    # via hatch.envs.api
 pynvml==11.5.0
     # via hatch.envs.api
 pytest==8.2.2
@@ -184,8 +199,6 @@ sqlalchemy==1.4.52
     #   alembic
 starlette==0.37.2
     # via fastapi
-tomli==2.0.1
-    # via pytest
 typer==0.12.3
     # via fastapi-cli
 types-python-dateutil==2.9.0.20240316
@@ -193,12 +206,11 @@ types-python-dateutil==2.9.0.20240316
 typing-extensions==4.12.2
     # via
     #   alembic
-    #   anyio
     #   fastapi
     #   fastapi-pagination
+    #   jwcrypto
     #   pydantic
     #   typer
-    #   uvicorn
 tzdata==2024.1
     # via pandas
 ujson==5.10.0


### PR DESCRIPTION
First version.

Adds settings and auth layer for fief.
Still a bit experimental, it will have to be challenged once the dust settles but it works.

More than one auth strategies implemented.
It's meant to allow authentication through web page (using cookie), or web app (using token). 
The token strategy is also meant as a test for API token auth later (that part could be discussed). 

I also added a dependency (not used in this PR) to reconciliate user profiles between fief and the app DB.
Using the dependency in a router ensures the user is authenticated by fief and present in the local DB so we can then check permissions.
