### PR TITLE
Feat/organization access control

### DIFF
--- a/carbonserver/carbonserver/api/routers/organizations.py
+++ b/carbonserver/carbonserver/api/routers/organizations.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends
 from starlette import status
 
 from carbonserver.api.dependencies import get_token_header
+from carbonserver.api.routers.authenticate import UserWithAuthDependency
 from carbonserver.api.schemas import (
     Organization,
     OrganizationCreate,
@@ -82,11 +83,15 @@ def read_organization(
 )
 @inject
 def list_organizations(
+    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
     organization_service: OrganizationService = Depends(
         Provide[ServerContainer.organization_service]
     ),
 ) -> List[Organization]:
-    return organization_service.list_organizations()
+    try:
+        return organization_service.list_organizations(user=auth_user.db_user)
+    except Exception:
+        return []
 
 
 @router.get(

--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -353,7 +353,7 @@ class User(UserBase):
     id: UUID
     name: str
     email: EmailStr
-    api_key: str
+    api_key: Optional[str]
     organizations: Optional[List]
     is_active: bool
 

--- a/carbonserver/carbonserver/api/services/organization_service.py
+++ b/carbonserver/carbonserver/api/services/organization_service.py
@@ -3,7 +3,12 @@ from typing import List
 from carbonserver.api.infra.repositories.repository_organizations import (
     SqlAlchemyRepository,
 )
-from carbonserver.api.schemas import Organization, OrganizationCreate, OrganizationPatch
+from carbonserver.api.schemas import (
+    Organization,
+    OrganizationCreate,
+    OrganizationPatch,
+    User,
+)
 
 
 class OrganizationService:
@@ -22,9 +27,8 @@ class OrganizationService:
         )
         return organization
 
-    def list_organizations(self) -> List[Organization]:
-        organizations: List[Organization] = self._repository.list_organizations()
-        return organizations
+    def list_organizations(self, user: User = None) -> List[Organization]:
+        return self._repository.list_organizations(user=user)
 
     def patch_organization(
         self, organization_id: str, organization: OrganizationPatch


### PR DESCRIPTION
This will add access control to the organizations list
The backward compatibility is maintained for now, in order to keep the PR small and avoid a big overhaul.
With this:
If the user is authenticated, only the users organizations will be listed.

Next steps:
- reject unauthenticated users
- extend the access control to projects, ...
- add tests to the e2e local server (since we can't mock the user there we'll need a API Token auth strategy first)



