### PR TITLE
fix: added the TDP of CPU Intel Core i7-1360P

### DIFF
--- a/codecarbon/data/hardware/cpu_power.csv
+++ b/codecarbon/data/hardware/cpu_power.csv
@@ -2231,6 +2231,7 @@ Intel Core i7-1185G7E,28
 Intel Core i7-1185GRE,28
 Intel Core i7-1195G7,28
 Intel Core i7-1270P,64
+Intel Core i7-1360P,28
 Intel Core i7-2600,95
 Intel Core i7-2600K,95
 Intel Core i7-2600S,65


### PR DESCRIPTION
Added the TDP of the CPU Intel Core i7-1360P to cpu_power.csv
Source: https://www.intel.com/content/www/us/en/products/sku/232155/intel-core-i71360p-processor-18m-cache-up-to-5-00-ghz/specifications.html