### PR TITLE
Added type hint co2 signal

### DIFF
--- a/codecarbon/core/co2_signal.py
+++ b/codecarbon/core/co2_signal.py
@@ -23,7 +23,7 @@ def get_emissions(
         energy (Energy):
             An object representing the energy consumption in kilowatt-hours (kWh).
         geo (GeoMetadata):
-            An object containing geographic metadata, including either latitude/longitude
+            Geographic metadata, including either latitude/longitude
             or a country code.
         co2_signal_api_token (str, optional):
             The API token for authenticating with the CO2 Signal API (default is an empty string).

--- a/codecarbon/core/co2_signal.py
+++ b/codecarbon/core/co2_signal.py
@@ -12,6 +12,31 @@ CO2_SIGNAL_API_TIMEOUT: int = 30
 def get_emissions(
     energy: Energy, geo: GeoMetadata, co2_signal_api_token: str = ""
 ) -> float:
+    """
+    Calculate the CO2 emissions based on energy consumption and geographic location.
+
+    This function retrieves the carbon intensity (in grams of CO2 per kWh) from the CO2
+    Signal API based on the geographic location provided. It then calculates the total
+    CO2 emissions for a given amount of energy consumption.
+
+    Args:
+        energy (Energy):
+            An object representing the energy consumption in kilowatt-hours (kWh).
+        geo (GeoMetadata):
+            An object containing geographic metadata, including either latitude/longitude
+            or a country code.
+        co2_signal_api_token (str, optional):
+            The API token for authenticating with the CO2 Signal API (default is an empty string).
+
+    Returns:
+        float:
+            The total CO2 emissions in kilograms based on the provided energy consumption and
+            carbon intensity of the specified geographic location.
+
+    Raises:
+        CO2SignalAPIError:
+            If the CO2 Signal API request fails or returns an error.
+    """
     params: Dict[str, Any]
     if geo.latitude:
         params = {"lat": geo.latitude, "lon": geo.longitude}

--- a/codecarbon/core/co2_signal.py
+++ b/codecarbon/core/co2_signal.py
@@ -5,11 +5,13 @@ import requests
 from codecarbon.core.units import EmissionsPerKWh, Energy
 from codecarbon.external.geography import GeoMetadata
 
-URL = "https://api.co2signal.com/v1/latest"
-CO2_SIGNAL_API_TIMEOUT = 30
+URL: str = "https://api.co2signal.com/v1/latest"
+CO2_SIGNAL_API_TIMEOUT: int = 30
 
 
-def get_emissions(energy: Energy, geo: GeoMetadata, co2_signal_api_token: str = ""):
+def get_emissions(
+    energy: Energy, geo: GeoMetadata, co2_signal_api_token: str = ""
+) -> float:
     params: Dict[str, Any]
     if geo.latitude:
         params = {"lat": geo.latitude, "lon": geo.longitude}


### PR DESCRIPTION
Added type hints for constants as well as `get_emissions(...)` function return type.
Additionally added docstring to `get_emissions(...)` function.