### PR TITLE
feat(api) use new membership table to manage org members

### DIFF
--- a/carbonserver/carbonserver/api/domain/memberships.py
+++ b/carbonserver/carbonserver/api/domain/memberships.py
@@ -1,0 +1,17 @@
+import abc
+
+from carbonserver.api import schemas
+
+
+class Memberships(abc.ABC):
+    @abc.abstractmethod
+    def add_user_to_organization(
+        self, user_id: str, organization_id: str
+    ) -> schemas.Membership:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def remove_user_from_organization(
+        self, user_id: str, organization_id: str
+    ) -> schemas.Membership:
+        raise NotImplementedError

--- a/carbonserver/carbonserver/api/routers/organizations.py
+++ b/carbonserver/carbonserver/api/routers/organizations.py
@@ -14,6 +14,7 @@ from carbonserver.api.schemas import (
     OrganizationCreate,
     OrganizationPatch,
     OrganizationReport,
+    OrganizationUser,
 )
 from carbonserver.api.services.organization_service import OrganizationService
 from carbonserver.api.usecases.organization.organization_sum import (
@@ -123,3 +124,27 @@ def read_organization_detailed_sums(
     return organization_global_sum_usecase.compute_detailed_sum(
         organization_id, start_date, end_date
     )
+
+
+@router.get(
+    "/organizations/{organization_id}/users",
+    tags=ORGANIZATIONS_ROUTER_TAGS,
+    status_code=status.HTTP_200_OK,
+)
+@inject
+def list_organization_users(
+    organization_id: str,
+    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    organization_service: OrganizationService = Depends(
+        Provide[ServerContainer.organization_service]
+    ),
+) -> List[OrganizationUser]:
+    return organization_service.list_users(
+        organization_id=organization_id, user=auth_user.db_user
+    )
+    try:
+        return organization_service.list_users(
+            organization_id=organization_id, user=auth_user.db_user
+        )
+    except Exception:
+        return []

--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -38,7 +38,7 @@ class User(UserBase):
     id: UUID
     name: str
     email: EmailStr
-    organizations: Optional[List]
+    organizations: Optional[List[UUID | str]]  # TODO: cleanup type
     is_active: bool
 
     class Config:
@@ -396,6 +396,17 @@ class OrganizationReport(OrganizationBase):
     emissions_count: int
 
 
+class Membership(BaseModel):
+    user_id = UUID
+    organization_id = UUID
+    is_admin: bool
+
+
 class Token(BaseModel):
     access_token: str
     token_type: str
+
+
+class OrganizationUser(User):
+    organization_id = UUID
+    is_admin: bool

--- a/carbonserver/carbonserver/api/services/organization_service.py
+++ b/carbonserver/carbonserver/api/services/organization_service.py
@@ -1,4 +1,5 @@
 from typing import List
+from uuid import UUID
 
 from carbonserver.api.errors import NotAllowedError, NotAllowedErrorEnum, UserException
 from carbonserver.api.infra.repositories.repository_organizations import (
@@ -42,6 +43,11 @@ class OrganizationService:
 
     def list_organizations(self, user: User = None) -> List[Organization]:
         return self._repository.list_organizations(user=user)
+
+    def list_users(
+        self, organization_id: UUID | str, user: User = None
+    ) -> List[Organization]:
+        return self._repository.list_users(organization_id=organization_id, user=user)
 
     def patch_organization(
         self, organization_id: str, organization: OrganizationPatch, user: User

--- a/carbonserver/carbonserver/api/services/user_service.py
+++ b/carbonserver/carbonserver/api/services/user_service.py
@@ -10,7 +10,11 @@ class UserService:
 
     def create_user(self, user: UserAutoCreate) -> User:
         created_user: User = self._repository.create_user(user)
+        return created_user
 
+    def create_user_by_id(self, user: UserAutoCreate) -> User:
+        print("userservice", user)
+        created_user: User = self._repository.create_user(user)
         return created_user
 
     def get_user_by_id(self, user_id: str) -> User:
@@ -19,5 +23,7 @@ class UserService:
 
     def list_users(self) -> List[User]:
         users_list = self._repository.list_users()
-
         return users_list
+
+    def add_organization(self, user: User, organisation_id: str):
+        return self._repository.add_organisation(user, organisation_id)

--- a/carbonserver/carbonserver/database/alembic/versions/3f64cdda4d67_added_organization_to_project.py
+++ b/carbonserver/carbonserver/database/alembic/versions/3f64cdda4d67_added_organization_to_project.py
@@ -1,7 +1,7 @@
 """Added organization to project
 
 Revision ID: 3f64cdda4d67
-Revises: 298059b19bde
+Revises: 951141858cff
 Create Date: 2024-06-16 22:27:43.746807
 
 """

--- a/carbonserver/carbonserver/database/alembic/versions/711ce9f88326_add_org_memberships.py
+++ b/carbonserver/carbonserver/database/alembic/versions/711ce9f88326_add_org_memberships.py
@@ -1,0 +1,86 @@
+"""Add org memberships.
+
+Revision ID: 711ce9f88326
+Revises: 951141858cff
+Create Date: 2024-08-26 18:17:36.679046
+
+"""
+
+from uuid import UUID
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "711ce9f88326"
+down_revision = "951141858cff"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Remove organizations field from User
+    Add new many to many relationship with admin flag
+    """
+    op.drop_constraint("fk_users_organizations", "users", type_="foreignkey")
+    op.alter_column("users", "organizations", new_column_name="old_organizations")
+    t_memberships = op.create_table(
+        "memberships",
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("is_admin", sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organizations.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+        ),
+        sa.PrimaryKeyConstraint("organization_id", "user_id"),
+    )
+
+    connection = op.get_bind()
+    t_users = sa.Table(
+        "users",
+        sa.MetaData(),
+        sa.Column("id", sa.String(32)),
+        sa.Column(
+            "old_organizations", sa.ARRAY(sa.String, as_tuple=False, dimensions=1)
+        ),
+    )
+
+    # get old organizations list from users and migrate to new table
+    users_to_migrate = connection.execute(
+        sa.select(
+            [
+                t_users.c.id,
+                t_users.c.old_organizations,
+            ]
+        )
+    ).fetchall()
+    for user_id, old_organizations in users_to_migrate:
+        print("=====", user_id, old_organizations)
+        for organization_id in old_organizations:
+            print(f"adding {user_id=}, {organization_id=}, is_admin=True")
+            connection.execute(
+                t_memberships.insert().values(
+                    user_id=user_id,
+                    organization_id=UUID(organization_id),
+                    is_admin=True,
+                )
+            )
+
+    op.drop_column("users", "old_organizations")
+
+
+def downgrade():
+    op.create_foreign_key(
+        "fk_users_organizations", "users", "organizations", ["organization_id"], ["id"]
+    )
+    op.drop_table("memberships")
+    op.add_column(
+        "organizations", sa.Column(sa.ARRAY(sa.String, as_tuple=False, dimensions=1))
+    )

--- a/carbonserver/tests/api/integration/test_api_black_box.py
+++ b/carbonserver/tests/api/integration/test_api_black_box.py
@@ -558,3 +558,9 @@ def test_api34_project_api_token_delete():
     url = f"{URL}/projects/{project_id}/api-tokens/{project_token_id}"
     r = requests.delete(url, timeout=2)
     tc.assertEqual(r.status_code, 204)
+
+
+def test_api35_organization_read_users():
+    r = requests.get(url=URL + "/organizations/" + org_new_id + "/users", timeout=2)
+    tc.assertEqual(r.status_code, 200)
+    # TODO: check that user is a mamber

--- a/carbonserver/tests/api/service/test_organization_service.py
+++ b/carbonserver/tests/api/service/test_organization_service.py
@@ -1,11 +1,19 @@
+from typing import List
 from unittest import mock
 from uuid import UUID
 
 from carbonserver.api.infra.repositories.repository_organizations import (
     SqlAlchemyRepository,
 )
-from carbonserver.api.schemas import Organization, OrganizationCreate, OrganizationPatch
+from carbonserver.api.schemas import (
+    Organization,
+    OrganizationCreate,
+    OrganizationPatch,
+    OrganizationUser,
+)
 from carbonserver.api.services.organization_service import OrganizationService
+
+USER_ID_1 = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
 
 ORG_ID = UUID("f52fe339-164d-4c2b-a8c0-f562dfce066d")
 ORG_ID_2 = UUID("e52fe339-164d-4c2b-a8c0-f562dfce066d")
@@ -21,6 +29,15 @@ ORG_2 = Organization(
     name="Data For Good",
     description="Data For Good Organization 2",
     api_key=API_KEY,
+)
+
+ORG_USER = OrganizationUser(
+    id=USER_ID_1,
+    name="user1",
+    email="user1@local.com",
+    is_active=True,
+    organization_id=ORG_1.id,
+    is_admin=True,
 )
 
 
@@ -91,3 +108,14 @@ def test_organization_service_patches_correct_org():
     assert actual_saved_org.name == "PATCHED - Data For Good"
     assert actual_saved_org.description == "PATCHED - Data For Good Organization"
     assert actual_saved_org.api_key == API_KEY
+
+
+def test_orgganization_service_list_users():
+    repository_mock: SqlAlchemyRepository = mock.Mock(spec=SqlAlchemyRepository)
+    expected_org_users: List[OrganizationUser] = [ORG_USER]
+    organization_service: OrganizationService = OrganizationService(repository_mock)
+    repository_mock.list_users.return_value = [ORG_USER]
+
+    actual_user_list = organization_service.list_users(ORG_ID)
+
+    assert actual_user_list == expected_org_users


### PR DESCRIPTION
WIP


We want to have a list of users and admins in an organization. Instead of having user.organizations and organization.admins, we use a new table.



- [X] migration
- [x] other stuff