### PR TITLE
Build conda package

### DIFF
--- a/.conda/build-env.yaml
+++ b/.conda/build-env.yaml
@@ -1,0 +1,23 @@
+name: codecarbon_build_environment
+channels:
+- conda-forge
+- codecarbon
+
+dependencies:
+- python=3.12
+- pip
+- hatchling
+- conda-build
+- conda-verify
+- arrow
+- click
+- pandas
+- prometheus_client
+- psutil
+- py-cpuinfo
+- pynvml
+- rapidfuzz
+- requests
+- questionary
+- rich
+- type

--- a/.conda/build-env.yaml
+++ b/.conda/build-env.yaml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
 - python=3.12
+- anaconda-client
 - pip
 - hatchling
 - conda-build
@@ -20,4 +21,4 @@ dependencies:
 - requests
 - questionary
 - rich
-- type
+- typer

--- a/.conda/build-env.yaml
+++ b/.conda/build-env.yaml
@@ -1,3 +1,5 @@
+# This file probably could be deleted as we don't use it
+# but we will keep it until conda package is back on conda-forge
 name: codecarbon_build_environment
 channels:
 - conda-forge

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -46,5 +46,5 @@ about:
 
     By taking into account your computing infrastructure, location, usage and running time, Emissions Tracker can provide an estimate of how much CO2 you produced, and give you some comparisons with common modes of transporation to give you an order of magnitude.
   dev_url: https://github.com/mlco2/codecarbon
-  doc_url: https://pypi.python.org/TO-BE-DEFINED/codecarbon
+  doc_url: https://mlco2.github.io/codecarbon/
   doc_source_url: https://github.com/mlco2/codecarbon/blob/master/README.md

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
     - name: set PY
       run: echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
     - uses: actions/cache@v4
@@ -21,31 +23,3 @@ jobs:
       run: |
         pip install pre-commit==3.7.0
         pre-commit run --show-diff-on-failure --color=always --all-files
-
-# TO REMOVE BEFORE PUBLISHING !!!!
-  conda_deployment:
-    name: Conda deployment of package with Python 3.12
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Conda environment creation and activation
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          python-version: "3.12"
-          auto-update-conda: true
-          channels: codecarbon,conda-forge
-          activate-environment: codecarbon_build_environment
-          environment-file: .conda/build-env.yaml
-      - name: Build and upload the conda packages
-        uses: uibcdf/action-build-and-upload-conda-packages@v1.3.0
-        with:
-          meta_yaml_dir: .conda
-          python-version: "3.12"
-          platform_linux-64: true
-          platform_osx-64: true
-          platform_win-64: true
-          user: codecarbon
-          label: auto
-          token: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,3 +21,31 @@ jobs:
       run: |
         pip install pre-commit==3.7.0
         pre-commit run --show-diff-on-failure --color=always --all-files
+
+# TO REMOVE BEFORE PUBLISHING !!!!
+  conda_deployment:
+    name: Conda deployment of package with Python 3.12
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Conda environment creation and activation
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: "3.12"
+          auto-update-conda: true
+          channels: codecarbon,conda-forge
+          activate-environment: codecarbon_build_environment
+          environment-file: .conda/build-env.yaml
+      - name: Build and upload the conda packages
+        uses: uibcdf/action-build-and-upload-conda-packages@v1.3.0
+        with:
+          meta_yaml_dir: .conda
+          python-version: "3.12"
+          platform_linux-64: true
+          platform_osx-64: true
+          platform_win-64: true
+          user: codecarbon
+          label: auto
+          token: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -53,16 +53,10 @@ jobs:
           python-version: "3.12"
           auto-update-conda: true
           channels: codecarbon,conda-forge
-          activate-environment: codecarbon_build_environment
-          environment-file: .conda/build-env.yaml
-      - name: Build and upload the conda packages
-        uses: uibcdf/action-build-and-upload-conda-packages@v1.3.0
-        with:
-          meta_yaml_dir: .conda
-          python-version: "3.12"
-          platform_linux-64: true
-          platform_osx-64: true
-          platform_win-64: true
-          user: codecarbon
-          label: auto
-          token: ${{ secrets.ANACONDA_TOKEN }}
+      - name: Conda build and upload
+        shell: bash -l {0}
+        run: |
+          conda install --yes conda-build anaconda-client
+          conda config --set anaconda_upload yes
+          conda build --channel conda-forge --token ${{ secrets.ANACONDA_TOKEN }} --user codecarbon .conda
+

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -41,11 +41,8 @@ jobs:
         password: ${{ secrets.PYPI_TOKEN }}
 
   conda_deployment:
-    name: Conda deployment of package with Python ${{ matrix.python-version }}
+    name: Conda deployment of package with Python 3.12
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -53,18 +50,19 @@ jobs:
       - name: Conda environment creation and activation
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
           auto-update-conda: true
           channels: codecarbon,conda-forge
-          activate-environment: true
+          activate-environment: codecarbon_build_environment
+          environment-file: .conda/build-env.yaml
       - name: Build and upload the conda packages
         uses: uibcdf/action-build-and-upload-conda-packages@v1.3.0
         with:
           meta_yaml_dir: .conda
-          python-version: ${{ matrix.python-version }} # Values previously defined in `matrix`
+          python-version: "3.12"
           platform_linux-64: true
           platform_osx-64: true
           platform_win-64: true
           user: codecarbon
           label: auto
-          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the right name of your secret
+          token: ${{ secrets.ANACONDA_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install codecarbon
 
 **From Conda repository**
 ```python
-conda install -c conda-forge codecarbon
+conda install -c codecarbon codecarbon
 ```
 To see more installation options please refer to the documentation: [**Installation**](https://mlco2.github.io/codecarbon/installation.html#)
 


### PR DESCRIPTION
Conda package stop working more than one year ago. This PR is to make it work again.

This is to publish to https://anaconda.org/codecarbon/codecarbon and not to https://anaconda.org/conda-forge/codecarbon that will be better but will be done later.

To install codecarbon with conda:
`conda install -c codecarbon codecarbon`
