### PR TITLE
WIP feat(api) add permissions checks where needed

### DIFF
--- a/carbonserver/carbonserver/api/errors.py
+++ b/carbonserver/carbonserver/api/errors.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from enum import Enum
 
+from fastapi import HTTPException
+
 
 class EmptyResultException(Exception):
     """
@@ -51,3 +53,13 @@ class NotAllowedError(ErrorBase):
 class UserException(Exception):
     def __init__(self, error):
         self.error = error
+
+
+def get_http_exception(exception) -> HTTPException:
+    """
+    take an internal exception and return a HTTPException
+    """
+    if isinstance(exception, UserException):
+        if isinstance(error := exception.error, NotAllowedError):
+            return HTTPException(status_code=403, detail=error.message)
+    return HTTPException(status_code=500)

--- a/carbonserver/carbonserver/api/routers/authenticate.py
+++ b/carbonserver/carbonserver/api/routers/authenticate.py
@@ -10,7 +10,10 @@ from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import RedirectResponse
 from fief_client import FiefAsync
 
-from carbonserver.api.services.auth_service import UserWithAuthDependency
+from carbonserver.api.services.auth_service import (
+    OptionalUserWithAuthDependency,
+    UserWithAuthDependency,
+)
 from carbonserver.api.services.signup_service import SignUpService
 from carbonserver.config import settings
 
@@ -30,7 +33,7 @@ fief = FiefAsync(
 @router.get("/auth/check", name="auth-check")
 @inject
 def check_login(
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(OptionalUserWithAuthDependency),
 ):
     """
     return user data or redirect to login screen

--- a/carbonserver/carbonserver/api/routers/experiments.py
+++ b/carbonserver/carbonserver/api/routers/experiments.py
@@ -8,7 +8,10 @@ from fastapi import APIRouter, Depends
 from starlette import status
 
 from carbonserver.api.schemas import Experiment, ExperimentCreate, ExperimentReport
-from carbonserver.api.services.auth_service import UserWithAuthDependency
+from carbonserver.api.services.auth_service import (
+    MandatoryUserWithAuthDependency,
+    UserWithAuthDependency,
+)
 from carbonserver.api.services.experiments_service import ExperimentService
 from carbonserver.api.usecases.experiment.project_sum_by_experiment import (
     ProjectSumsByExperimentUsecase,
@@ -28,7 +31,7 @@ router = APIRouter()
 @inject
 def add_experiment(
     experiment: ExperimentCreate,
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(MandatoryUserWithAuthDependency),
     experiment_service: ExperimentService = Depends(
         Provide[ServerContainer.experiment_service]
     ),
@@ -45,7 +48,7 @@ def add_experiment(
 @inject
 def read_experiment(
     experiment_id: str,
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(MandatoryUserWithAuthDependency),
     experiment_service: ExperimentService = Depends(
         Provide[ServerContainer.experiment_service]
     ),
@@ -62,7 +65,7 @@ def read_experiment(
 @inject
 def read_project_experiments(
     project_id: str,
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(MandatoryUserWithAuthDependency),
     experiment_service: ExperimentService = Depends(
         Provide[ServerContainer.experiment_service]
     ),
@@ -80,7 +83,7 @@ def read_project_experiments(
 @inject
 def read_project_detailed_sums_by_experiment(
     project_id: str,
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(MandatoryUserWithAuthDependency),
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
     project_global_sum_by_experiment_usecase: ProjectSumsByExperimentUsecase = Depends(

--- a/carbonserver/carbonserver/api/routers/projects.py
+++ b/carbonserver/carbonserver/api/routers/projects.py
@@ -8,7 +8,10 @@ from fastapi import APIRouter, Depends
 from starlette import status
 
 from carbonserver.api.schemas import Project, ProjectCreate, ProjectPatch, ProjectReport
-from carbonserver.api.services.auth_service import UserWithAuthDependency
+from carbonserver.api.services.auth_service import (
+    MandatoryUserWithAuthDependency,
+    UserWithAuthDependency,
+)
 from carbonserver.api.services.project_service import ProjectService
 from carbonserver.api.usecases.project.project_sum import ProjectSumsUsecase
 
@@ -28,7 +31,7 @@ projects_temp_db = []
 @inject
 def add_project(
     project: ProjectCreate,
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(MandatoryUserWithAuthDependency),
     project_service=Depends(Provide[ServerContainer.project_service]),
 ) -> Project:
     print("Entering router")
@@ -45,7 +48,7 @@ def add_project(
 @inject
 def delete_project(
     project_id: str,
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(MandatoryUserWithAuthDependency),
     project_service=Depends(Provide[ServerContainer.project_service]),
 ) -> None:
     return project_service.delete_project(project_id, auth_user.db_user)
@@ -62,7 +65,7 @@ def delete_project(
 def patch_project(
     project_id: str,
     project: ProjectPatch,
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(MandatoryUserWithAuthDependency),
     project_service=Depends(Provide[ServerContainer.project_service]),
 ) -> Project:
     return project_service.patch_project(project_id, project, auth_user.db_user)
@@ -72,7 +75,7 @@ def patch_project(
 @inject
 def read_project(
     project_id: str,
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(MandatoryUserWithAuthDependency),
     project_service=Depends(Provide[ServerContainer.project_service]),
 ) -> Project:
     return project_service.get_one_project(project_id, auth_user.db_user)
@@ -111,7 +114,7 @@ def read_project_detailed_sums(
 @inject
 def list_projects_nested(
     organization_id: str,
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(MandatoryUserWithAuthDependency),
     project_service: ProjectService = Depends(Provide[ServerContainer.project_service]),
 ) -> List[Project]:
     return project_service.list_projects_from_organization(
@@ -127,7 +130,7 @@ def list_projects_nested(
 @inject
 def list_projects(
     organization: str,
-    auth_user: UserWithAuthDependency = Depends(UserWithAuthDependency),
+    auth_user: UserWithAuthDependency = Depends(MandatoryUserWithAuthDependency),
     project_service: ProjectService = Depends(Provide[ServerContainer.project_service]),
 ) -> List[Project]:
     return project_service.list_projects_from_organization(

--- a/carbonserver/carbonserver/api/services/auth_context.py
+++ b/carbonserver/carbonserver/api/services/auth_context.py
@@ -12,12 +12,6 @@ class AuthContext:
     def isOperationAuthorizedOnProject(self, project_id, user):
         return self._user_repository.is_user_authorized_on_project(project_id, user.id)
 
-    def is_admin_on_project(self, project_id, user):
-        pass
-
-    def is_admin_on_organization(self, organization_id, user):
-        pass
-
     def can_read_organization(self, organization_id, user):
         return self._user_repository.is_user_in_organization(
             organization_id=organization_id, user=user

--- a/carbonserver/carbonserver/api/usecases/experiment/project_sum_by_experiment.py
+++ b/carbonserver/carbonserver/api/usecases/experiment/project_sum_by_experiment.py
@@ -11,8 +11,9 @@ class ProjectSumsByExperimentUsecase:
         self._experiment_repository = experiment_repository
 
     def compute_detailed_sum(
-        self, project_id: str, start_date, end_date
+        self, project_id: str, start_date, end_date, user=None
     ) -> List[ExperimentReport]:
+        # TODO: check permissions
         sums = self._experiment_repository.get_project_detailed_sums_by_experiment(
             project_id,
             start_date,

--- a/carbonserver/initial_data.py
+++ b/carbonserver/initial_data.py
@@ -1,0 +1,59 @@
+"""
+Import initial data used for develop e2e api tests
+The most important is the main user with a known id
+We can then forge an access token and use the API for testing
+"""
+
+import logging
+
+from carbonserver.api.infra.database.database_manager import Database
+from carbonserver.api.infra.database.sql_models import User as SqlModelUser
+from carbonserver.config import settings
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def check_initial_data(db):
+    if settings.environment not in ("develop", "local"):
+        raise Exception("This script must be run in develop environment")
+
+    logger.info("Checking initial data...")
+    MAIN_USER_ID = "bb479cc8-3357-4859-985d-e3cc209d6fc9"
+    with db.session() as session:
+        e = session.query(SqlModelUser).filter(SqlModelUser.id == MAIN_USER_ID).first()
+        if e is None:
+            logger.info("User not found. Creating...")
+            db_user = SqlModelUser(
+                id=MAIN_USER_ID,
+                name="main user",
+                email="main.user@example.com",
+            )
+            session.add(db_user)
+            session.commit()
+
+
+# flake8: noqa
+def shell(db):
+    if settings.environment not in ("develop", "local"):
+        raise Exception("This script must be run in develop environment")
+    from carbonserver.api.infra.database.sql_models import (
+        Membership as SqlModelMembership,
+    )
+    from carbonserver.api.infra.database.sql_models import Project as SqlModelProject
+    from carbonserver.api.infra.database.sql_models import User as SqlModelUser
+
+    logger.info("Checking initial data...")
+    with db.session() as session:
+        import IPython
+
+        IPython.embed()
+
+
+def main() -> None:
+    db = Database(db_url=settings.db_url)
+    check_initial_data(db)
+
+
+if __name__ == "__main__":
+    main()

--- a/carbonserver/main.py
+++ b/carbonserver/main.py
@@ -7,7 +7,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from carbonserver.api.dependencies import get_query_token
-from carbonserver.api.errors import DBException
+from carbonserver.api.errors import DBException, UserException, get_http_exception
 from carbonserver.api.infra.database import sql_models
 from carbonserver.api.routers import (
     authenticate,
@@ -122,3 +122,8 @@ app.mount("/api", app, name="api")
 @app.get("/")
 def default():
     return {"status": "OK"}
+
+
+@app.exception_handler(UserException)
+async def custom_exception_handler(request: Request, exc: UserException):
+    raise get_http_exception(exc)

--- a/carbonserver/tests/api/mocks.py
+++ b/carbonserver/tests/api/mocks.py
@@ -26,3 +26,11 @@ class FakeAuthContext:
     @staticmethod
     def isOperationAuthorizedOnProject(*args, **kwargs):
         return True
+
+    @staticmethod
+    def can_read_organization(*args, **kwargs):
+        return True
+
+    @staticmethod
+    def can_write_organization(*args, **kwargs):
+        return True

--- a/carbonserver/tests/api/routers/test_experiments.py
+++ b/carbonserver/tests/api/routers/test_experiments.py
@@ -15,7 +15,7 @@ from carbonserver.api.infra.repositories.repository_experiments import (
 )
 from carbonserver.api.routers import experiments
 from carbonserver.api.schemas import Experiment
-from carbonserver.api.services.auth_service import UserWithAuthDependency
+from carbonserver.api.services.auth_service import MandatoryUserWithAuthDependency
 
 PROJECT_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
 
@@ -106,7 +106,9 @@ def custom_test_server():
     app = FastAPI()
     app.container = container
     app.include_router(experiments.router)
-    app.dependency_overrides[UserWithAuthDependency] = FakeUserWithAuthDependency
+    app.dependency_overrides[MandatoryUserWithAuthDependency] = (
+        FakeUserWithAuthDependency
+    )
     app.container.auth_context.override(providers.Factory(FakeAuthContext))
     add_pagination(app)
     yield app

--- a/carbonserver/tests/api/routers/test_projects.py
+++ b/carbonserver/tests/api/routers/test_projects.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from carbonserver.api.infra.repositories.repository_projects import SqlAlchemyRepository
 from carbonserver.api.routers import projects
 from carbonserver.api.schemas import Project
-from carbonserver.api.services.auth_service import UserWithAuthDependency
+from carbonserver.api.services.auth_service import MandatoryUserWithAuthDependency
 
 PROJECT_ID = "f52fe339-164d-4c2b-a8c0-f562dfce066d"
 PROJECT_ID_2 = "e52fe339-164d-4c2b-a8c0-f562dfce066d"
@@ -52,7 +52,9 @@ def custom_test_server() -> FastAPI:
     app = FastAPI()
     app.container = container
     app.include_router(projects.router)
-    app.dependency_overrides[UserWithAuthDependency] = FakeUserWithAuthDependency
+    app.dependency_overrides[MandatoryUserWithAuthDependency] = (
+        FakeUserWithAuthDependency
+    )
     app.container.auth_context.override(providers.Factory(FakeAuthContext))
     yield app
 
@@ -126,6 +128,5 @@ def test_get_projects_from_organization_returns_correct_project(
     with custom_test_server.container.project_repository.override(repository_mock):
         response = client.get(f"/organizations/{ORGANIZATION_ID}/projects")
         actual_project_list = response.json()
-
     assert response.status_code == status.HTTP_200_OK
     assert actual_project_list == expected_project_list


### PR DESCRIPTION
This will:
- add more permission checks
- differenciate 401 and 403
- add an initial_data script to add API test user to develop
- add auth to the e2e tests
- add db shell function to init script (temporary place)
- fix project permission check (it was using old db column)
- a few fixes to comply with changes



Notes:
- The 401 is managed by the router dependency. since we don't need to check in DB for that, I kept it at the router level
  if the enpoint is not public -> `UserWithAuthDependency(error_if_not_found=True)`
- the frontend has a lot of expectations on return data being mostly public
  => this will break