### PR TITLE
fix(webapp) fix app crashing when fetching organizations list without auth

### DIFF
--- a/webapp/src/app/(dashboard)/home/page.tsx
+++ b/webapp/src/app/(dashboard)/home/page.tsx
@@ -32,12 +32,17 @@ async function getDefaultOrgId(): Promise<string | null> {
     const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/organizations`);
 
     if (!res.ok) {
-        throw new Error("Failed to fetch /organizations");
+        // throw new Error("Failed to fetch /organizations");
+        console.warn("error fetching organizations list");
+        return null;
     }
-
-    const orgs = await res.json();
-    if (orgs.length > 0) {
-        return orgs[0].id;
+    try {
+        const orgs = await res.json();
+        if (orgs.length > 0) {
+            return orgs[0].id;
+        }
+    } catch (err) {
+        console.warn("error processing organizations list");
     }
     return null;
 }


### PR DESCRIPTION
note: this function is not going to work anyway since it has no authentication
I'm not going to fix it now so I'm adding a safe default return value in case of error, thus preventing the app from crashing (but not fixing the auto redirect to the default organization page when applicable - now that I think of it we might want to get rid of that later).