### PR TITLE
feat(cli,api) add auth to cli for new api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,7 @@ tests/test_data/rapl/*
 
 #asciinema
 *.cast
+
+
+# credentials
+credentials.json

--- a/codecarbon/cli/cli_utils.py
+++ b/codecarbon/cli/cli_utils.py
@@ -40,12 +40,19 @@ def get_api_endpoint(path: Optional[Path] = None):
 def get_existing_local_exp_id(path: Optional[Path] = None):
     p = path or Path.cwd().resolve() / ".codecarbon.config"
     if p.exists():
-        config = configparser.ConfigParser()
-        config.read(str(p))
-        if "codecarbon" in config.sections():
-            d = dict(config["codecarbon"])
-            if "experiment_id" in d:
-                return d["experiment_id"]
+        existing_path = p
+    else:
+        existing_path = Path("~/.codecarbon.config").expanduser()
+    return _get_local_exp_id(existing_path)
+
+
+def _get_local_exp_id(p: Optional[Path] = None):
+    config = configparser.ConfigParser()
+    config.read(str(p))
+    if "codecarbon" in config.sections():
+        d = dict(config["codecarbon"])
+        if "experiment_id" in d:
+            return d["experiment_id"]
 
 
 def write_local_exp_id(exp_id, path: Optional[Path] = None):

--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -3,7 +3,10 @@ from pathlib import Path
 from typing import Optional
 
 import questionary
+import requests
 import typer
+from fief_client import Fief
+from fief_client.integrations.cli import FiefAuth
 from rich import print
 from rich.prompt import Confirm
 from typing_extensions import Annotated
@@ -19,6 +22,10 @@ from codecarbon.cli.cli_utils import (
 from codecarbon.core.api_client import ApiClient, get_datetime_with_timezone
 from codecarbon.core.schemas import ExperimentCreate, OrganizationCreate, ProjectCreate
 from codecarbon.emissions_tracker import EmissionsTracker
+
+AUTH_CLIENT_ID = "pkqh9CiOkp4MkPqRqM_k8Xc3mwBRpojS3RayIk1i5Pg"
+AUTH_SERVER_URL = "https://auth.codecarbon.io/codecarbon-dev"
+API_URL = "https://dash-dev.cleverapps.io/api"
 
 DEFAULT_PROJECT_ID = "e60afa92-17b7-4720-91a0-1ae91e409ba1"
 DEFAULT_ORGANIzATION_ID = "e60afa92-17b7-4720-91a0-1ae91e409ba1"
@@ -85,6 +92,51 @@ def show_config(path: Path = Path("./.codecarbon.config")) -> None:
         )
 
 
+fief = Fief(AUTH_SERVER_URL, AUTH_CLIENT_ID)
+fief_auth = FiefAuth(fief, "./credentials.json")
+
+
+def _get_access_token():
+    access_token_info = fief_auth.access_token_info()
+    access_token = access_token_info["access_token"]
+    return access_token
+
+
+@codecarbon.command(
+    "test-api", short_help="Make an authenticated GET request to an API endpoint"
+)
+def api_get():
+    """
+    ex: test-api
+    """
+    api = ApiClient(endpoint_url=API_URL)  # TODO: get endpoint from config
+    api.set_access_token(_get_access_token())
+    organizations = api.get_list_organizations()
+    print(organizations)
+
+
+@codecarbon.command("login", short_help="Login to CodeCarbon")
+def login():
+    fief_auth.authorize()
+
+
+@codecarbon.command("get-token", short_help="Get project token")
+def get_token(project_id: str):
+    # api = ApiClient(endpoint_url=API_URL) # TODO: get endpoint from config
+    # api.set_access_token(_get_access_token())
+    req = requests.post(
+        f"{API_URL}/projects/{project_id}/api-tokens",
+        json={
+            "project_id": project_id,
+            "name": "api token",
+            "x_token": "???",
+        },
+        headers={"Authorization": f"Bearer {_get_access_token()}"},
+    )
+    print("Your token: " + req.json()["token"])
+    print("Add it to the api_key field in your configuration file")
+
+
 @codecarbon.command("config", short_help="Generate or show config")
 def config():
     """
@@ -127,6 +179,7 @@ def config():
     )
     overwrite_local_config("api_endpoint", api_endpoint, path=file_path)
     api = ApiClient(endpoint_url=api_endpoint)
+    api.set_access_token(_get_access_token())
     organizations = api.get_list_organizations()
     org = questionary_prompt(
         "Pick existing organization from list or Create new organization ?",

--- a/codecarbon/core/api_client.py
+++ b/codecarbon/core/api_client.py
@@ -39,7 +39,8 @@ class ApiClient:  # (AsyncClient)
 
     def __init__(
         self,
-        endpoint_url="https://api.codecarbon.io",
+        # endpoint_url="https://api.codecarbon.io",
+        endpoint_url="https://dash-dev.cleverapps.io/api",  # beta API
         experiment_id=None,
         api_key=None,
         conf=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "arrow",
     "click",
+    "fief-client[cli]",
     "pandas",
     "prometheus_client",
     "psutil",

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -42,6 +42,8 @@ colorama==0.4.6
     # via bumpver
 distlib==0.3.8
     # via virtualenv
+fief-client[cli]==0.19.0
+    # via codecarbon (pyproject.toml)
 filelock==3.16.0
     # via virtualenv
 identify==2.6.0

--- a/requirements/requirements-test.py3.10.txt
+++ b/requirements/requirements-test.py3.10.txt
@@ -54,6 +54,8 @@ dash-table==5.0.0
     # via dash
 exceptiongroup==1.2.2
     # via pytest
+fief-client[cli]==0.19.0
+    # via codecarbon (pyproject.toml)
 fire==0.6.0
     # via hatch.envs.test.py3.10
 flask==3.0.3

--- a/requirements/requirements-test.py3.11.txt
+++ b/requirements/requirements-test.py3.11.txt
@@ -52,6 +52,8 @@ dash-html-components==2.0.0
     # via dash
 dash-table==5.0.0
     # via dash
+fief-client[cli]==0.19.0
+    # via codecarbon (pyproject.toml)
 fire==0.6.0
     # via hatch.envs.test.py3.11
 flask==3.0.3

--- a/requirements/requirements-test.py3.12.txt
+++ b/requirements/requirements-test.py3.12.txt
@@ -52,6 +52,8 @@ dash-html-components==2.0.0
     # via dash
 dash-table==5.0.0
     # via dash
+fief-client[cli]==0.19.0
+    # via codecarbon (pyproject.toml)
 fire==0.6.0
     # via hatch.envs.test.py3.12
 flask==3.0.3

--- a/requirements/requirements-test.py3.8.txt
+++ b/requirements/requirements-test.py3.8.txt
@@ -54,6 +54,8 @@ dash-table==5.0.0
     # via dash
 exceptiongroup==1.2.2
     # via pytest
+fief-client[cli]==0.19.0
+    # via codecarbon (pyproject.toml)
 fire==0.6.0
     # via hatch.envs.test.py3.8
 flask==3.0.3

--- a/requirements/requirements-test.py3.9.txt
+++ b/requirements/requirements-test.py3.9.txt
@@ -54,6 +54,8 @@ dash-table==5.0.0
     # via dash
 exceptiongroup==1.2.2
     # via pytest
+fief-client[cli]==0.19.0
+    # via codecarbon (pyproject.toml)
 fire==0.6.0
     # via hatch.envs.test.py3.9
 flask==3.0.3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,8 +55,9 @@ class TestApp(unittest.TestCase):
     @patch("codecarbon.cli.main.Path.exists")
     @patch("codecarbon.cli.main.Confirm.ask")
     @patch("codecarbon.cli.main.questionary_prompt")
+    @patch("codecarbon.cli.main._get_access_token")
     def test_config_no_local_new_all(
-        self, mock_prompt, mock_confirm, mock_path_exists, MockApiClient
+        self, mock_token, mock_prompt, mock_confirm, mock_path_exists, MockApiClient
     ):
         temp_dir = os.getenv("RUNNER_TEMP", tempfile.gettempdir())
         temp_codecarbon_config = tempfile.NamedTemporaryFile(
@@ -74,6 +75,7 @@ class TestApp(unittest.TestCase):
         side_effect_wrapper.call_count = 0
         mock_path_exists.side_effect = side_effect_wrapper
         MockApiClient.return_value = self.mock_api_client
+        mock_token.return_value = "user_token"
         mock_prompt.side_effect = [
             "Create New Organization",
             "Create New Project",


### PR DESCRIPTION
WIP

TODO: add http://localhost:8080& to fief redir uri
Needs public pkce oauth2 app on fief 

This will add fief auth to the cli. This allows the user to manage the projects.
And allow creating an api token to send emissions for a given project.



