### PR TITLE
feat: hashed passwords + alembic migration

### DIFF
--- a/carbonserver/carbonserver/api/infra/api_key_service.py
+++ b/carbonserver/carbonserver/api/infra/api_key_service.py
@@ -1,5 +1,0 @@
-import secrets
-
-
-def generate_api_key():
-    return secrets.token_urlsafe(16)

--- a/carbonserver/carbonserver/api/infra/api_key_utils.py
+++ b/carbonserver/carbonserver/api/infra/api_key_utils.py
@@ -1,17 +1,19 @@
-import secrets
-import bcrypt
 import hashlib
+import secrets
 
-PREFIX_KEY = "cpt_" # cpt stands for codecarbon project token
+import bcrypt
+
+PREFIX_KEY = "cpt_"  # cpt stands for codecarbon project token
 
 
-def generate_api_key()->str:
+def generate_api_key() -> str:
     # Generate a random API key
     api_key = secrets.token_urlsafe(32)
     prefixed_api_key = f"{PREFIX_KEY}{api_key}"
     return prefixed_api_key
 
-def get_api_key_hash(api_key:str)->str:
+
+def get_api_key_hash(api_key: str) -> str:
     """Get the hash of the api key"""
     return bcrypt.hashpw(
         api_key.encode(),
@@ -19,7 +21,7 @@ def get_api_key_hash(api_key:str)->str:
     )
 
 
-def verify_api_key(plain_api_key:str, hashed_api_key:str) -> bool:
+def verify_api_key(plain_api_key: str, hashed_api_key: str) -> bool:
     """
     Verify the api key
     """
@@ -27,6 +29,7 @@ def verify_api_key(plain_api_key:str, hashed_api_key:str) -> bool:
         plain_api_key.encode(),
         hashed_api_key.encode(),
     )
+
 
 def generate_lookup_value(api_key: str) -> str:
     # Generate a SHA-256 hash of the API key

--- a/carbonserver/carbonserver/api/infra/api_key_utils.py
+++ b/carbonserver/carbonserver/api/infra/api_key_utils.py
@@ -1,0 +1,35 @@
+import secrets
+import bcrypt
+import hashlib
+
+PREFIX_KEY = "cpt_" # cpt stands for codecarbon project token
+
+
+def generate_api_key()->str:
+    # Generate a random API key
+    api_key = secrets.token_urlsafe(32)
+    prefixed_api_key = f"{PREFIX_KEY}{api_key}"
+    return prefixed_api_key
+
+def get_api_key_hash(api_key:str)->str:
+    """Get the hash of the api key"""
+    return bcrypt.hashpw(
+        api_key.encode(),
+        bcrypt.gensalt(),
+    )
+
+
+def verify_api_key(plain_api_key:str, hashed_api_key:str) -> bool:
+    """
+    Verify the api key
+    """
+    return bcrypt.checkpw(
+        plain_api_key.encode(),
+        hashed_api_key.encode(),
+    )
+
+def generate_lookup_value(api_key: str) -> str:
+    # Generate a SHA-256 hash of the API key
+    sha256_hash = hashlib.sha256(api_key.encode()).hexdigest()
+    # Use the first 8 characters of the hash as a lookup value
+    return sha256_hash[:8]

--- a/carbonserver/carbonserver/api/infra/database/sql_models.py
+++ b/carbonserver/carbonserver/api/infra/database/sql_models.py
@@ -183,14 +183,13 @@ class ProjectToken(Base):
     project = relationship("Project", back_populates="project_tokens")
     # Dates
     last_used = Column(DateTime, nullable=True)
-    expiration_date = Column(DateTime, nullable=False)
     # Permissions
     access = Column(Integer)
 
     def __repr__(self):
         return (
             f'<ApiKey(project_id="{self.project_id}", '
-            f'api_key="{self.hashed_token}", '
+            f'hashed_token="{self.hashed_token}", '
             f'name="{self.name}", '
             f'revoked="{self.revoked}", '
             f'last_used="{self.last_used}", '

--- a/carbonserver/carbonserver/api/infra/database/sql_models.py
+++ b/carbonserver/carbonserver/api/infra/database/sql_models.py
@@ -177,8 +177,10 @@ class ProjectToken(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4)
     project_id = Column(UUID(as_uuid=True), ForeignKey("projects.id"))
     name = Column(String)
-    hashed_token = Column(String,nullable=False)
-    lookup_value = Column(String,nullable=False) # This is the first 8 characters of the SHA-256 hash of the API key. Used for filtering faster
+    hashed_token = Column(String, nullable=False)
+    lookup_value = Column(
+        String, nullable=False
+    )  # This is the first 8 characters of the SHA-256 hash of the API key. Used for filtering faster
     revoked = Column(Boolean, default=False)
     project = relationship("Project", back_populates="project_tokens")
     # Dates

--- a/carbonserver/carbonserver/api/infra/database/sql_models.py
+++ b/carbonserver/carbonserver/api/infra/database/sql_models.py
@@ -177,17 +177,22 @@ class ProjectToken(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4)
     project_id = Column(UUID(as_uuid=True), ForeignKey("projects.id"))
     name = Column(String)
-    token = Column(String, unique=True)
+    hashed_token = Column(String,nullable=False)
+    lookup_value = Column(String,nullable=False) # This is the first 8 characters of the SHA-256 hash of the API key. Used for filtering faster
+    revoked = Column(Boolean, default=False)
     project = relationship("Project", back_populates="project_tokens")
+    # Dates
     last_used = Column(DateTime, nullable=True)
+    expiration_date = Column(DateTime, nullable=False)
     # Permissions
     access = Column(Integer)
 
     def __repr__(self):
         return (
             f'<ApiKey(project_id="{self.project_id}", '
-            f'api_key="{self.token}", '
+            f'api_key="{self.hashed_token}", '
             f'name="{self.name}", '
+            f'revoked="{self.revoked}", '
             f'last_used="{self.last_used}", '
             f'access="{self.access}", '
         )

--- a/carbonserver/carbonserver/api/infra/repositories/repository_projects_tokens.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_projects_tokens.py
@@ -1,5 +1,6 @@
 from contextlib import AbstractContextManager
 import datetime
+from typing import List, Optional
 
 from dependency_injector.providers import Callable
 from fastapi import HTTPException
@@ -67,26 +68,22 @@ class SqlAlchemyRepository(ProjectTokens):
     def get_project_token_by_project_id_and_token(self, project_id: str, token: str):
         lookup_value = generate_lookup_value(token)
         with self.session_factory() as session:
-            db_project_token = (
+            db_project_tokens = (
                 session.query(SqlModelProjectToken)
                 .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
                 .filter(
                     SqlModelProjectToken.project_id == project_id
                 )
-                .filter(verify_api_key(token, SqlModelProjectToken.hashed_token))
-                .first()
+                .all()
             )
-            if db_project_token:
-                self._set_last_used(db_project_token)
-                return self.map_sql_to_schema(db_project_token)
-            return None
+            return self._verify_possible_tokens(db_project_tokens, token)
 
     def get_project_token_by_experiment_id_and_token(
         self, experiment_id: str, token: str
     ):
         lookup_value = generate_lookup_value(token)
         with self.session_factory() as session:
-            db_project_token = (
+            db_project_tokens = (
                 session.query(SqlModelProjectToken)
                 .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
                 .join(
@@ -94,18 +91,14 @@ class SqlAlchemyRepository(ProjectTokens):
                     SqlModelProjectToken.project_id == SqlModelExperiment.project_id,
                 )
                 .filter(SqlModelExperiment.id == experiment_id)
-                .filter(verify_api_key(token, SqlModelProjectToken.hashed_token)) # Done last to avoid unnecessary hashing
-                .first()
+                .all()
             )
-            if db_project_token:
-                self._set_last_used(db_project_token)
-                return self.map_sql_to_schema(db_project_token)
-            return None
+            return self._verify_possible_tokens(db_project_tokens, token)
 
     def get_project_token_by_run_id_and_token(self, run_id: str, token: str):
         lookup_value = generate_lookup_value(token)
         with self.session_factory() as session:
-            db_project_token = (
+            db_project_tokens = (
                 session.query(SqlModelProjectToken)
                 .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
                 .join(
@@ -114,19 +107,14 @@ class SqlAlchemyRepository(ProjectTokens):
                 )
                 .join(SqlModelRun, SqlModelExperiment.id == SqlModelRun.experiment_id)
                 .filter(SqlModelRun.id == run_id)
-                .filter(verify_api_key(token, SqlModelProjectToken.hashed_token)) # Done last to avoid unnecessary hashing
-                .first()
+                .all()
             )
-
-            if db_project_token:
-                self._set_last_used(db_project_token)
-                return self.map_sql_to_schema(db_project_token)
-            return None
+            return self._verify_possible_tokens(db_project_tokens, token)
 
     def get_project_token_by_emission_id_and_token(self, emission_id: str, token: str):
         lookup_value = generate_lookup_value(token)
         with self.session_factory() as session:
-            db_project_token = (
+            db_project_tokens = (
                 session.query(SqlModelProjectToken)
                 .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
                 .join(
@@ -136,21 +124,35 @@ class SqlAlchemyRepository(ProjectTokens):
                 .join(SqlModelRun, SqlModelExperiment.id == SqlModelRun.experiment_id)
                 .join(SqlModelEmission, SqlModelRun.id == SqlModelEmission.run_id)
                 .filter(SqlModelEmission.id == emission_id)
-                .filter(verify_api_key(token, SqlModelProjectToken.hashed_token)) # Done last to avoid unnecessary hashing
-                .first()
+                .all()
             )
-            if db_project_token:
-                self._set_last_used(db_project_token)
-                return self.map_sql_to_schema(db_project_token)
-            return None
+            return self._verify_possible_tokens(db_project_tokens, token)
         
-    def _set_last_used(self, project_token: SqlModelProjectToken):
+    def _verify_possible_tokens(self, db_project_tokens:List[SqlModelProjectToken], target_token:str)->Optional[ProjectToken]:
+        """Common function to verify the possible tokens and return the correct one if found
+
+        Args:
+            db_project_tokens (List[SqlModelProjectToken]): _description_
+            target_token (str): _description_
+
+        Returns:
+            ProjectToken: The correct token if found, None otherwise
+        """
+        if db_project_tokens!=[]:
+            for db_project_token in db_project_tokens:
+                verification_response = verify_api_key(target_token, db_project_token.hashed_token)
+                if verification_response:
+                    self._set_last_used(db_project_token)
+                    return self.map_sql_to_schema(db_project_token)
+        return None
+
+    def _set_last_used(self, project_token: SqlModelProjectToken)->SqlModelProjectToken:
         """Update the last_used field of the project token"""
         with self.session_factory() as session:
             project_token.last_used = datetime.datetime.now()
             session.commit()
             session.refresh(project_token)
-            return self.map_sql_to_schema(project_token)
+            return project_token
 
     @staticmethod
     def map_sql_to_schema(project_token: SqlModelProjectToken) -> ProjectToken:

--- a/carbonserver/carbonserver/api/infra/repositories/repository_projects_tokens.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_projects_tokens.py
@@ -26,7 +26,6 @@ class SqlAlchemyRepository(ProjectTokens):
             db_project_token = SqlModelProjectToken(
                 project_id=project_token.project_id,
                 hashed_token=project_token.hashed_token,
-                expiration_date=project_token.expiration_date,
                 name=project_token.name,
                 access=project_token.access,
                 lookup_value=lookup_value,
@@ -168,6 +167,5 @@ class SqlAlchemyRepository(ProjectTokens):
             project_id=project_token.project_id,
             last_used=project_token.last_used,
             access=project_token.access,
-            expiration_date=project_token.expiration_date,
             revoked=project_token.revoked,
         )

--- a/carbonserver/carbonserver/api/infra/repositories/repository_projects_tokens.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_projects_tokens.py
@@ -1,12 +1,12 @@
-from contextlib import AbstractContextManager
 import datetime
+from contextlib import AbstractContextManager
 from typing import List, Optional
 
 from dependency_injector.providers import Callable
 from fastapi import HTTPException
 
 from carbonserver.api.domain.project_tokens import ProjectTokens
-from carbonserver.api.infra.api_key_utils import  generate_lookup_value,  verify_api_key
+from carbonserver.api.infra.api_key_utils import generate_lookup_value, verify_api_key
 from carbonserver.api.infra.database.sql_models import Emission as SqlModelEmission
 from carbonserver.api.infra.database.sql_models import Experiment as SqlModelExperiment
 from carbonserver.api.infra.database.sql_models import (
@@ -69,10 +69,10 @@ class SqlAlchemyRepository(ProjectTokens):
         with self.session_factory() as session:
             db_project_tokens = (
                 session.query(SqlModelProjectToken)
-                .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
                 .filter(
-                    SqlModelProjectToken.project_id == project_id
-                )
+                    SqlModelProjectToken.lookup_value == lookup_value
+                )  # To be used for faster filtering
+                .filter(SqlModelProjectToken.project_id == project_id)
                 .all()
             )
             return self._verify_possible_tokens(db_project_tokens, token)
@@ -84,7 +84,9 @@ class SqlAlchemyRepository(ProjectTokens):
         with self.session_factory() as session:
             db_project_tokens = (
                 session.query(SqlModelProjectToken)
-                .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
+                .filter(
+                    SqlModelProjectToken.lookup_value == lookup_value
+                )  # To be used for faster filtering
                 .join(
                     SqlModelExperiment,
                     SqlModelProjectToken.project_id == SqlModelExperiment.project_id,
@@ -99,7 +101,9 @@ class SqlAlchemyRepository(ProjectTokens):
         with self.session_factory() as session:
             db_project_tokens = (
                 session.query(SqlModelProjectToken)
-                .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
+                .filter(
+                    SqlModelProjectToken.lookup_value == lookup_value
+                )  # To be used for faster filtering
                 .join(
                     SqlModelExperiment,
                     SqlModelProjectToken.project_id == SqlModelExperiment.project_id,
@@ -115,7 +119,9 @@ class SqlAlchemyRepository(ProjectTokens):
         with self.session_factory() as session:
             db_project_tokens = (
                 session.query(SqlModelProjectToken)
-                .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
+                .filter(
+                    SqlModelProjectToken.lookup_value == lookup_value
+                )  # To be used for faster filtering
                 .join(
                     SqlModelExperiment,
                     SqlModelProjectToken.project_id == SqlModelExperiment.project_id,
@@ -126,8 +132,10 @@ class SqlAlchemyRepository(ProjectTokens):
                 .all()
             )
             return self._verify_possible_tokens(db_project_tokens, token)
-        
-    def _verify_possible_tokens(self, db_project_tokens:List[SqlModelProjectToken], target_token:str)->Optional[ProjectToken]:
+
+    def _verify_possible_tokens(
+        self, db_project_tokens: List[SqlModelProjectToken], target_token: str
+    ) -> Optional[ProjectToken]:
         """Common function to verify the possible tokens and return the correct one if found
 
         Args:
@@ -137,15 +145,19 @@ class SqlAlchemyRepository(ProjectTokens):
         Returns:
             ProjectToken: The correct token if found, None otherwise
         """
-        if db_project_tokens!=[]:
+        if db_project_tokens != []:
             for db_project_token in db_project_tokens:
-                verification_response = verify_api_key(target_token, db_project_token.hashed_token)
+                verification_response = verify_api_key(
+                    target_token, db_project_token.hashed_token
+                )
                 if verification_response:
                     self._set_last_used(db_project_token)
                     return self.map_sql_to_schema(db_project_token)
         return None
 
-    def _set_last_used(self, project_token: SqlModelProjectToken)->SqlModelProjectToken:
+    def _set_last_used(
+        self, project_token: SqlModelProjectToken
+    ) -> SqlModelProjectToken:
         """Update the last_used field of the project token"""
         with self.session_factory() as session:
             project_token.last_used = datetime.datetime.now()

--- a/carbonserver/carbonserver/api/infra/repositories/repository_projects_tokens.py
+++ b/carbonserver/carbonserver/api/infra/repositories/repository_projects_tokens.py
@@ -1,31 +1,34 @@
 from contextlib import AbstractContextManager
+import datetime
 
 from dependency_injector.providers import Callable
 from fastapi import HTTPException
 
 from carbonserver.api.domain.project_tokens import ProjectTokens
-from carbonserver.api.infra.api_key_service import generate_api_key
+from carbonserver.api.infra.api_key_utils import  generate_lookup_value,  verify_api_key
 from carbonserver.api.infra.database.sql_models import Emission as SqlModelEmission
 from carbonserver.api.infra.database.sql_models import Experiment as SqlModelExperiment
 from carbonserver.api.infra.database.sql_models import (
     ProjectToken as SqlModelProjectToken,
 )
 from carbonserver.api.infra.database.sql_models import Run as SqlModelRun
-from carbonserver.api.schemas import ProjectToken, ProjectTokenCreate
+from carbonserver.api.schemas import ProjectToken, ProjectTokenInternal
 
 
 class SqlAlchemyRepository(ProjectTokens):
     def __init__(self, session_factory) -> Callable[..., AbstractContextManager]:
         self.session_factory = session_factory
 
-    def add_project_token(self, project_id: str, project_token: ProjectTokenCreate):
-        token = f"pt_{generate_api_key()}"  # pt stands for project token
+    def add_project_token(self, project_token: ProjectTokenInternal):
+        lookup_value = generate_lookup_value(project_token.token)
         with self.session_factory() as session:
             db_project_token = SqlModelProjectToken(
-                project_id=project_id,
-                token=token,
+                project_id=project_token.project_id,
+                hashed_token=project_token.hashed_token,
+                expiration_date=project_token.expiration_date,
                 name=project_token.name,
                 access=project_token.access,
+                lookup_value=lookup_value,
             )
             session.add(db_project_token)
             session.commit()
@@ -62,59 +65,70 @@ class SqlAlchemyRepository(ProjectTokens):
             ]
 
     def get_project_token_by_project_id_and_token(self, project_id: str, token: str):
+        lookup_value = generate_lookup_value(token)
         with self.session_factory() as session:
             db_project_token = (
                 session.query(SqlModelProjectToken)
+                .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
                 .filter(
                     SqlModelProjectToken.project_id == project_id
-                    and SqlModelProjectToken.token == token
                 )
+                .filter(verify_api_key(token, SqlModelProjectToken.hashed_token))
                 .first()
             )
-            return (
-                self.map_sql_to_schema(db_project_token) if db_project_token else None
-            )
+            if db_project_token:
+                self._set_last_used(db_project_token)
+                return self.map_sql_to_schema(db_project_token)
+            return None
 
     def get_project_token_by_experiment_id_and_token(
         self, experiment_id: str, token: str
     ):
+        lookup_value = generate_lookup_value(token)
         with self.session_factory() as session:
             db_project_token = (
                 session.query(SqlModelProjectToken)
-                .filter(SqlModelProjectToken.token == token)
+                .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
                 .join(
                     SqlModelExperiment,
                     SqlModelProjectToken.project_id == SqlModelExperiment.project_id,
                 )
                 .filter(SqlModelExperiment.id == experiment_id)
+                .filter(verify_api_key(token, SqlModelProjectToken.hashed_token)) # Done last to avoid unnecessary hashing
                 .first()
             )
-            return (
-                self.map_sql_to_schema(db_project_token) if db_project_token else None
-            )
+            if db_project_token:
+                self._set_last_used(db_project_token)
+                return self.map_sql_to_schema(db_project_token)
+            return None
 
     def get_project_token_by_run_id_and_token(self, run_id: str, token: str):
+        lookup_value = generate_lookup_value(token)
         with self.session_factory() as session:
             db_project_token = (
                 session.query(SqlModelProjectToken)
-                .filter(SqlModelProjectToken.token == token)
+                .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
                 .join(
                     SqlModelExperiment,
                     SqlModelProjectToken.project_id == SqlModelExperiment.project_id,
                 )
                 .join(SqlModelRun, SqlModelExperiment.id == SqlModelRun.experiment_id)
                 .filter(SqlModelRun.id == run_id)
+                .filter(verify_api_key(token, SqlModelProjectToken.hashed_token)) # Done last to avoid unnecessary hashing
                 .first()
             )
-            return (
-                self.map_sql_to_schema(db_project_token) if db_project_token else None
-            )
+
+            if db_project_token:
+                self._set_last_used(db_project_token)
+                return self.map_sql_to_schema(db_project_token)
+            return None
 
     def get_project_token_by_emission_id_and_token(self, emission_id: str, token: str):
+        lookup_value = generate_lookup_value(token)
         with self.session_factory() as session:
             db_project_token = (
                 session.query(SqlModelProjectToken)
-                .filter(SqlModelProjectToken.token == token)
+                .filter(SqlModelProjectToken.lookup_value == lookup_value) # To be used for faster filtering
                 .join(
                     SqlModelExperiment,
                     SqlModelProjectToken.project_id == SqlModelExperiment.project_id,
@@ -122,11 +136,21 @@ class SqlAlchemyRepository(ProjectTokens):
                 .join(SqlModelRun, SqlModelExperiment.id == SqlModelRun.experiment_id)
                 .join(SqlModelEmission, SqlModelRun.id == SqlModelEmission.run_id)
                 .filter(SqlModelEmission.id == emission_id)
+                .filter(verify_api_key(token, SqlModelProjectToken.hashed_token)) # Done last to avoid unnecessary hashing
                 .first()
             )
-            return (
-                self.map_sql_to_schema(db_project_token) if db_project_token else None
-            )
+            if db_project_token:
+                self._set_last_used(db_project_token)
+                return self.map_sql_to_schema(db_project_token)
+            return None
+        
+    def _set_last_used(self, project_token: SqlModelProjectToken):
+        """Update the last_used field of the project token"""
+        with self.session_factory() as session:
+            project_token.last_used = datetime.datetime.now()
+            session.commit()
+            session.refresh(project_token)
+            return self.map_sql_to_schema(project_token)
 
     @staticmethod
     def map_sql_to_schema(project_token: SqlModelProjectToken) -> ProjectToken:
@@ -140,7 +164,8 @@ class SqlAlchemyRepository(ProjectTokens):
             id=str(project_token.id),
             name=project_token.name,
             project_id=project_token.project_id,
-            token=project_token.token,
             last_used=project_token.last_used,
             access=project_token.access,
+            expiration_date=project_token.expiration_date,
+            revoked=project_token.revoked,
         )

--- a/carbonserver/carbonserver/api/routers/project_api_tokens.py
+++ b/carbonserver/carbonserver/api/routers/project_api_tokens.py
@@ -13,6 +13,7 @@ PROJECTS_TOKENS_ROUTER_TAGS = ["Project tokens"]
 router = APIRouter(
     dependencies=[Depends(get_token_header)],
 )
+# TODO: Add authentication to the endpoints
 
 
 # Create project token

--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -302,7 +302,7 @@ class ProjectToken(BaseModel):
     id: UUID
     project_id: UUID
     name: Optional[str]
-    token: Optional[str]
+    token: Optional[str] = None
     expiration_date: Optional[datetime] = None
     last_used: Optional[datetime] = None
     access: int = AccessLevel.WRITE.value
@@ -314,7 +314,6 @@ class ProjectToken(BaseModel):
                 "id": "8edb03e1-9a28-452a-9c93-a3b6560136d7",
                 "project_id": "8edb03e1-9a28-452a-9c93-a3b6560136d7",
                 "name": "my project token",
-                "token": "8edb03e1-9a28-452a-9c93-a3b6560136d7",
                 "last_used": "2021-04-04T08:43:00+02:00",
                 "expiration_date": "2021-04-07T08:43:00+02:00",
                 "access": 1,

--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -13,8 +13,7 @@ from enum import Enum
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr, Extra, Field, SecretStr, validator
-
+from pydantic import BaseModel, EmailStr, Extra, Field, SecretStr
 
 class Empty(BaseModel, extra=Extra.forbid):
     pass
@@ -303,7 +302,6 @@ class ProjectToken(BaseModel):
     project_id: UUID
     name: Optional[str]
     token: Optional[str] = None
-    expiration_date: Optional[datetime] = None
     last_used: Optional[datetime] = None
     access: int = AccessLevel.WRITE.value
     revoked: bool = False
@@ -315,7 +313,6 @@ class ProjectToken(BaseModel):
                 "project_id": "8edb03e1-9a28-452a-9c93-a3b6560136d7",
                 "name": "my project token",
                 "last_used": "2021-04-04T08:43:00+02:00",
-                "expiration_date": "2021-04-07T08:43:00+02:00",
                 "access": 1,
                 "revoked": False,
             }
@@ -329,20 +326,12 @@ class ProjectTokenInternal(ProjectToken):
 class ProjectTokenCreate(BaseModel):
     name: Optional[str]
     access: int = AccessLevel.WRITE.value
-    expiration_date: datetime
-
-    @validator('expiration_date')
-    def check_expiration_date(cls, value):
-        if value < datetime.now(timezone.utc):
-            raise ValueError('Expiration date must be in the future')
-        return value
 
     class Config:
         schema_extra = {
             "example": {
                 "name": "my project token",
                 "access": 1,
-                "expiration_date": "2041-04-07T08:43:00+02:00",
             }
         }
 

--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -8,12 +8,13 @@ These Pydantic models define more or less a "schema" (a valid data shape).
 So this will help us avoiding confusion while using both.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, EmailStr, Extra, Field, SecretStr
+
 
 class Empty(BaseModel, extra=Extra.forbid):
     pass
@@ -318,10 +319,12 @@ class ProjectToken(BaseModel):
             }
         }
 
+
 # Used to handle responses from the database
 class ProjectTokenInternal(ProjectToken):
     id: Optional[str]
     hashed_token: str
+
 
 class ProjectTokenCreate(BaseModel):
     name: Optional[str]

--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -8,12 +8,12 @@ These Pydantic models define more or less a "schema" (a valid data shape).
 So this will help us avoiding confusion while using both.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr, Extra, Field, SecretStr
+from pydantic import BaseModel, EmailStr, Extra, Field, SecretStr, validator
 
 
 class Empty(BaseModel, extra=Extra.forbid):
@@ -297,13 +297,16 @@ class AccessLevel(Enum):
     READ_WRITE = 3
 
 
+# Used in the responses to the user
 class ProjectToken(BaseModel):
     id: UUID
     project_id: UUID
     name: Optional[str]
-    token: str
+    token: Optional[str]
+    expiration_date: Optional[datetime] = None
     last_used: Optional[datetime] = None
     access: int = AccessLevel.WRITE.value
+    revoked: bool = False
 
     class Config:
         schema_extra = {
@@ -313,20 +316,34 @@ class ProjectToken(BaseModel):
                 "name": "my project token",
                 "token": "8edb03e1-9a28-452a-9c93-a3b6560136d7",
                 "last_used": "2021-04-04T08:43:00+02:00",
+                "expiration_date": "2021-04-07T08:43:00+02:00",
                 "access": 1,
+                "revoked": False,
             }
         }
 
+# Used to handle responses from the database
+class ProjectTokenInternal(ProjectToken):
+    id: Optional[str]
+    hashed_token: str
 
 class ProjectTokenCreate(BaseModel):
     name: Optional[str]
     access: int = AccessLevel.WRITE.value
+    expiration_date: datetime
+
+    @validator('expiration_date')
+    def check_expiration_date(cls, value):
+        if value < datetime.now(timezone.utc):
+            raise ValueError('Expiration date must be in the future')
+        return value
 
     class Config:
         schema_extra = {
             "example": {
                 "name": "my project token",
                 "access": 1,
+                "expiration_date": "2041-04-07T08:43:00+02:00",
             }
         }
 

--- a/carbonserver/carbonserver/api/services/auth_service.py
+++ b/carbonserver/carbonserver/api/services/auth_service.py
@@ -20,7 +20,6 @@ fief = FiefAsync(
     settings.fief_url, settings.fief_client_id, settings.fief_client_secret
 )
 
-
 @dataclass
 class FullUser:
     db_user: dict

--- a/carbonserver/carbonserver/api/services/auth_service.py
+++ b/carbonserver/carbonserver/api/services/auth_service.py
@@ -71,7 +71,6 @@ class UserWithAuthDependency:
             fief_auth_cookie.current_user(optional=True)
         ),
         cookie_token: Optional[str] = Depends(web_scheme),
-        # api_key: Optional[HTTPAuthorizationCredentials] = Depends(web_scheme),
         bearer_token: Optional[str] = Depends(HTTPBearer(auto_error=False)),
         user_service: Optional[UserService] = Depends(
             Provide[ServerContainer.user_service]

--- a/carbonserver/carbonserver/api/services/auth_service.py
+++ b/carbonserver/carbonserver/api/services/auth_service.py
@@ -20,6 +20,7 @@ fief = FiefAsync(
     settings.fief_url, settings.fief_client_id, settings.fief_client_secret
 )
 
+
 @dataclass
 class FullUser:
     db_user: dict

--- a/carbonserver/carbonserver/api/services/project_token_service.py
+++ b/carbonserver/carbonserver/api/services/project_token_service.py
@@ -1,10 +1,15 @@
 from fastapi import HTTPException
 
+from carbonserver.api.infra.api_key_utils import generate_api_key, get_api_key_hash
 from carbonserver.api.infra.repositories.repository_projects_tokens import (
     SqlAlchemyRepository as ProjectTokensSqlRepository,
 )
-from carbonserver.api.infra.api_key_utils import generate_api_key, get_api_key_hash
-from carbonserver.api.schemas import AccessLevel, ProjectToken, ProjectTokenCreate, ProjectTokenInternal
+from carbonserver.api.schemas import (
+    AccessLevel,
+    ProjectToken,
+    ProjectTokenCreate,
+    ProjectTokenInternal,
+)
 
 
 class ProjectTokenService:
@@ -18,8 +23,9 @@ class ProjectTokenService:
             **input_project_token.dict(),
             project_id=project_id,
             hashed_token=hashed_api_key,
-            token=api_key)
-        response_db= self._repository.add_project_token(project_token)
+            token=api_key,
+        )
+        response_db = self._repository.add_project_token(project_token)
 
         # Return the project token with the api key
         return ProjectToken(
@@ -27,8 +33,8 @@ class ProjectTokenService:
             project_id=response_db.project_id,
             name=response_db.name,
             access=response_db.access,
-            token=api_key
-            )
+            token=api_key,
+        )
 
     def delete_project_token(self, project_id, token_id):
         return self._repository.delete_project_token(project_id, token_id)

--- a/carbonserver/carbonserver/api/services/project_token_service.py
+++ b/carbonserver/carbonserver/api/services/project_token_service.py
@@ -3,15 +3,33 @@ from fastapi import HTTPException
 from carbonserver.api.infra.repositories.repository_projects_tokens import (
     SqlAlchemyRepository as ProjectTokensSqlRepository,
 )
-from carbonserver.api.schemas import AccessLevel, ProjectToken, ProjectTokenCreate
+from carbonserver.api.infra.api_key_utils import generate_api_key, get_api_key_hash
+from carbonserver.api.schemas import AccessLevel, ProjectToken, ProjectTokenCreate, ProjectTokenInternal
 
 
 class ProjectTokenService:
     def __init__(self, project_token_repository: ProjectTokensSqlRepository):
         self._repository = project_token_repository
 
-    def add_project_token(self, project_id, project_token: ProjectTokenCreate):
-        return self._repository.add_project_token(project_id, project_token)
+    def add_project_token(self, project_id, input_project_token: ProjectTokenCreate):
+        api_key = generate_api_key()
+        hashed_api_key = get_api_key_hash(api_key=api_key)
+        project_token = ProjectTokenInternal(
+            **input_project_token.dict(),
+            project_id=project_id,
+            hashed_token=hashed_api_key,
+            token=api_key)
+        response_db= self._repository.add_project_token(project_token)
+
+        # Return the project token with the api key
+        return ProjectToken(
+            id=response_db.id,
+            project_id=response_db.project_id,
+            name=response_db.name,
+            access=response_db.access,
+            expiration_date=response_db.expiration_date,
+            token=api_key
+            )
 
     def delete_project_token(self, project_id, token_id):
         return self._repository.delete_project_token(project_id, token_id)
@@ -105,6 +123,7 @@ class ProjectTokenService:
         self._has_access(desired_access, full_project_token)
 
     def _has_access(self, desired_access: int, full_project_token: ProjectToken | None):
+        # TODO: Check if the project token is expired
         if full_project_token:
             has_access = (
                 desired_access == full_project_token.access

--- a/carbonserver/carbonserver/api/services/project_token_service.py
+++ b/carbonserver/carbonserver/api/services/project_token_service.py
@@ -27,7 +27,6 @@ class ProjectTokenService:
             project_id=response_db.project_id,
             name=response_db.name,
             access=response_db.access,
-            expiration_date=response_db.expiration_date,
             token=api_key
             )
 

--- a/carbonserver/carbonserver/database/alembic/versions/54d9cae546ad_project_tokens_hashed.py
+++ b/carbonserver/carbonserver/database/alembic/versions/54d9cae546ad_project_tokens_hashed.py
@@ -25,13 +25,9 @@ def upgrade():
     op.add_column('project_tokens', sa.Column('lookup_value', sa.String(), nullable=False))
     # Add revoked column
     op.add_column('project_tokens', sa.Column('revoked', sa.Boolean(), nullable=False, server_default='false'))
-    # Add expiration_date column
-    op.add_column('project_tokens', sa.Column('expiration_date', sa.DateTime(), nullable=False))
 
 
 def downgrade():
-    # Remove expiration_date column
-    op.drop_column('project_tokens', 'expiration_date')
     # Remove revoked column
     op.drop_column('project_tokens', 'revoked')
     # Remove lookup_value column

--- a/carbonserver/carbonserver/database/alembic/versions/54d9cae546ad_project_tokens_hashed.py
+++ b/carbonserver/carbonserver/database/alembic/versions/54d9cae546ad_project_tokens_hashed.py
@@ -1,0 +1,42 @@
+"""project tokens hashed
+
+Revision ID: 54d9cae546ad
+Revises: 711ce9f88326
+Create Date: 2024-10-15 10:03:34.722490
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '54d9cae546ad'
+down_revision = '711ce9f88326'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Remove token column
+    op.drop_column('project_tokens', 'token')
+    # Add hashed_token column
+    op.add_column('project_tokens', sa.Column('hashed_token', sa.String(), nullable=False))
+    # Add lookup_value column
+    op.add_column('project_tokens', sa.Column('lookup_value', sa.String(), nullable=False))
+    # Add revoked column
+    op.add_column('project_tokens', sa.Column('revoked', sa.Boolean(), nullable=False, server_default='false'))
+    # Add expiration_date column
+    op.add_column('project_tokens', sa.Column('expiration_date', sa.DateTime(), nullable=False))
+
+
+def downgrade():
+    # Remove expiration_date column
+    op.drop_column('project_tokens', 'expiration_date')
+    # Remove revoked column
+    op.drop_column('project_tokens', 'revoked')
+    # Remove lookup_value column
+    op.drop_column('project_tokens', 'lookup_value')
+    # Remove hashed_token column
+    op.drop_column('project_tokens', 'hashed_token')
+    # Add token column
+    op.add_column('project_tokens', sa.Column('token', sa.String(), nullable=True))

--- a/carbonserver/carbonserver/database/alembic/versions/54d9cae546ad_project_tokens_hashed.py
+++ b/carbonserver/carbonserver/database/alembic/versions/54d9cae546ad_project_tokens_hashed.py
@@ -5,34 +5,41 @@ Revises: 711ce9f88326
 Create Date: 2024-10-15 10:03:34.722490
 
 """
-from alembic import op
-import sqlalchemy as sa
 
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '54d9cae546ad'
-down_revision = '711ce9f88326'
+revision = "54d9cae546ad"
+down_revision = "711ce9f88326"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
     # Remove token column
-    op.drop_column('project_tokens', 'token')
+    op.drop_column("project_tokens", "token")
     # Add hashed_token column
-    op.add_column('project_tokens', sa.Column('hashed_token', sa.String(), nullable=False))
+    op.add_column(
+        "project_tokens", sa.Column("hashed_token", sa.String(), nullable=False)
+    )
     # Add lookup_value column
-    op.add_column('project_tokens', sa.Column('lookup_value', sa.String(), nullable=False))
+    op.add_column(
+        "project_tokens", sa.Column("lookup_value", sa.String(), nullable=False)
+    )
     # Add revoked column
-    op.add_column('project_tokens', sa.Column('revoked', sa.Boolean(), nullable=False, server_default='false'))
+    op.add_column(
+        "project_tokens",
+        sa.Column("revoked", sa.Boolean(), nullable=False, server_default="false"),
+    )
 
 
 def downgrade():
     # Remove revoked column
-    op.drop_column('project_tokens', 'revoked')
+    op.drop_column("project_tokens", "revoked")
     # Remove lookup_value column
-    op.drop_column('project_tokens', 'lookup_value')
+    op.drop_column("project_tokens", "lookup_value")
     # Remove hashed_token column
-    op.drop_column('project_tokens', 'hashed_token')
+    op.drop_column("project_tokens", "hashed_token")
     # Add token column
-    op.add_column('project_tokens', sa.Column('token', sa.String(), nullable=True))
+    op.add_column("project_tokens", sa.Column("token", sa.String(), nullable=True))

--- a/carbonserver/tests/api/service/test_project_tokens_service.py
+++ b/carbonserver/tests/api/service/test_project_tokens_service.py
@@ -35,8 +35,7 @@ def test_project_token_service_creates_correct_project_token(_):
 
     project_token_to_create = ProjectTokenCreate(
         name="Project",
-        access=AccessLevel.READ.value,
-        expiration_date="2051-08-27T14:00:00Z",
+        access=AccessLevel.READ.value
     )
 
     actual_saved_project_token = project_token_service.add_project_token(

--- a/carbonserver/tests/api/service/test_project_tokens_service.py
+++ b/carbonserver/tests/api/service/test_project_tokens_service.py
@@ -34,8 +34,7 @@ def test_project_token_service_creates_correct_project_token(_):
     repository_mock.add_project_token.return_value = PROJECT_TOKEN
 
     project_token_to_create = ProjectTokenCreate(
-        name="Project",
-        access=AccessLevel.READ.value
+        name="Project", access=AccessLevel.READ.value
     )
 
     actual_saved_project_token = project_token_service.add_project_token(

--- a/carbonserver/tests/api/service/test_project_tokens_service.py
+++ b/carbonserver/tests/api/service/test_project_tokens_service.py
@@ -36,6 +36,7 @@ def test_project_token_service_creates_correct_project_token(_):
     project_token_to_create = ProjectTokenCreate(
         name="Project",
         access=AccessLevel.READ.value,
+        expiration_date="2051-08-27T14:00:00Z",
     )
 
     actual_saved_project_token = project_token_service.add_project_token(


### PR DESCRIPTION
# 2 Flows
Create token flow:
1. Generate a key
2. Get a look_up value (to make it easier/faster to read from the db)
3. Store hashed key with lookup value


Verify token flow:
1. Get lookup value of the incoming token
2. Look up by that value all possible candidates + other params (e.g. project_id)
3. Hash the incoming token
4. Verify that the hash key is the same as the stored hashed key

Why use `bcrypt` instead of passlib? It seems passlib is abandoned, in FastApi they recommend using bcrypt ==>
https://github.com/fastapi/fastapi/discussions/11773#discussioncomment-10640267

# TODO
- [x] Test create project token + list + delete
- [x] Test post run + post emission (will use the verification of the token)