### PR TITLE
fix: starlette version compatible with fastapi

### DIFF
--- a/requirements/requirements-api.txt
+++ b/requirements/requirements-api.txt
@@ -194,7 +194,7 @@ sqlalchemy==1.4.54
     # via
     #   hatch.envs.api
     #   alembic
-starlette==0.40.0
+starlette
     # via fastapi
 typer==0.12.5
     # via hatch.envs.api


### PR DESCRIPTION
Starlette was not letting fast-api deploy because incompatible versions.
In FastAPI they say not to fix the version of starlette https://fastapi.tiangolo.com/deployment/versions/#about-starlette
@benoit-cty  How can we handle this with `hatch`?