### PR TITLE
fix: lock release when there is a python error

### DIFF
--- a/codecarbon/lock.py
+++ b/codecarbon/lock.py
@@ -4,8 +4,10 @@ It creates a lock file in /tmp/.codecarbon.lock and removes it on exit.
 If the lock file already exists, it exits the program.
 """
 
+import atexit
 import errno
 import os
+import signal
 import tempfile
 
 from codecarbon.external.logger import logger
@@ -19,6 +21,19 @@ class Lock:
 
     def __init__(self):
         self._has_created_lock = False
+
+        atexit.register(
+            self.release
+        )  # Ensure release() is called on unexpected exit of the user's python code
+        # Register signal handlers to ensure lock release on interruption
+        signal.signal(signal.SIGINT, self._handle_exit)  # Ctrl+C
+        signal.signal(signal.SIGTERM, self._handle_exit)  # Termination signal
+
+    def _handle_exit(self, signum, frame):
+        """Ensures the lock file is removed when the script is interrupted."""
+        logger.debug(f"Signal {signum} received. Releasing lock and exiting.")
+        self.release()
+        os._exit(1)  # Exit immediately to prevent further execution
 
     def acquire(self):
         """Creates a lock file and ensures it's the only instance running."""
@@ -41,6 +56,6 @@ class Lock:
             if self._has_created_lock:
                 os.remove(LOCKFILE)
         except OSError as e:
-            logger.error("Error:", e)
+            logger.debug(f"Error: {e}")
             if e.errno != errno.ENOENT:
                 raise


### PR DESCRIPTION
# Before

If there was an error in the user's code

```
tracker.start()

raise ValueError()

tracker.stop() <== this line is never called
```

the lock will not be removed. Meaning the next time you run the same script, you will get an error `Error: Another instance of codecarbon is already running. Turn off the other instance to be able to run this one. Exiting.`

# Now

The lock is removed even if:
* the user does `Ctl + C` to terminate the script
* there is a python error in between start and stop
* Some other error terminates it