### PR TITLE
ui: aclaratory text for token modal

### DIFF
--- a/webapp/src/components/projectTokens/modal.tsx
+++ b/webapp/src/components/projectTokens/modal.tsx
@@ -3,7 +3,6 @@ import React, { useState } from "react";
 import { ClipboardCopy, ClipboardCheck } from "lucide-react";
 import { createProjectToken } from "@/server-functions/projectTokens";
 import GeneralModal from "../ui/modal";
-import { Separator } from "../ui/separator";
 import { Input } from "../ui/input";
 
 interface ModalProps {
@@ -87,6 +86,10 @@ const ProjectTokenModal: React.FC<ModalProps> = ({
                     )}
                 </button>
             </div>
+            <p className="text-l mb-4 p-2">
+                Make sure to copy the token above as it will not be shown again.
+                We don&apos;t store it for security reasons.
+            </p>
         </div>
     );
     return (


### PR DESCRIPTION
Message telling the user to save the token in a safe place because we do not store it:
![image](https://github.com/user-attachments/assets/baca316e-92e1-436a-a1e8-c9224fcd5b4c)
