### PR TITLE
fix: pin versions of hatch and hatchling

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,7 +30,8 @@ jobs:
           python3 .github/check_version.py
     - name: Install dependencies
       run: |
-        pipx install hatch
+        python -m pip install --upgrade pip
+        pip install hatch==1.13.0 hatchling==1.25.0
     - name: Build package
       run: hatch build -c
     - name: Publish package


### PR DESCRIPTION
Known issue in hatchling does not allow hatch to build the package. 
Issue in hatchling ==> https://github.com/pypa/hatch/issues/1793

# Workaround
Fix the versions of hatch and hatchling (I have already done it in the other CI jobs, this is the only one remaining)