### PR TITLE
Raise an exception when another is running

### DIFF
--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -22,7 +22,7 @@ from codecarbon.cli.cli_utils import (
 )
 from codecarbon.core.api_client import ApiClient, get_datetime_with_timezone
 from codecarbon.core.schemas import ExperimentCreate, OrganizationCreate, ProjectCreate
-from codecarbon.emissions_tracker import EmissionsTracker
+from codecarbon.emissions_tracker import AnotherInstanceException, EmissionsTracker
 
 AUTH_CLIENT_ID = os.environ.get(
     "AUTH_CLIENT_ID", "pkqh9CiOkp4MkPqRqM_k8Xc3mwBRpojS3RayIk1i5Pg"
@@ -99,7 +99,7 @@ def show_config(path: Path = Path("./.codecarbon.config")) -> None:
 
 fief = Fief(AUTH_SERVER_URL, AUTH_CLIENT_ID)
 fief_auth = FiefAuth(fief, "./credentials.json")
-print("FIEF", AUTH_SERVER_URL, AUTH_CLIENT_ID)
+# print("FIEF", AUTH_SERVER_URL, AUTH_CLIENT_ID)
 
 
 def _get_access_token():
@@ -319,14 +319,18 @@ def monitor(
     if api and experiment_id is None:
         print("ERROR: No experiment id, call 'codecarbon init' first.", err=True)
     print("CodeCarbon is going in an infinite loop to monitor this machine.")
-    with EmissionsTracker(
-        measure_power_secs=measure_power_secs,
-        api_call_interval=api_call_interval,
-        save_to_api=api,
-    ):
-        # Infinite loop
-        while True:
-            time.sleep(300)
+    try:
+        with EmissionsTracker(
+            measure_power_secs=measure_power_secs,
+            api_call_interval=api_call_interval,
+            save_to_api=api,
+        ):
+            # Infinite loop
+            while True:
+                time.sleep(300)
+    except AnotherInstanceException:
+        print("Another instance of CodeCarbon is already running.")
+        exit(1)
 
 
 def questionary_prompt(prompt, list_options, default):

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -64,6 +64,11 @@ from codecarbon.output import (
 _sentinel = object()
 
 
+# Define an exception to raise when another instance of codecarbon is already running
+class AnotherInstanceException(Exception):
+    pass
+
+
 class BaseEmissionsTracker(ABC):
     """
     Primary abstraction with Emissions Tracking functionality.
@@ -252,7 +257,7 @@ class BaseEmissionsTracker(ABC):
                 )
                 # Do not continue if another instance of codecarbon is running
                 self._another_instance_already_running = True
-                return
+                raise AnotherInstanceException
 
         self._set_from_conf(api_call_interval, "api_call_interval", 8, int)
         self._set_from_conf(api_endpoint, "api_endpoint", "https://api.codecarbon.io")
@@ -515,7 +520,6 @@ class BaseEmissionsTracker(ABC):
     def start(self) -> None:
         """
         Starts tracking the experiment.
-        Currently, Nvidia GPUs are supported.
         :return: None
         """
         # if another instance of codecarbon is already running, stop here
@@ -526,7 +530,7 @@ class BaseEmissionsTracker(ABC):
             logger.warning(
                 "Another instance of codecarbon is already running. Exiting."
             )
-            return
+            raise AnotherInstanceException
         if self._start_time is not None:
             logger.warning("Already started tracking")
             return
@@ -633,7 +637,7 @@ class BaseEmissionsTracker(ABC):
             logger.warning(
                 "Another instance of codecarbon is already running. Exiting."
             )
-            return
+            raise AnotherInstanceException
         if not self._allow_multiple_runs:
             # Release the lock
             self._lock.release()


### PR DESCRIPTION
## Problem
Currently, when running `codecarbon monitor` while another instance is active, the CLI displays "Another instance of codecarbon is already running" but continues its infinite loop instead of terminating. This creates a confusing user experience.

## Solution
Modify the behavior to raise an exception when detecting another running instance, forcing the program to terminate unless the calling code explicitly handles this case.
This makes the error condition more explicit and helps prevent unintended parallel executions of codecarbon monitoring.
Please review and provide feedback on this approach.