### PR TITLE
fix(cli): codecarbon monitor --no-api working again

### DIFF
--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -316,14 +316,17 @@ def monitor(
         api (Annotated[bool, typer.Option, optional): Choose to call Code Carbon API or not. Defaults to True.
     """
     experiment_id = get_existing_local_exp_id()
-    if api and experiment_id is None:
-        print("ERROR: No experiment id, call 'codecarbon init' first.", err=True)
+    token = None
+    if api:
+        if experiment_id is None:
+            print("ERROR: No experiment id, call 'codecarbon init' first.", err=True)
+        token = _get_access_token()
     print("CodeCarbon is going in an infinite loop to monitor this machine.")
     with EmissionsTracker(
         measure_power_secs=measure_power_secs,
         api_call_interval=api_call_interval,
         save_to_api=api,
-        access_token=_get_access_token(),
+        access_token=token,
     ) as tracker:
         # Infinite loop
         while True:


### PR DESCRIPTION
This pull request includes a change to the `monitor` function in the `codecarbon/cli/main.py` file. The change ensures that the access token is only retrieved if the API is enabled.

* [`codecarbon/cli/main.py`](diffhunk://#diff-867adf601dc4438f5179978311c3f810b6d4400ac751334adf433474fbcea4a5L319-R329): Modified the `monitor` function to retrieve the access token only if the API is enabled and an experiment ID is present.