### PR TITLE
Improve arguments consistency in track_emissions decorator

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -912,24 +912,29 @@ def track_emissions(
     save_to_file: Optional[bool] = _sentinel,
     save_to_api: Optional[bool] = _sentinel,
     save_to_logger: Optional[bool] = _sentinel,
+    logging_logger: Optional[LoggerOutput] = _sentinel,
     save_to_prometheus: Optional[bool] = _sentinel,
     save_to_logfire: Optional[bool] = _sentinel,
     prometheus_url: Optional[str] = _sentinel,
     output_handlers: Optional[List[BaseOutput]] = _sentinel,
-    logging_logger: Optional[LoggerOutput] = _sentinel,
-    offline: Optional[bool] = _sentinel,
+    gpu_ids: Optional[List] = _sentinel,
     emissions_endpoint: Optional[str] = _sentinel,
     experiment_id: Optional[str] = _sentinel,
+    experiment_name: Optional[str] = _sentinel,
+    co2_signal_api_token: Optional[str] = _sentinel,
+    tracking_mode: Optional[str] = _sentinel,
+    log_level: Optional[Union[int, str]] = _sentinel,
+    on_csv_write: Optional[str] = _sentinel,
+    logger_preamble: Optional[str] = _sentinel,
+    default_cpu_power: Optional[int] = _sentinel,
+    pue: Optional[int] = _sentinel,
+    allow_multiple_runs: Optional[bool] = _sentinel,
+    offline: Optional[bool] = _sentinel,
     country_iso_code: Optional[str] = _sentinel,
     region: Optional[str] = _sentinel,
     cloud_provider: Optional[str] = _sentinel,
     cloud_region: Optional[str] = _sentinel,
-    gpu_ids: Optional[List] = _sentinel,
-    co2_signal_api_token: Optional[str] = _sentinel,
-    log_level: Optional[Union[int, str]] = _sentinel,
-    default_cpu_power: Optional[int] = _sentinel,
-    pue: Optional[int] = _sentinel,
-    allow_multiple_runs: Optional[bool] = _sentinel,
+    country_2letter_iso_code: Optional[str] = _sentinel,
 ):
     """
     Decorator that supports both `EmissionsTracker` and `OfflineEmissionsTracker`
@@ -938,7 +943,10 @@ def track_emissions(
                          default name is "codecarbon".
     :param measure_power_secs: Interval (in seconds) to measure hardware power usage,
                                defaults to 15.
-    :api_call_interval: Number of measure to make before calling the Code Carbon API.
+    :param api_call_interval: Number of measure to make before calling the Code Carbon API.
+    :param api_endpoint: Optional URL of Code Carbon API endpoint for sending
+                         emissions data.
+    :param api_key: API key for Code Carbon API (mandatory!).
     :param output_dir: Directory path to which the experiment details are logged,
                        defaults to current directory.
     :param output_file: Name of output CSV file, defaults to `emissions.csv`
@@ -948,13 +956,40 @@ def track_emissions(
                         CodeCarbon API, defaults to False.
     :param save_to_logger: Indicates if the emission artifacts should be written
                         to a dedicated logger, defaults to False.
+    :param logging_logger: LoggerOutput object encapsulating a logging.logger
+                        or a Google Cloud logger.
     :param save_to_prometheus: Indicates if the emission artifacts should be
                             pushed to prometheus, defaults to False.
     :param save_to_logfire: Indicates if the emission artifacts should be
                             pushed to logfire, defaults to False.
     :param prometheus_url: url of the prometheus server, defaults to `localhost:9091`.
-    :param logging_logger: LoggerOutput object encapsulating a logging.logger
-                        or a Google Cloud logger.
+    :param output_handlers: List of output handlers to use.
+    :param gpu_ids: User-specified known gpu ids to track.
+                    Defaults to None, which means that all available gpus will be tracked.
+                    It needs to be a list of integers or a comma-separated string.
+                    Valid examples: [1, 3, 4] or "1,2".
+    :param emissions_endpoint: Optional URL of http endpoint for sending emissions
+                               data.
+    :param experiment_id: Id of the experiment.
+    :param experiment_name: Label of the experiment
+    :param co2_signal_api_token: API token for co2signal.com (requires sign-up for
+                                 free beta)
+    :param tracking_mode: One of "process" or "machine" in order to measure the
+                          power consumption due to the entire machine or to try and
+                          isolate the tracked processe's in isolation.
+                          Defaults to "machine".
+    :param log_level: Global codecarbon log level. Accepts one of:
+                      {"debug", "info", "warning", "error", "critical"}.
+                      Defaults to "info".
+    :param on_csv_write: "append" or "update". Whether to always append a new line
+                         to the csv when writing or to update the existing `run_id`
+                         row (useful when calling`tracker.flush()` manually).
+                         Accepts one of "append" or "update". Default is "append".
+    :param logger_preamble: String to systematically include in the logger.
+                            messages. Defaults to "".
+    :param default_cpu_power: cpu power to be used as default if the cpu is not known.
+    :param pue: PUE (Power Usage Effectiveness) of the datacenter.
+    :param allow_multiple_runs: Prevent multiple instances of codecarbon running. Defaults to False.
     :param offline: Indicates if the tracker should be run in offline mode.
     :param country_iso_code: 3 letter ISO Code of the country where the experiment is
                              being run, required if `offline=True`
@@ -969,13 +1004,10 @@ def track_emissions(
                          See https://github.com/mlco2/codecarbon/
                                             blob/master/codecarbon/data/cloud/impact.csv
                          for a list of cloud regions.
-    :param gpu_ids: User-specified known gpu ids to track, defaults to None
-    :param log_level: Global codecarbon log level. Accepts one of:
-                        {"debug", "info", "warning", "error", "critical"}.
-                      Defaults to "info".
-    :param default_cpu_power: cpu power to be used as default if the cpu is not known.
-    :param pue: PUE (Power Usage Effectiveness) of the datacenter.
-    :param allow_multiple_runs: Prevent multiple instances of codecarbon running. Defaults to False.
+    :param country_2letter_iso_code: For use with the CO2Signal emissions API.
+                                     See http://api.electricitymap.org/v3/zones for
+                                     a list of codes and their corresponding
+                                     locations.
 
     :return: The decorated function
     """
@@ -996,44 +1028,52 @@ def track_emissions(
                     output_file=output_file,
                     save_to_file=save_to_file,
                     save_to_logger=save_to_logger,
+                    logging_logger=logging_logger,
                     save_to_prometheus=save_to_prometheus,
                     save_to_logfire=save_to_logfire,
                     prometheus_url=prometheus_url,
                     output_handlers=output_handlers,
-                    logging_logger=logging_logger,
+                    gpu_ids=gpu_ids,
+                    co2_signal_api_token=co2_signal_api_token,
+                    tracking_mode=tracking_mode,
+                    log_level=log_level,
+                    on_csv_write=on_csv_write,
+                    logger_preamble=logger_preamble,
+                    default_cpu_power=default_cpu_power,
+                    pue=pue,
+                    allow_multiple_runs=allow_multiple_runs,
                     country_iso_code=country_iso_code,
                     region=region,
                     cloud_provider=cloud_provider,
                     cloud_region=cloud_region,
-                    gpu_ids=gpu_ids,
-                    log_level=log_level,
-                    co2_signal_api_token=co2_signal_api_token,
-                    default_cpu_power=default_cpu_power,
-                    pue=pue,
-                    allow_multiple_runs=allow_multiple_runs,
+                    country_2letter_iso_code=country_2letter_iso_code,
                 )
             else:
                 tracker = EmissionsTracker(
                     project_name=project_name,
                     measure_power_secs=measure_power_secs,
+                    api_call_interval=api_call_interval,
+                    api_endpoint=api_endpoint,
+                    api_key=api_key,
                     output_dir=output_dir,
                     output_file=output_file,
                     save_to_file=save_to_file,
+                    save_to_api=save_to_api,
                     save_to_logger=save_to_logger,
+                    logging_logger=logging_logger,
                     save_to_prometheus=save_to_prometheus,
                     save_to_logfire=save_to_logfire,
                     prometheus_url=prometheus_url,
                     output_handlers=output_handlers,
-                    logging_logger=logging_logger,
                     gpu_ids=gpu_ids,
-                    log_level=log_level,
                     emissions_endpoint=emissions_endpoint,
                     experiment_id=experiment_id,
-                    api_call_interval=api_call_interval,
-                    api_key=api_key,
-                    api_endpoint=api_endpoint,
-                    save_to_api=save_to_api,
+                    experiment_name=experiment_name,
                     co2_signal_api_token=co2_signal_api_token,
+                    tracking_mode=tracking_mode,
+                    log_level=log_level,
+                    on_csv_write=on_csv_write,
+                    logger_preamble=logger_preamble,
                     default_cpu_power=default_cpu_power,
                     pue=pue,
                     allow_multiple_runs=allow_multiple_runs,


### PR DESCRIPTION
This PR was motivated by the fact that, at the moment, it is not possible to set the `tracking_mode` for the emissions tracker when using the `track_emissions` decorator.

When I was fixing it, I realized that other arguments were also missing, such as `experiment_name`, `on_csv_write`, `logger_preamble`, and `country_2letter_iso_code`.

To make it easier to check for missing arguments in the future, I changed the order of the arguments in the decorator to match the order in the `BaseEmissionsTracker` and `OfflineEmissionsTracker`.
