### PR TITLE
CLI can be called in offline mode without and API endpoint

### DIFF
--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -1,9 +1,9 @@
 import os
+import signal
 import sys
 import time
 from pathlib import Path
 from typing import Optional
-import signal
 
 import questionary
 import requests
@@ -328,19 +328,31 @@ def config():
 
 @codecarbon.command("monitor", short_help="Monitor your machine's carbon emissions.")
 def monitor(
-    measure_power_secs: Annotated[int, typer.Argument(help="Interval between two measures.")] = 10,
-    api_call_interval: Annotated[int, typer.Argument(help="Number of measures between API calls.")] = 30,
-    api: Annotated[bool, typer.Option(help="Choose to call Code Carbon API or not")] = True,
+    measure_power_secs: Annotated[
+        int, typer.Argument(help="Interval between two measures.")
+    ] = 10,
+    api_call_interval: Annotated[
+        int, typer.Argument(help="Number of measures between API calls.")
+    ] = 30,
+    api: Annotated[
+        bool, typer.Option(help="Choose to call Code Carbon API or not")
+    ] = True,
     offline: Annotated[bool, typer.Option(help="Run in offline mode")] = False,
-    country_iso_code: Annotated[str, typer.Option(help="3-letter country ISO code for offline mode")] = None,
-    region: Annotated[str, typer.Option(help="Region/province for offline mode")] = None,
+    country_iso_code: Annotated[
+        str, typer.Option(help="3-letter country ISO code for offline mode")
+    ] = None,
+    region: Annotated[
+        str, typer.Option(help="Region/province for offline mode")
+    ] = None,
 ):
     """Monitor your machine's carbon emissions."""
     if offline:
         if not country_iso_code:
-            print("ERROR: country_iso_code is required for offline mode", file=sys.stderr)
+            print(
+                "ERROR: country_iso_code is required for offline mode", file=sys.stderr
+            )
             raise typer.Exit(1)
-        
+
         tracker = OfflineEmissionsTracker(
             measure_power_secs=measure_power_secs,
             country_iso_code=country_iso_code,
@@ -349,9 +361,12 @@ def monitor(
     else:
         experiment_id = get_existing_local_exp_id()
         if api and experiment_id is None:
-            print("ERROR: No experiment id, call 'codecarbon config' first.", file=sys.stderr)
+            print(
+                "ERROR: No experiment id, call 'codecarbon config' first.",
+                file=sys.stderr,
+            )
             raise typer.Exit(1)
-            
+
         tracker = EmissionsTracker(
             measure_power_secs=measure_power_secs,
             api_call_interval=api_call_interval,
@@ -366,15 +381,16 @@ def monitor(
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
-
     print("CodeCarbon is going in an infinite loop to monitor this machine.")
     print("Press Ctrl+C to stop and save emissions data.")
 
     tracker.start()
     try:
         while True:
-            if (hasattr(tracker, "_another_instance_already_running") 
-                and tracker._another_instance_already_running):
+            if (
+                hasattr(tracker, "_another_instance_already_running")
+                and tracker._another_instance_already_running
+            ):
                 print("Another instance of CodeCarbon is already running. Exiting.")
                 break
             time.sleep(300)
@@ -382,6 +398,7 @@ def monitor(
         print(f"\nError occurred: {e}")
         tracker.stop()
         raise e
+
 
 def questionary_prompt(prompt, list_options, default):
     value = questionary.select(

--- a/docs/edit/usage.rst
+++ b/docs/edit/usage.rst
@@ -15,17 +15,17 @@ Command line
 ~~~~~~~~~~~~
 
 
-Create a minimal configuration file (just follow the prompts) : 
+Create a minimal configuration file (just follow the prompts) :
 
 .. code-block:: console
 
-  codecarbon config  
+  codecarbon config
 
 .. image:: https://asciinema.org/a/667970.svg
             :align: center
             :alt: Init config
             :target: https://asciinema.org/a/667970
-            
+
 You can use the same command to modify an existing config :
 
 .. image:: https://asciinema.org/a/667971.svg
@@ -38,12 +38,12 @@ If you want to track the emissions of a computer without having to modify your c
 
 .. code-block:: console
 
-    codecarbon monitor  
+    codecarbon monitor
 
 You have to stop the monitoring manually with ``Ctrl+C``.
 
-In the following example you will see how to use the CLI to monitor all the emissions of you computer and sending everything 
-to an API running on "localhost:8008" (Or you can start a private local API with "docker-compose up"). Using the public API with 
+In the following example you will see how to use the CLI to monitor all the emissions of you computer and sending everything
+to an API running on "localhost:8008" (Or you can start a private local API with "docker-compose up"). Using the public API with
 this is not supported yet (coming soon!)
 
 .. image:: https://asciinema.org/a/667984.svg
@@ -52,6 +52,11 @@ this is not supported yet (coming soon!)
             :target: https://asciinema.org/a/667984
 
 
+The command line could also works without internet by providing the country code like this:
+
+.. code-block:: console
+
+    codecarbon monitor --offline --country-iso-code FRA
 
 Implementing CodeCarbon in your code allows you to track the emissions of a specific block of code.
 


### PR DESCRIPTION
I was having trouble getting `codecarbon monitor` to work in an offline environment. It seems like OfflineEmissionsTracker is only accessible in the python api. I changed the main CLI script to allow the user to start an offline mode.

Side note, I also could not use `codecarbon config` in this environment - the second prompt, for the api endpoint gave me `FiefAuthNotAuthenticatedError`

The tool could be pretty useful for researchers using HPC clusters and submitting jobs for training/and or other non deep learning hgh compute jobs like simulations, if a clear offline CLI was available