### PR TITLE
Fix SIGTERM handling to allow cleanup code execution

### DIFF
--- a/codecarbon/lock.py
+++ b/codecarbon/lock.py
@@ -38,7 +38,7 @@ class Lock:
         """Ensures the lock file is removed when the script is interrupted."""
         logger.debug(f"Signal {signum} received. Releasing lock and exiting.")
         self.release()
-        os._exit(1)  # Exit immediately to prevent further execution
+        raise SystemExit(1)  # Exit gracefully to prevent further execution
 
     def acquire(self):
         """Creates a lock file and ensures it's the only instance running."""


### PR DESCRIPTION
The current implementation uses `os._exit(1)` in the Lock class's signal handler, which immediately terminates the process without allowing any cleanup code to execute. This prevents important cleanup code in `finally` blocks from being executed.

This PR replaces `os._exit(1)` with `raise SystemExit(1)`, which allows Python to handle the termination gracefully. This ensures that:
- `try/finally` blocks complete their execution
- Context managers can clean up resources
- `atexit` handlers are called
- Other cleanup code has a chance to run

This is particularly important for users who rely on cleanup code in decorators like `@track_emissions` to properly close resources and save data when their application receives a SIGTERM signal.

Fixes issue #768 