### PR TITLE
fix(api): auth context can read project

### DIFF
--- a/carbonserver/carbonserver/api/services/auth_context.py
+++ b/carbonserver/carbonserver/api/services/auth_context.py
@@ -21,9 +21,9 @@ class AuthContext:
         token_repository: ProjectTokensRepository,
         project_repository: ProjectRepository,
     ):
-        self._user_repository = user_repository
-        self._token_repository = token_repository
-        self._project_repository = project_repository
+        self._user_repository: UserRepository = user_repository
+        self._token_repository: ProjectTokensRepository = token_repository
+        self._project_repository: ProjectRepository = project_repository
 
     def isOperationAuthorizedOnOrg(self, organization_id, user: User):
         return self._user_repository.is_user_in_organization(
@@ -38,9 +38,7 @@ class AuthContext:
             return True
         if user is None:
             raise Exception("Not authenticated")
-        return self._user_repository.is_user_read_authorized_on_project(
-            project_id, user.id
-        )
+        return self._user_repository.is_user_authorized_on_project(project_id, user.id)
 
     def can_read_organization(self, organization_id: UUID, user: User):
         return self._user_repository.is_user_in_organization(

--- a/carbonserver/tests/api/service/test_auth_context.py
+++ b/carbonserver/tests/api/service/test_auth_context.py
@@ -1,0 +1,135 @@
+from unittest import mock
+from uuid import UUID
+
+import pytest
+
+from carbonserver.api.infra.repositories.repository_projects import (
+    SqlAlchemyRepository as ProjectRepository,
+)
+from carbonserver.api.infra.repositories.repository_projects_tokens import (
+    SqlAlchemyRepository as ProjectTokensRepository,
+)
+from carbonserver.api.infra.repositories.repository_users import (
+    SqlAlchemyRepository as UserRepository,
+)
+from carbonserver.api.schemas import User
+from carbonserver.api.services.auth_context import AuthContext
+
+# Test Constants
+TEST_USER_ID = UUID("550e8400-e29b-41d4-a716-446655440000")
+TEST_PROJECT_ID = UUID("f52fe339-164d-4c2b-a8c0-f562dfce066d")
+TEST_ORG_ID = UUID("e60afa92-17b7-4720-91a0-1ae91e409ba1")
+TEST_EXPERIMENT_ID = UUID("b4e18750-3721-4131-9e13-603a8b89e73f")
+
+TEST_USER = User(id=TEST_USER_ID, email="test@test.com", name="Test User")
+
+
+@pytest.fixture
+def auth_context():
+    user_repo_mock = mock.Mock(spec=UserRepository)
+    token_repo_mock = mock.Mock(spec=ProjectTokensRepository)
+    project_repo_mock = mock.Mock(spec=ProjectRepository)
+
+    return (
+        AuthContext(
+            user_repository=user_repo_mock,
+            token_repository=token_repo_mock,
+            project_repository=project_repo_mock,
+        ),
+        user_repo_mock,
+        token_repo_mock,
+        project_repo_mock,
+    )
+
+
+def test_is_operation_authorized_on_org(auth_context):
+    context, user_repo_mock, _, _ = auth_context
+    user_repo_mock.is_user_in_organization.return_value = True
+
+    result = context.isOperationAuthorizedOnOrg(TEST_ORG_ID, TEST_USER)
+
+    assert result is True
+    user_repo_mock.is_user_in_organization.assert_called_once_with(
+        organization_id=TEST_ORG_ID, user=TEST_USER
+    )
+
+
+def test_is_operation_authorized_on_project(auth_context):
+    context, user_repo_mock, _, _ = auth_context
+    user_repo_mock.is_user_authorized_on_project.return_value = True
+
+    result = context.isOperationAuthorizedOnProject(TEST_PROJECT_ID, TEST_USER)
+
+    assert result is True
+    user_repo_mock.is_user_authorized_on_project.assert_called_once_with(
+        TEST_PROJECT_ID, TEST_USER.id
+    )
+
+
+def test_can_read_public_project(auth_context):
+    context, _, _, project_repo_mock = auth_context
+    project_repo_mock.is_project_public.return_value = True
+
+    result = context.can_read_project(TEST_PROJECT_ID, None)
+
+    assert result is True
+    project_repo_mock.is_project_public.assert_called_once_with(TEST_PROJECT_ID)
+
+
+def test_can_read_private_project_with_auth(auth_context):
+    context, user_repo_mock, _, project_repo_mock = auth_context
+    project_repo_mock.is_project_public.return_value = False
+    user_repo_mock.is_user_authorized_on_project.return_value = True
+
+    result = context.can_read_project(TEST_PROJECT_ID, TEST_USER)
+
+    assert result is True
+    user_repo_mock.is_user_authorized_on_project.assert_called_once_with(
+        TEST_PROJECT_ID, TEST_USER.id
+    )
+
+
+def test_can_read_private_project_without_auth(auth_context):
+    context, _, _, project_repo_mock = auth_context
+    project_repo_mock.is_project_public.return_value = False
+
+    with pytest.raises(Exception) as exc:
+        context.can_read_project(TEST_PROJECT_ID, None)
+
+    assert str(exc.value) == "Not authenticated"
+
+
+def test_can_read_organization(auth_context):
+    context, user_repo_mock, _, _ = auth_context
+    user_repo_mock.is_user_in_organization.return_value = True
+
+    result = context.can_read_organization(TEST_ORG_ID, TEST_USER)
+
+    assert result is True
+    user_repo_mock.is_user_in_organization.assert_called_once_with(
+        organization_id=TEST_ORG_ID, user=TEST_USER
+    )
+
+
+def test_can_write_organization(auth_context):
+    context, user_repo_mock, _, _ = auth_context
+    user_repo_mock.is_admin_in_organization.return_value = True
+
+    result = context.can_write_organization(TEST_ORG_ID, TEST_USER)
+
+    assert result is True
+    user_repo_mock.is_admin_in_organization.assert_called_once_with(
+        organization_id=TEST_ORG_ID, user=TEST_USER
+    )
+
+
+def test_can_create_run(auth_context):
+    context, user_repo_mock, _, _ = auth_context
+    user_repo_mock.is_user_authorized_on_experiment.return_value = True
+
+    result = context.can_create_run(TEST_EXPERIMENT_ID, TEST_USER)
+
+    assert result is True
+    user_repo_mock.is_user_authorized_on_experiment.assert_called_once_with(
+        TEST_EXPERIMENT_ID, TEST_USER.id
+    )

--- a/carbonserver/tests/api/service/test_auth_context.py
+++ b/carbonserver/tests/api/service/test_auth_context.py
@@ -21,7 +21,9 @@ TEST_PROJECT_ID = UUID("f52fe339-164d-4c2b-a8c0-f562dfce066d")
 TEST_ORG_ID = UUID("e60afa92-17b7-4720-91a0-1ae91e409ba1")
 TEST_EXPERIMENT_ID = UUID("b4e18750-3721-4131-9e13-603a8b89e73f")
 
-TEST_USER = User(id=TEST_USER_ID, email="test@test.com", name="Test User")
+TEST_USER = User(
+    id=TEST_USER_ID, email="test@test.com", name="Test User", is_active=True
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
This is related to https://github.com/mlco2/codecarbon/issues/778.
Get one project did not work because the call to know if the user had enough permissions did not work.
