### PR TITLE
[Issue No. 845] Change to use app.run()

### DIFF
--- a/codecarbon/viz/carbonboard.py
+++ b/codecarbon/viz/carbonboard.py
@@ -270,7 +270,7 @@ def render_app(df: pd.DataFrame):
 def viz(filepath: str, port: int = 8050, debug: bool = False) -> None:
     df = pd.read_csv(filepath)
     app = render_app(df)
-    app.run_server(port=port, debug=debug)
+    app.run(port=port, debug=debug)
 
 
 def main():


### PR DESCRIPTION
The Dash App v3.0+ switches from using app.run_server() to app.run().

Fixes mlco2/codecarbon#845