### PR TITLE
fix(cli): auth error when doing codecarbon login

### DIFF
--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -139,8 +139,8 @@ def api_get():
 def login():
     get_fief_auth().authorize()
     api = ApiClient(endpoint_url=API_URL)  # TODO: get endpoint from config
-    id_token = _get_id_token()
-    api.set_access_token(id_token)
+    access_token = _get_access_token()
+    api.set_access_token(access_token)
     api.check_auth()
 
 


### PR DESCRIPTION
There was an issue after the login via `codecarbon` cli, the wrong token was being checked.