### PR TITLE
Update cpu_power.csv for Intel Xeon W7-2495X

### DIFF
--- a/codecarbon/data/hardware/cpu_power.csv
+++ b/codecarbon/data/hardware/cpu_power.csv
@@ -4817,6 +4817,7 @@ Intel Xeon W-3335,250.0
 Intel Xeon W-3345,250.0
 Intel Xeon W-3365,270.0
 Intel Xeon W-3375,270.0
+Intel Xeon W7-2495X,225.0
 Intel Xeon W3503,130
 Intel Xeon W3505,130
 Intel Xeon W3520,130


### PR DESCRIPTION
Add Intel Xeon W7-2495X CPU TDP.