### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: package
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mlco2/codecarbon/security/code-scanning/6](https://github.com/mlco2/codecarbon/security/code-scanning/6)

To address the issue, we need to add an explicit `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow's jobs to function correctly. 

- **General approach:** Add a top-level `permissions` key for the entire workflow to cover all jobs. If specific jobs require additional permissions, we can override the top-level permissions within those jobs.
- **Specific changes:** Update the `.github/workflows/package.yml` file. Add `permissions` at the workflow root level (before `jobs`) and configure it with minimal privileges (e.g., `contents: read`).
- **Implementation details:** The `contents: read` permission will allow read-only access to repository contents, which is sufficient for most operations in the workflow. If specific jobs need write access to specific components (e.g., `pull-requests: write`), this can be added explicitly within those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
