### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,4 +1,6 @@
 name: package
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/mlco2/codecarbon/security/code-scanning/22](https://github.com/mlco2/codecarbon/security/code-scanning/22)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimum required permissions for the `GITHUB_TOKEN`. Based on the workflow's tasks, the `contents: read` permission is sufficient for most jobs, as they primarily involve checking out code, installing dependencies, and running tests. If any job requires additional permissions (e.g., `pull-requests: write`), we will specify them at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
