### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: build server
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/mlco2/codecarbon/security/code-scanning/20](https://github.com/mlco2/codecarbon/security/code-scanning/20)

To resolve the issue, we need to add a `permissions` block to the workflow file. This block should explicitly define the least privileges required for the workflow tasks. Since the workflow primarily involves installing dependencies, running tests, and setting up a database, it likely only requires read access to repository contents. Write permissions are not visibly required for the tasks in this workflow.

The `permissions` block can be added at the root level of the workflow, applying to all jobs, or to each job individually. For simplicity and consistency, we will add this block at the root level of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
