### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: test-package
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/mlco2/codecarbon/security/code-scanning/19](https://github.com/mlco2/codecarbon/security/code-scanning/19)

To fix the issue, we will add an explicit `permissions` block to the workflow. Since this workflow mostly involves reading repository contents and performing tests, we will set the `contents: read` permission at the workflow level. This will apply to all jobs in the workflow. If any specific job later requires additional permissions, they can be specified individually for that job.

The changes will be made at the root of the workflow file (`.github/workflows/test-package.yml`) by adding a `permissions` block just below the workflow `name`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
