### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -26,6 +26,8 @@ jobs:
       run: uv run task test-api-unit
   test_api_server:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container


### PR DESCRIPTION
Potential fix for [https://github.com/mlco2/codecarbon/security/code-scanning/17](https://github.com/mlco2/codecarbon/security/code-scanning/17)

To resolve the issue, we need to add explicit `permissions` blocks to limit the `GITHUB_TOKEN` privileges to the minimum required. This can be done at the job level by specifying the `permissions` key for the `test_api_server` job. If the job does not require write access, we should set `contents: read` as the minimal permissions.

In this case:
1. Add a `permissions` block to the `test_api_server` job with `contents: read` to restrict the `GITHUB_TOKEN` to read-only access to repository contents.
2. Ensure that no unintended permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
