### PR TITLE
Potential fix for code scanning alert no. 14: Failure to use secure cookies

### DIFF
--- a/carbonserver/carbonserver/api/routers/authenticate.py
+++ b/carbonserver/carbonserver/api/routers/authenticate.py
@@ -118,7 +118,8 @@ async def get_login(
             SESSION_COOKIE_NAME,
             res.json()["access_token"],
             httponly=True,
-            secure=False,
+            secure=True,
+            samesite='Lax',
         )
         return response
 


### PR DESCRIPTION
Potential fix for [https://github.com/mlco2/codecarbon/security/code-scanning/14](https://github.com/mlco2/codecarbon/security/code-scanning/14)

To address the issue, we should ensure that the cookie is always created with secure attributes:
1. Set the `secure` attribute to `True` to ensure the cookie is only transmitted over HTTPS.
2. Add the `samesite` attribute with a value of `'Lax'` to protect against CSRF attacks while allowing some cross-origin requests.
3. Verify that the `httponly` attribute remains set to `True` to prevent JavaScript access to the cookie.

These changes should be applied to the `response.set_cookie` call in the provided code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
