### PR TITLE
fix: redirect to Fief profile page

### DIFF
--- a/webapp/src/components/navbar.tsx
+++ b/webapp/src/components/navbar.tsx
@@ -26,6 +26,7 @@ import CreateOrganizationModal from "./createOrganizationModal";
 import { getOrganizations } from "@/server-functions/organizations";
 import { Button } from "./ui/button";
 
+const USER_PROFILE_URL = process.env.NEXT_PUBLIC_FIEF_BASE_URL; // Redirect to Fief profile to handle profile updates there
 export default function NavBar({
     orgs,
     setSheetOpened,
@@ -255,7 +256,7 @@ export default function NavBar({
                             onClick={() => {
                                 setSelected("profile");
                                 setSheetOpened?.(false);
-                                router.push(`/profile`);
+                                window.location.href = USER_PROFILE_URL!; // Redirect to Fief profile to handle profile updates there
                             }}
                             paddingY={1.5}
                             icon={<UserIcon className={iconStyles} />}


### PR DESCRIPTION
## Description
Profile section now redirects to fief, to handle the user name+ attributes in Fief.

## Related Issue
Resolves #924 

This plus the update of fields in Fief, allows the user to change its name. 
<img width="807" height="500" alt="image" src="https://github.com/user-attachments/assets/388dd400-fa3a-4858-9f34-da59805aa3b3" />
