### PR TITLE
Add carbonboard assets to build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ codecarbon = [
     "data/private_infra/carbon_intensity_per_source.json",
     "data/private_infra/2016/usa_emissions.json",
     "data/private_infra/2023/canada_energy_mix.json",
+    "viz/assets/car_icon.png",
+    "viz/assets/house_icon.png",
+    "viz/assets/tv_icon.png"
 ]
 
 [project.urls]


### PR DESCRIPTION


## Description
Add `carbonboard` PNG's  to package.

## Related Issue
Please link to the issue this PR resolves: will close #957 

## Motivation and Context

Missing images in carbonboard.

## How Has This Been Tested?

`uv build`

```
...
adding 'codecarbon/viz/assets/car_icon.png'
adding 'codecarbon/viz/assets/house_icon.png'
adding 'codecarbon/viz/assets/tv_icon.png'
...
```

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/mlco2/codecarbon/blob/master/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.