### PR TITLE
Specify all labels, including empty ones, when sending data to prometheus

### DIFF
--- a/codecarbon/output_methods/metrics/prometheus.py
+++ b/codecarbon/output_methods/metrics/prometheus.py
@@ -101,37 +101,25 @@ class PrometheusOutput(BaseOutput):
         Send emissions data to push gateway
         """
 
-        # Save the values of the metrics to the local registry
-        duration_gauge.labels(carbon_emission["project_name"]).set(
-            int(carbon_emission["duration"])
-        )
-        emissions_gauge.labels(carbon_emission["project_name"]).set(
-            carbon_emission["emissions"]
-        )
-        emissions_rate_gauge.labels(carbon_emission["project_name"]).set(
-            carbon_emission["emissions_rate"]
-        )
-        cpu_power_gauge.labels(carbon_emission["project_name"]).set(
-            carbon_emission["cpu_power"]
-        )
-        gpu_power_gauge.labels(carbon_emission["project_name"]).set(
-            carbon_emission["gpu_power"]
-        )
-        ram_power_gauge.labels(carbon_emission["project_name"]).set(
-            carbon_emission["ram_power"]
-        )
-        cpu_energy_gauge.labels(carbon_emission["project_name"]).set(
-            carbon_emission["cpu_energy"]
-        )
-        gpu_energy_gauge.labels(carbon_emission["project_name"]).set(
-            carbon_emission["gpu_energy"]
-        )
-        ram_energy_gauge.labels(carbon_emission["project_name"]).set(
-            carbon_emission["ram_energy"]
-        )
-        energy_consumed_gauge.labels(carbon_emission["project_name"]).set(
-            carbon_emission["energy_consumed"]
-        )
+        # We set label values to '' by default because if we set them to None
+        # they get turned into 'None' by gauage.labels(), which is more
+        # confusing than an empty string.
+        labels = dict.fromkeys(labelnames, "")
+        labels["project_name"] = carbon_emission["project_name"]
+
+        for gauge, emission_name in [
+            (duration_gauge, "duration"),
+            (emissions_gauge, "emissions"),
+            (emissions_rate_gauge, "emissions_rate"),
+            (cpu_power_gauge, "cpu_power"),
+            (gpu_power_gauge, "gpu_power"),
+            (ram_power_gauge, "ram_power"),
+            (cpu_energy_gauge, "cpu_energy"),
+            (gpu_energy_gauge, "gpu_energy"),
+            (ram_energy_gauge, "ram_energy"),
+            (energy_consumed_gauge, "energy_consumed"),
+        ]:
+            gauge.labels(**labels).set(carbon_emission[emission_name])
 
         # Send the new metric values
         push_to_gateway(

--- a/tests/output_methods/metrics/test_prometheus.py
+++ b/tests/output_methods/metrics/test_prometheus.py
@@ -1,0 +1,147 @@
+import dataclasses
+import importlib
+import os
+import unittest
+from unittest.mock import patch
+
+from codecarbon.output_methods.emissions_data import EmissionsData
+from codecarbon.output_methods.metrics import prometheus
+
+EMISSIONS_DATA = EmissionsData(
+    timestamp="2021-01-01T00:00:00",
+    project_name="test_project",
+    run_id="test_run_id",
+    experiment_id="test_experiment_id",
+    duration=60,
+    emissions=0.1,
+    emissions_rate=0.01,
+    cpu_power=100,
+    gpu_power=200,
+    ram_power=50,
+    cpu_energy=6000,
+    gpu_energy=12000,
+    ram_energy=3000,
+    energy_consumed=21000,
+    water_consumed=0.2,
+    country_name="test_country",
+    country_iso_code="TC",
+    region="test_region",
+    cloud_provider="test_provider",
+    cloud_region="test_cloud_region",
+    os="test_os",
+    python_version="3.9",
+    codecarbon_version="2.0",
+    cpu_model="test_cpu",
+    cpu_count=8,
+    gpu_model="test_gpu",
+    gpu_count=1,
+    longitude=0.0,
+    latitude=0.0,
+    tracking_mode="test_mode",
+    ram_total_size=16,
+)
+
+
+class TestPrometheusOutput(unittest.TestCase):
+    def setUp(self):
+        importlib.reload(prometheus)
+
+    @patch("codecarbon.output_methods.metrics.prometheus.push_to_gateway")
+    def test_out_method(self, mock_push_to_gateway):
+        output = prometheus.PrometheusOutput("url")
+        output.out(total=EMISSIONS_DATA, delta=EMISSIONS_DATA)
+
+    @patch(
+        "codecarbon.output_methods.metrics.prometheus.push_to_gateway",
+        side_effect=Exception("Test error"),
+    )
+    @patch("codecarbon.external.logger.logger.error")
+    def test_out_method_handles_exception(
+        self, mock_logger_error, mock_push_to_gateway
+    ):
+        output = prometheus.PrometheusOutput("url")
+        output.out(total=EMISSIONS_DATA, delta=EMISSIONS_DATA)
+
+        mock_logger_error.assert_called_once()
+
+    def test_live_out_method_calls_out(self):
+        self.test_out_method()
+
+    @patch("codecarbon.output_methods.metrics.prometheus.basic_auth_handler")
+    def test_auth_handler(self, mock_basic_auth_handler):
+        with patch.dict(
+            os.environ,
+            {"PROMETHEUS_USERNAME": "user", "PROMETHEUS_PASSWORD": "password"},
+        ):
+            output = prometheus.PrometheusOutput("url")
+            output._auth_handler("url", "method", "timeout", "headers", "data")
+            mock_basic_auth_handler.assert_called_with(
+                "url", "method", "timeout", "headers", "data", "user", "password"
+            )
+
+    @patch("codecarbon.output_methods.metrics.prometheus.push_to_gateway")
+    def test_add_emission(self, mock_push_to_gateway):
+        output = prometheus.PrometheusOutput("url")
+        output.add_emission(dataclasses.asdict(EMISSIONS_DATA))
+
+        mock_push_to_gateway.assert_called_once_with(
+            "url",
+            job="codecarbon",
+            registry=prometheus.registry,
+            handler=output._auth_handler,
+        )
+
+        # Verify that the gauges have the correct values
+        labels = dict.fromkeys(prometheus.labelnames, "")
+        labels["project_name"] = "test_project"
+
+        self.assertEqual(
+            prometheus.registry.get_sample_value("codecarbon_duration", labels=labels),
+            60,
+        )
+        self.assertEqual(
+            prometheus.registry.get_sample_value("codecarbon_emissions", labels=labels),
+            0.1,
+        )
+        self.assertEqual(
+            prometheus.registry.get_sample_value(
+                "codecarbon_emissions_rate", labels=labels
+            ),
+            0.01,
+        )
+        self.assertEqual(
+            prometheus.registry.get_sample_value("codecarbon_cpu_power", labels=labels),
+            100,
+        )
+        self.assertEqual(
+            prometheus.registry.get_sample_value("codecarbon_gpu_power", labels=labels),
+            200,
+        )
+        self.assertEqual(
+            prometheus.registry.get_sample_value("codecarbon_ram_power", labels=labels),
+            50,
+        )
+        self.assertEqual(
+            prometheus.registry.get_sample_value(
+                "codecarbon_cpu_energy", labels=labels
+            ),
+            6000,
+        )
+        self.assertEqual(
+            prometheus.registry.get_sample_value(
+                "codecarbon_gpu_energy", labels=labels
+            ),
+            12000,
+        )
+        self.assertEqual(
+            prometheus.registry.get_sample_value(
+                "codecarbon_ram_energy", labels=labels
+            ),
+            3000,
+        )
+        self.assertEqual(
+            prometheus.registry.get_sample_value(
+                "codecarbon_energy_consumed", labels=labels
+            ),
+            21000,
+        )


### PR DESCRIPTION
## Description
Fixing a bug where lack of a complete set of labels when writing to prometheus was causing failures.

## Related Issue
Please link to the issue this PR resolves: 963

## Motivation and Context
Fixes broken prometheus integration.

## How Has This Been Tested?
Added a new test module and ran all existing tests.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/mlco2/codecarbon/blob/master/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.