### PR TITLE
Add unittests for output_methods/file.py

### DIFF
--- a/codecarbon/output_methods/file.py
+++ b/codecarbon/output_methods/file.py
@@ -1,10 +1,8 @@
 import csv
-import dataclasses
 import os
 from typing import List
 
 import pandas as pd
-import warnings
 
 from codecarbon.core.util import backup
 from codecarbon.external.logger import logger
@@ -87,7 +85,7 @@ class FileOutput(BaseOutput):
         Args:
             total: data to save.
 
-        
+
         """
         file_exists: bool = os.path.isfile(self.save_file_path)
         if file_exists and not self.has_valid_headers(total):
@@ -121,7 +119,9 @@ class FileOutput(BaseOutput):
                 for col, val in dict(total.values).items():
                     # Explicitly cast new values to prevent warnings about incompatible dtypes.
                     update_values[col] = df[col].dtype.type(val)
-                df.loc[df.run_id == total.run_id, update_values.keys()] = update_values.values()
+                df.loc[df.run_id == total.run_id, update_values.keys()] = (
+                    update_values.values()
+                )
 
         df.to_csv(self.save_file_path, index=False)
 

--- a/tests/output_methods/test_file.py
+++ b/tests/output_methods/test_file.py
@@ -1,4 +1,3 @@
-import dataclasses
 import os
 import shutil
 import tempfile
@@ -55,7 +54,7 @@ class TestFileOutput(unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
     def test_file_output_initialization(self):
-        file_output = FileOutput("test.csv", self.temp_dir)
+        FileOutput("test.csv", self.temp_dir)
 
     def test_file_output_initialization_invalid_csv_write_mode(self):
         with self.assertRaises(ValueError):
@@ -66,19 +65,17 @@ class TestFileOutput(unittest.TestCase):
             FileOutput("test.csv", "/non/existent/dir")
 
     def test_has_valid_headers_success(self):
-        file_path = os.path.join(self.temp_dir, "test.csv")
         file_output = FileOutput("test.csv", self.temp_dir)
         file_output.out(self.emissions_data, MagicMock())
 
         self.assertTrue(file_output.has_valid_headers(self.emissions_data))
 
     def test_has_valid_headers_failure(self):
-        file_path = os.path.join(self.temp_dir, "test.csv")
         file_output = FileOutput("test.csv", self.temp_dir)
         file_output.out(self.emissions_data, MagicMock())
 
         df = pd.read_csv(os.path.join(self.temp_dir, "test.csv"))
-        df.rename(columns={'wue': 'new_header'}, inplace=True)
+        df.rename(columns={"wue": "new_header"}, inplace=True)
         df.to_csv(os.path.join(self.temp_dir, "test.csv"), index=False)
 
         self.assertFalse(file_output.has_valid_headers(self.emissions_data))


### PR DESCRIPTION
## Description
Add tests for file output.

Also:
* Fix the "update" logic in FileOutput.out() when a single matching row exists. I do not think this ever worked due to passing an `odict_keys` to pandas.at instead of a tuple.
* Add docstrings for file.py
* Drop empty columsn before doing dataframe concatenations to prevent panda warnings.

## Related Issue
Please link to the issue this PR resolves: #972

## Motivation and Context
File output has no unit tests.

## How Has This Been Tested?
All new and existing unittests run.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/mlco2/codecarbon/blob/master/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.