### PR TITLE
chore: add logfire to CI test run

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         # Install the wheel and test dependencies without the source code
         uv pip install dist/*.whl
-        uv pip install pytest pytest-mock requests-mock responses pandas
+        uv pip install pytest pytest-mock requests-mock responses pandas logfire
     - name: Test package integrity
       run: |
         # Run the package integrity tests to verify all data files are included


### PR DESCRIPTION
## Description
As suggested by @cianc. Add logfire to the job that runs the tests of codecarbon in wheel mode. [See original discussion](https://github.com/mlco2/codecarbon/pull/988#issuecomment-3591669920) for more info.

## Related Issue
Please link to the issue this PR resolves: [issue #]

## Motivation and Context
Why is this change required? What problem does it solve?

## How Has This Been Tested?
Please describe in detail how you tested your changes.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTING.md](https://github.com/mlco2/codecarbon/blob/master/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.