### PR TITLE
Fix tracking for NVIDIA Blackwell GPUs (catching pynvml.NVMLError_NotSupported)

### DIFF
--- a/codecarbon/core/gpu.py
+++ b/codecarbon/core/gpu.py
@@ -144,7 +144,7 @@ class GPUDevice:
         try:
             return pynvml.nvmlDeviceGetMemoryInfo(self.handle)
         except pynvml.NVMLError_NotSupported:
-                # this error is currently thrown for the NVIDIA Blackwell GPU, due to memory sharing on NVIDIA DGX Spark
+            # error thrown for the NVIDIA Blackwell GPU of DGX Spark, due to memory sharing -> return defaults instead
             return pynvml.c_nvmlMemory_t(-1, -1, -1)
 
     def _get_temperature(self) -> int:


### PR DESCRIPTION
## Description
Added error catching for the static GPU memory information. Behavior only changes when the `pynvml` call is not successful.

## Related Issue
https://github.com/mlco2/codecarbon/issues/1037

## Motivation and Context
For the [NVIDIA DGX Spark](https://www.nvidia.com/en-gb/products/workstations/dgx-spark/), CodeCarbon trackers currently cannot be correctly initialized. When debugging into that, I noticed that calling `pynvml.nvmlDeviceGetMemoryInfo` in `codecarbon/core/gpu.py` throws an `pynvml.NVMLError_NotSupported`, probably due to the shared memore architecture of the NVIDIA Blackwell GPU (internally read as NVIDIA GB10). 

## How Has This Been Tested?
Locally tested tracking functionality after the fix.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/mlco2/codecarbon/blob/master/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.