### PR TITLE
docs(quickstart): port login + no-api guidance to markdown docs

### DIFF
--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -20,6 +20,12 @@ codecarbon config
 
 [![Init config](https://asciinema.org/a/667970.svg){.align-center}](https://asciinema.org/a/667970)
 
+Then login from your terminal to authenticate CLI/API usage:
+
+``` console
+codecarbon login
+```
+
 You can use the same command to modify an existing config :
 
 [![Modify config](https://asciinema.org/a/667971.svg){.align-center}](https://asciinema.org/a/667971)
@@ -32,6 +38,13 @@ codecarbon monitor
 ```
 
 You have to stop the monitoring manually with `Ctrl+C`.
+
+If you only need local measurement and do not want to send data to the API,
+use:
+
+``` console
+codecarbon monitor --no-api
+```
 
 If you want to detect the hardware of your computer without starting any
 measurement, you can use:


### PR DESCRIPTION
## Summary
This ports the same quickstart guidance from #1079 to the new Markdown docs structure (docs migration branch):

- adds `codecarbon login` right after `codecarbon config`
- adds local-only `codecarbon monitor --no-api` guidance in CLI quickstart

## Scope
- File updated: `docs/getting-started/usage.md`
- Base branch: `docs/port-to-zensical`

Related:
- #928
- #1079 (same content in legacy RST docs)
