### PR TITLE
fix: add CNAME for docs.codecarbon.io custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.codecarbon.io


### PR DESCRIPTION
Adds CNAME file to gh-pages so GitHub Pages serves the docs at https://docs.codecarbon.io/

**Context:** The site shows "There isn't a GitHub Pages site here" at docs.codecarbon.io because the custom domain wasn't configured. The CNAME file tells GitHub Pages to serve this branch at this domain.

**Also:** Ensure Settings > Pages > Custom domain is set to docs.codecarbon.io and DNS has a CNAME record: docs.codecarbon.io -> mlco2.github.io