### PR TITLE
fix: add CNAME to deploy script and site_url for docs.codecarbon.io

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: CodeCarbon
 site_description: Measure and reduce carbon emissions from computing - Official Documentation
-site_url: https://mlco2.github.io/codecarbon/
+site_url: https://docs.codecarbon.io/
 docs_dir: docs
 site_dir: site
 repo_url: https://github.com/mlco2/codecarbon

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -68,6 +68,8 @@ cat > index.html << 'HTMLEOF'
 </html>
 HTMLEOF
 
+echo "docs.codecarbon.io" > CNAME
+
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 git add -A


### PR DESCRIPTION
**Will this trigger the workflow?** Yes. The deploy-docs workflow runs on push to `master` when `scripts/deploy-docs.sh` or `mkdocs.yml` changes. Merging this PR will trigger a deploy that pushes to gh-pages with the CNAME file included.

**Changes:**
- `scripts/deploy-docs.sh`: Write CNAME file (`docs.codecarbon.io`) on every deploy so future deploys always include the custom domain
- `mkdocs.yml`: Set `site_url` to `https://docs.codecarbon.io/` for correct asset paths when served from the custom domain

**Related:** PR #1085 adds CNAME directly to gh-pages for immediate fix. This PR ensures master has the fix so the deploy workflow keeps CNAME on every future deploy.

Made with [Cursor](https://cursor.com)