### PR TITLE
fix: use .deploy-docs-workdir to avoid deploy/ folder conflict in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ venv.bak/
 # mkdocs documentation
 /site
 /deploy
+.deploy-docs-workdir/
 
 # mypy
 .mypy_cache/

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -9,7 +9,7 @@ VERSION_FULL="${1:?Usage: deploy-docs.sh VERSION_FULL}"
 VERSION_MINOR="${VERSION_FULL%.*}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SITE_DIR="${2:-site}"
-DEPLOY_DIR="${3:-deploy}"
+DEPLOY_DIR="${3:-.deploy-docs-workdir}"
 
 cd "$REPO_ROOT"
 mkdir -p "$DEPLOY_DIR"


### PR DESCRIPTION
Fixes CI failure in deploy-docs workflow:

```
error: The following untracked working tree files would be overwritten by checkout:
	.env.example
	deploy.py
	...
```

The deploy script used `deploy/` as workdir, which conflicts with the repo's `deploy/` folder. Use isolated `.deploy-docs-workdir` instead.

Made with [Cursor](https://cursor.com)