### PR TITLE
fix: update geolocation fallback API and use static country code mapping

### DIFF
--- a/codecarbon/external/geography.py
+++ b/codecarbon/external/geography.py
@@ -3,10 +3,10 @@ Encapsulates external dependencies to retrieve cloud and geographical metadata
 """
 
 import re
-import urllib.parse
 from dataclasses import dataclass
 from typing import Callable, Dict, Optional
 
+import pycountry
 import requests
 
 from codecarbon.core.cloud import get_env_cloud_details
@@ -93,10 +93,14 @@ class GeoMetadata:
         try:
             response: Dict = requests.get(url, timeout=0.5).json()
 
+            region = response.get("region", "").lower()
+            if not region:
+                raise ValueError("Region is empty")
+
             return cls(
                 country_iso_code=response["country_code3"].upper(),
                 country_name=response["country"],
-                region=response.get("region", "").lower(),
+                region=region,
                 latitude=float(response.get("latitude")),
                 longitude=float(response.get("longitude")),
                 country_2letter_iso_code=response.get("country_code"),
@@ -107,32 +111,36 @@ class GeoMetadata:
                 f"Unable to access geographical location through primary API. Will resort to using the backup API - Exception : {e} - url={url}"
             )
 
-        geo_url_backup = "https://ip-api.com/json/"
+        geo_url_backup = "https://ipinfo.io/json"
 
         try:
             geo_response: Dict = requests.get(geo_url_backup, timeout=0.5).json()
-            country_name = geo_response["country"]
 
-            # The previous request does not return the three-letter country code
-            country_code_3_url = f"https://api.first.org/data/v1/countries?q={urllib.parse.quote_plus(country_name)}&scope=iso"
-            country_code_response: Dict = requests.get(
-                country_code_3_url, timeout=0.5
-            ).json()
+            # extract latitude and longitude from loc (e.g., "loc": "37.4056,-122.0775")
+            loc = geo_response.get("loc", "").split(",")
+            latitude = float(loc[0]) if len(loc) == 2 else 0.0
+            longitude = float(loc[1]) if len(loc) == 2 else 0.0
+
+            # Retrieve the 3-letter ISO code using pycountry
+            country_2letter_iso_code = geo_response.get("country")
+            country = pycountry.countries.get(alpha_2=country_2letter_iso_code)
+
+            # Some countries might not be found or mapped perfectly
+            country_iso_code = country.alpha_3 if country else ""
+            country_name = country.name if country else ""
 
             return cls(
-                country_iso_code=next(
-                    iter(country_code_response["data"].keys())
-                ).upper(),
+                country_iso_code=country_iso_code.upper(),
                 country_name=country_name,
-                region=geo_response.get("regionName", "").lower(),
-                latitude=float(geo_response.get("lat")),
-                longitude=float(geo_response.get("lon")),
-                country_2letter_iso_code=geo_response.get("countryCode"),
+                region=geo_response.get("region", "").lower(),
+                latitude=latitude,
+                longitude=longitude,
+                country_2letter_iso_code=country_2letter_iso_code,
             )
         except Exception as e:
             # If both API calls fail, default to Canada
             logger.warning(
-                f"Unable to access geographical location. Using 'Canada' as the default value - Exception : {e} - url={url}"
+                f"Unable to access geographical location through fallback API. Using 'Canada' as the default value - Exception : {e} - url={geo_url_backup}"
             )
 
             return cls(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "questionary",
     "rich",
     "typer",
+    "pycountry",
 ]
 
 [tool.setuptools.dynamic]

--- a/tests/test_geography.py
+++ b/tests/test_geography.py
@@ -9,7 +9,6 @@ from tests.testdata import (
     CLOUD_METADATA_AZURE,
     CLOUD_METADATA_GCP,
     CLOUD_METADATA_GCP_EMPTY,
-    COUNTRY_METADATA_USA,
     GEO_METADATA_CANADA,
     GEO_METADATA_USA,
     GEO_METADATA_USA_BACKUP,
@@ -91,14 +90,27 @@ class TestGeoMetadata(unittest.TestCase):
         )
         responses.add(
             responses.GET,
-            "https://ip-api.com/json/",
+            "https://ipinfo.io/json",
             json=GEO_METADATA_USA_BACKUP,
             status=200,
         )
+        geo = GeoMetadata.from_geo_js(self.geo_js_url)
+        self.assertEqual("USA", geo.country_iso_code)
+        self.assertEqual("United States", geo.country_name)
+        self.assertEqual("illinois", geo.region)
+
+    @responses.activate
+    def test_geo_metadata_empty_region_fallback(self):
+        empty_region_response = GEO_METADATA_USA.copy()
+        empty_region_response["region"] = ""
+
+        responses.add(
+            responses.GET, self.geo_js_url, json=empty_region_response, status=200
+        )
         responses.add(
             responses.GET,
-            "https://api.first.org/data/v1/countries?q=United%20States&scope=iso",
-            json=COUNTRY_METADATA_USA,
+            "https://ipinfo.io/json",
+            json=GEO_METADATA_USA_BACKUP,
             status=200,
         )
         geo = GeoMetadata.from_geo_js(self.geo_js_url)

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -19,38 +19,14 @@ GEO_METADATA_USA = {
 }
 
 GEO_METADATA_USA_BACKUP = {
-    "organization_name": "foobar",
-    "regionName": "Illinois",
-    "accuracy": 1,
-    "asn": 0,
-    "organization": "foobar",
-    "timezone": "America/Chicago",
-    "lon": "88",
-    "area_code": "0",
     "ip": "foobar",
     "city": "Chicago",
-    "country": "United States",
-    "countryCode": "US",
-    "lat": "0",
-}
-
-COUNTRY_METADATA_USA = {
-    "status": "OK",
-    "status-code": 200,
-    "version": "1.0",
-    "access": "public",
-    "data": {
-        "USA": {
-            "id": "USA",
-            "country": "United States of America (the)",
-            "region": "North America",
-        },
-        "UMI": {
-            "id": "UMI",
-            "country": "United States Minor Outlying Islands (the)",
-            "region": "Oceania",
-        },
-    },
+    "region": "Illinois",
+    "country": "US",
+    "loc": "0,88",
+    "org": "foobar",
+    "postal": "60601",
+    "timezone": "America/Chicago",
 }
 
 GEO_METADATA_CANADA = {

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -332,6 +332,7 @@ dependencies = [
     { name = "prometheus-client" },
     { name = "psutil" },
     { name = "py-cpuinfo" },
+    { name = "pycountry" },
     { name = "pydantic" },
     { name = "questionary" },
     { name = "rapidfuzz" },
@@ -391,6 +392,7 @@ requires-dist = [
     { name = "prometheus-client" },
     { name = "psutil", specifier = ">=6.0.0" },
     { name = "py-cpuinfo" },
+    { name = "pycountry" },
     { name = "pydantic" },
     { name = "questionary" },
     { name = "rapidfuzz" },
@@ -1611,6 +1613,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
+name = "pycountry"
+version = "26.2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/061b9e7a48b85cfd69f33c33d2ef784a531c359399ad764243399673c8f5/pycountry-26.2.16.tar.gz", hash = "sha256:5b6027d453fcd6060112b951dd010f01f168b51b4bf8a1f1fc8c95c8d94a0801", size = 7711342, upload-time = "2026-02-17T03:42:52.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl", hash = "sha256:115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a", size = 8044600, upload-time = "2026-02-17T03:42:49.777Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Fixes geolocation fallback API call

### Issue 1

The fallback API will always fail when using the HTTPS endpoint

```
curl https://ip-api.com/json/
{"status":"fail","message":"SSL unavailable for this endpoint, order a key at https://members.ip-api.com/"}%
```

Using the HTTP endpoint is not great because this could expose the application location to eavesdropper and be vulnerable to man-in-the-middle.

### Issue 2

If the fallback API call fails, it reports on the wrong URL on the exception: https://github.com/ucodia/codecarbon/blob/ebc8d1a3f5dcae9013dcbe6883d05e711ad6ce28/codecarbon/external/geography.py#L136

### Non-issue 1

The current fallback relies on another API to map the 2 letters country code to a 3 letters code. This is static data that almost never changes, by switching to a static mapping provider we can make the fallback more resilient.

## Related Issue

Fixes #1101 

## Motivation and Context

Certain IP ranges are not covered by the primary API and therefore a fallback is necessary otherwise CodeCarbon client will estimate on the wrong energy mix.

## How Has This Been Tested?

- Unit testing
- Tested in production environment

## Screenshots (if appropriate):

N/A

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/mlco2/codecarbon/blob/master/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.