### PR TITLE
fix(logger): preserve user-defined handlers in set_logger_format()

### DIFF
--- a/codecarbon/external/logger.py
+++ b/codecarbon/external/logger.py
@@ -13,9 +13,12 @@ def set_logger_format(custom_preamble: Optional[str] = ""):
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
 
-    if logger.hasHandlers():
-        logger.handlers.clear()
-
+    logger.handlers = [
+        h
+        for h in logger.handlers
+        if isinstance(h, logging.FileHandler)
+        or not isinstance(h, logging.StreamHandler)
+    ]
     logger.addHandler(handler)
 
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,59 @@
+import logging
+import os
+import tempfile
+import unittest
+
+from codecarbon.external.logger import logger, set_logger_format
+
+
+class TestSetLoggerFormat(unittest.TestCase):
+    """Tests for issue #375 — set_logger_format() must not clear user-defined handlers."""
+
+    def setUp(self):
+        self._original_handlers = logger.handlers[:]
+
+    def tearDown(self):
+        logger.handlers = self._original_handlers
+
+    def test_file_handler_preserved_after_set_logger_format(self):
+        """A FileHandler added by the user must survive a call to set_logger_format()."""
+        with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            fh = logging.FileHandler(tmp_path)
+            fh.setLevel(logging.DEBUG)
+            logger.addHandler(fh)
+
+            # set_logger_format() is called automatically inside EmissionsTracker.__init__
+            # It must NOT remove the user's FileHandler
+            set_logger_format()
+
+            file_handlers = [
+                h for h in logger.handlers if isinstance(h, logging.FileHandler)
+            ]
+            self.assertEqual(
+                len(file_handlers),
+                1,
+                "FileHandler must survive a call to set_logger_format()",
+            )
+        finally:
+            fh.close()
+            os.unlink(tmp_path)
+
+    def test_stream_handler_not_duplicated(self):
+        """Calling set_logger_format() twice must not duplicate the StreamHandler."""
+        set_logger_format()
+        set_logger_format()
+
+        stream_handlers = [
+            h for h in logger.handlers if type(h) is logging.StreamHandler
+        ]
+        self.assertEqual(
+            len(stream_handlers),
+            1,
+            "Only one StreamHandler should exist after two calls to set_logger_format()",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
`set_logger_format()` was calling `logger.handlers.clear()` which removed **all** handlers registered on the CodeCarbon logger, including any `FileHandler` instances added by the user. As a result, it was impossible to capture initialization logs to a file — any handler configured before or during `EmissionsTracker()` was silently destroyed.

The fix replaces the unconditional `handlers.clear()` with a targeted filter that only removes pure `StreamHandler` instances (i.e. terminal output), while preserving `FileHandler` and any other custom handlers added by the user.

## Related Issue
Closes #375

## Motivation and Context
Users who want to redirect CodeCarbon logs to a file (e.g. for long-running training jobs) cannot do so reliably. Any `FileHandler` added to the logger is destroyed every time `EmissionsTracker()` is instantiated, because `set_logger_format()` is called unconditionally in `__init__` and clears all handlers.

## How Has This Been Tested?
Two unit tests were added in `tests/test_logger.py`:

- `test_file_handler_preserved_after_set_logger_format`: adds a `FileHandler` to the logger, calls `set_logger_format()`, and asserts the `FileHandler` is still present.
- `test_stream_handler_not_duplicated`: calls `set_logger_format()` twice and asserts there is still only one `StreamHandler`, verifying the original intent of the deduplication logic is preserved.

Both tests pass: `uv run pytest tests/test_logger.py -v`

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/mlco2/codecarbon/blob/master/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.