### PR TITLE
Fix warning KeyError: 'gpu_index'

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -978,9 +978,10 @@ class BaseEmissionsTracker(ABC):
             if isinstance(hardware, GPU):
                 gpu_ids_to_monitor = hardware.gpu_ids
                 gpu_details = hardware.devices.get_gpu_details()
-                for gpu_detail in gpu_details:
+                for gpu_index, gpu_detail in enumerate(gpu_details):
+                    resolved_gpu_index = gpu_detail.get("gpu_index", gpu_index)
                     if (
-                        gpu_detail["gpu_index"] in gpu_ids_to_monitor
+                        resolved_gpu_index in gpu_ids_to_monitor
                         and "gpu_utilization" in gpu_detail
                     ):
                         self._gpu_utilization_history.append(

--- a/tests/test_emissions_tracker.py
+++ b/tests/test_emissions_tracker.py
@@ -117,6 +117,33 @@ class TestCarbonTracker(unittest.TestCase):
         self.assertIsInstance(emissions, float)
         self.assertAlmostEqual(emissions, 6.262572537957655e-05, places=2)
 
+    def test_monitor_power_uses_gpu_detail_position_when_gpu_index_is_missing(
+        self,
+        mock_cli_setup,
+        mock_log_values,
+        mocked_get_gpu_details,
+        mocked_env_cloud_details,
+        mocked_is_gpu_details_available,
+        mocked_is_nvidia_system,
+    ):
+        tracker = EmissionsTracker(measure_power_secs=1, save_to_file=False)
+
+        mock_gpu = mock.MagicMock()
+        from codecarbon.external.hardware import GPU
+
+        mock_gpu.__class__ = GPU
+        mock_gpu.gpu_ids = [0, 1]
+        mock_gpu.devices = mock.MagicMock()
+        mock_gpu.devices.get_gpu_details.return_value = [
+            {"gpu_utilization": 10},
+            {"gpu_index": 1, "gpu_utilization": 25},
+        ]
+        tracker._hardware = [mock_gpu]
+
+        tracker._monitor_power()
+
+        self.assertEqual([10, 25], tracker._gpu_utilization_history)
+
     @mock.patch("codecarbon.external.geography.requests.get")
     def test_carbon_tracker_timeout(
         self,


### PR DESCRIPTION
## Description

Fix warning in `tests/test_emissions_tracker.py::TestCarbonTracker::test_carbon_tracker_TWO_GPU_PRIVATE_INFRA_CANADA`:

```
=============================== warnings summary ===============================
tests/test_emissions_tracker.py::TestCarbonTracker::test_carbon_tracker_TWO_GPU_PRIVATE_INFRA_CANADA
  /home/runner/work/codecarbon/codecarbon/.venv/lib/python3.12/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-17
  
  Traceback (most recent call last):
    File "/home/runner/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
      self.run()
    File "/home/runner/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/threading.py", line 1433, in run
      self.function(*self.args, **self.kwargs)
    File "/home/runner/work/codecarbon/codecarbon/.venv/lib/python3.12/site-packages/codecarbon/external/scheduler.py", line 42, in _run
      self.function(*self.args, **self.kwargs)
    File "/home/runner/work/codecarbon/codecarbon/.venv/lib/python3.12/site-packages/codecarbon/emissions_tracker.py", line 983, in _monitor_power
      gpu_detail["gpu_index"] in gpu_ids_to_monitor
      ~~~~~~~~~~^^^^^^^^^^^^^
  KeyError: 'gpu_index'
```

## Motivation and Context

It's only a warning but it looks like an error.

The thread warning was caused by the background GPU utilization sampler assuming every GPU detail dict contains gpu_index. I fixed that in emissions_tracker.py:982 by falling back to the position in the returned GPU details list when the key is missing, which keeps subset filtering working and avoids the KeyError.

## How Has This Been Tested?

```
❯ uv run python -m pytest tests/test_emissions_tracker.py
=========================================================== test session starts ===========================================================
platform linux -- Python 3.13.7, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/benoit/CODECARBON/codecarbon
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: logfire-4.29.0, cov-7.0.0, requests-mock-1.12.1
collected 20 items                                                                                                                        

tests/test_emissions_tracker.py ....................                                                                                [100%]

=========================================================== 20 passed in 25.02s =================================
```


## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/mlco2/codecarbon/blob/master/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.