### PR TITLE
docs: clarify tracking_mode affects RAM and CPU

### DIFF
--- a/docs/how-to/configuration.md
+++ b/docs/how-to/configuration.md
@@ -84,6 +84,33 @@ Yields attributes:
     which relies on the [INI
     syntax](https://docs.python.org/3/library/configparser.html#supported-ini-file-structure).
 
+## Tracking Mode
+
+The `tracking_mode` parameter controls how CodeCarbon measures power consumption. It accepts two values:
+
+- **`"machine"`** (default): Measures power for the entire machine — total RAM in use and total CPU load across all processes.
+- **`"process"`**: Isolates measurements to the tracked process — only the process's RAM usage and its share of CPU time are used to estimate power.
+
+This setting affects **RAM and CPU** measurements. GPU power is always measured at the device level regardless of tracking mode.
+
+Set it in your config file:
+
+``` ini
+[codecarbon]
+tracking_mode = process
+```
+
+Or directly in code:
+
+``` python
+EmissionsTracker(tracking_mode="process")
+```
+
+!!! note "Note"
+
+    `"process"` mode gives a lower-bound estimate of your code's footprint.
+    `"machine"` mode is more conservative and accounts for all activity on the system.
+
 ## Access internet through proxy server
 
 If you need a proxy to access internet, which is needed to call a Web

--- a/docs/how-to/configuration.md
+++ b/docs/how-to/configuration.md
@@ -122,6 +122,33 @@ EmissionsTracker(electricitymaps_api_token="your-token-here")
     compatibility but is deprecated and will be removed in a future version.
     Use `electricitymaps_api_token` instead.
 
+## Tracking Mode
+
+The `tracking_mode` parameter controls how CodeCarbon measures power consumption. It accepts two values:
+
+- **`"machine"`** (default): Measures power for the entire machine — total RAM in use and total CPU load across all processes.
+- **`"process"`**: Isolates measurements to the tracked process — only the process's RAM usage and its share of CPU time are used to estimate power.
+
+This setting affects **RAM and CPU** measurements. GPU power is always measured at the device level regardless of tracking mode.
+
+Set it in your config file:
+
+``` ini
+[codecarbon]
+tracking_mode = process
+```
+
+Or in code:
+
+``` python
+EmissionsTracker(tracking_mode="process")
+```
+
+!!! note "Note"
+
+    `"process"` mode gives a lower-bound estimate of your code's footprint.
+    `"machine"` mode is more conservative and accounts for all activity on the system.
+
 ## Access internet through proxy server
 
 If you need a proxy to access internet, which is needed to call a Web


### PR DESCRIPTION
Closes #484

The `tracking_mode` parameter appears in config examples throughout the docs but was never explained. This PR adds a dedicated section to `configuration.md` that clarifies:

- Accepted values: `"machine"` (default) and `"process"`
- That it affects both RAM and CPU power measurement (not just RAM)
- That GPU is unaffected
- Usage examples for config file and Python code