### PR TITLE
feat: Improve Discord community references throughout docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 Estimate and track carbon emissions from your computer, quantify and analyze their impact.
 
-[![](https://img.shields.io/pypi/v/codecarbon?color=024758)](https://pypi.org/project/codecarbon/) [![DOI](https://zenodo.org/badge/263364731.svg)](https://zenodo.org/badge/latestdoi/263364731) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/mlco2/codecarbon/badge)](https://scorecard.dev/viewer/?uri=github.com/mlco2/codecarbon) [![codecov](https://codecov.io/gh/mlco2/codecarbon/graph/badge.svg)](https://codecov.io/gh/mlco2/codecarbon)
+[![](https://img.shields.io/pypi/v/codecarbon?color=024758)](https://pypi.org/project/codecarbon/) [![DOI](https://zenodo.org/badge/263364731.svg)](https://zenodo.org/badge/latestdoi/263364731) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/mlco2/codecarbon/badge)](https://scorecard.dev/viewer/?uri=github.com/mlco2/codecarbon) [![codecov](https://codecov.io/gh/mlco2/codecarbon/graph/badge.svg)](https://codecov.io/gh/mlco2/codecarbon) [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?logo=discord&logoColor=white)](https://discord.gg/GS9js2XkJR)
 
 - **A lightweight, easy to use Python library** – Simple API to track emissions
 - **Open source, free & community driven** – Built by and for the community
 - **Effective visual outputs** – Put emissions in context with real-world equivalents
 
 > **Tracking GenAI API calls?** CodeCarbon measures emissions from **local computing** (your hardware). To track emissions from remote GenAI API calls (OpenAI, Anthropic, Mistral, etc.), use [**EcoLogits**](https://ecologits.ai/). Both tools are complementary.
+
+> **Join the community!** Have questions, want to share your work, or contribute? Join us on [**Discord**](https://discord.gg/GS9js2XkJR) – we're here to help and excited to hear from you!
 
 ## Installation
 
@@ -97,6 +99,7 @@ You can visualize your experiment emissions on the [dashboard](https://dashboard
 | [Framework examples (scikit-learn)](https://docs.codecarbon.io/latest/how-to/scikit-learn/) | Task-oriented ML framework examples |
 | [Methodology](https://docs.codecarbon.io/latest/explanation/methodology/) | How emissions are calculated |
 | [EcoLogits](https://ecologits.ai/) | Track emissions from GenAI API calls |
+| [Discord Community](https://discord.gg/GS9js2XkJR) | Chat with us and the community |
 
 ## Links
 

--- a/docs/explanation/faq.md
+++ b/docs/explanation/faq.md
@@ -39,7 +39,7 @@ Yes. CodeCarbon can be installed and used in Docker containers just like any oth
 
 ## How can I help?
 
-If you find any functionality missing in the CodeCarbon repo, please [open an issue](https://github.com/mlco2/codecarbon/issues) so that you (and others!) can help add it. We did our best to cover all use cases and options, but we count on the open source community to help make the package an even greater success.
+If you find any functionality missing in the CodeCarbon repo, please [open an issue](https://github.com/mlco2/codecarbon/issues) so that you (and others!) can help add it. We did our best to cover all use cases and options, but we count on the open source community to help make the package an even greater success. You can also discuss ideas on [Discord](https://discord.gg/GS9js2XkJR) before diving into development.
 
 ## Is my data sent anywhere?
 
@@ -55,3 +55,5 @@ Please open an issue on [GitHub](https://github.com/mlco2/codecarbon/issues) wit
 - Your environment details
 - Steps to reproduce
 - Expected vs actual behavior
+
+You can also report bugs and ask for help on [Discord](https://discord.gg/GS9js2XkJR) where we can provide quick guidance.

--- a/docs/how-to/cloud-api.md
+++ b/docs/how-to/cloud-api.md
@@ -62,4 +62,3 @@ save_to_api = true
 ## View Your Results
 
 Once your runs complete, visit the [CodeCarbon dashboard](https://dashboard.codecarbon.io/) to see your results. For more visualization options, see the [visualization guide](visualize.md).
-

--- a/docs/how-to/cloud-api.md
+++ b/docs/how-to/cloud-api.md
@@ -62,3 +62,4 @@ save_to_api = true
 ## View Your Results
 
 Once your runs complete, visit the [CodeCarbon dashboard](https://dashboard.codecarbon.io/) to see your results. For more visualization options, see the [visualization guide](visualize.md).
+

--- a/docs/how-to/code-of-conduct.md
+++ b/docs/how-to/code-of-conduct.md
@@ -47,7 +47,7 @@ We agree to restrict the following behaviors in our community. Instances, threat
 
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
-When an incident does occur, it is important to report it promptly. To report a possible violation, **[NOTE: describe your means of reporting here.]**
+When an incident does occur, it is important to report it promptly. To report a possible violation, please contact us via [GitHub Issues](https://github.com/mlco2/codecarbon/issues) or [Discord](https://discord.gg/GS9js2XkJR).
 
 Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 

--- a/docs/how-to/contributing.md
+++ b/docs/how-to/contributing.md
@@ -39,7 +39,7 @@
 <!-- TOC --><a name="have-a-question"></a>
 ## </a> Have a Question?
 
-Please see the [FAQ](https://docs.codecarbon.io/latest/explanation/faq/) for questions.
+Please see the [FAQ](https://docs.codecarbon.io/latest/explanation/faq/) for questions. You can also ask on our [Discord community](https://discord.gg/GS9js2XkJR) – we're happy to help!
 
 
 <!-- TOC --><a name="found-a-bug"></a>
@@ -546,6 +546,10 @@ CODECARBON_API_URL="https://api.codecarbon.io"
 PORT="8000"
 ```
 
+
+## Questions or Need Help?
+
+Got stuck? Have an idea? Want to share your contribution? **[Join us on Discord](https://discord.gg/GS9js2XkJR)** – our community is here to help and support you!
 
 <!-- TOC --><a name="license"></a>
 ## License

--- a/docs/how-to/visualize.md
+++ b/docs/how-to/visualize.md
@@ -104,3 +104,4 @@ The app also provides a visualization of regional carbon intensity of electricit
 - [Set up the Cloud API](cloud-api.md) to send data to the online dashboard
 - [Configure CodeCarbon](configuration.md) for additional tracking options
 - [Integrate with experiment tracking tools](comet.md) like Comet for seamless workflow integration
+- [Join our Discord](https://discord.gg/GS9js2XkJR) to share your results and discuss emissions tracking with the community

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,3 +78,11 @@ A single datacenter can consume large amounts of energy to run computing code. A
 | [Methodology](explanation/methodology.md) | How emissions are calculated |
 | [EcoLogits](https://ecologits.ai/latest/?utm_source=codecarbon&utm_medium=docs) | Track emissions from GenAI API calls |
 | [Discord Community](https://discord.gg/GS9js2XkJR) | Chat with us and the community |
+
+## Contributors & Acknowledgements
+
+CodeCarbon is built by a community of open-source contributors and supported by organizations committed to sustainable computing.
+
+- **[Contributors](https://github.com/mlco2/codecarbon/graphs/contributors)** - See everyone who has contributed to the project
+- **[Citation](https://zenodo.org/records/11171501)** - Cite CodeCarbon in your research
+- **[Partners](https://github.com/mlco2/codecarbon#partners)** - The organizations supporting this work

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,3 +77,4 @@ A single datacenter can consume large amounts of energy to run computing code. A
 | [Framework Examples](how-to/scikit-learn.md) | Example usage patterns |
 | [Methodology](explanation/methodology.md) | How emissions are calculated |
 | [EcoLogits](https://ecologits.ai/latest/?utm_source=codecarbon&utm_medium=docs) | Track emissions from GenAI API calls |
+| [Discord Community](https://discord.gg/GS9js2XkJR) | Chat with us and the community |

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -39,7 +39,11 @@
 }
 
 [data-md-color-scheme="default"] .md-header .md-search__button,
-[data-md-color-scheme="default"] .md-search__button,
+[data-md-color-scheme="default"] .md-search__button {
+  color: #0d1f0d !important;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+}
+
 [data-md-color-scheme="slate"] .md-header .md-search__button,
 [data-md-color-scheme="slate"] .md-search__button {
   color: #ffffff !important;
@@ -47,7 +51,11 @@
 }
 
 [data-md-color-scheme="default"] .md-header .md-search__input,
-[data-md-color-scheme="default"] .md-search__input,
+[data-md-color-scheme="default"] .md-search__input {
+  color: #0d1f0d !important;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+}
+
 [data-md-color-scheme="slate"] .md-header .md-search__input,
 [data-md-color-scheme="slate"] .md-search__input {
   color: #ffffff !important;

--- a/docs/tutorials/first-tracking.md
+++ b/docs/tutorials/first-tracking.md
@@ -62,3 +62,7 @@ print(f"Energy consumed: {tracker.final_emissions_data.energy_consumed:.6f} kWh"
 - Explore all [Python API options](python-api.md) (decorators, explicit objects, offline mode)
 - See the full [API Reference](../reference/api.md) for all configuration parameters
 - Try the [CodeCarbon Workshop notebook](https://github.com/mlco2/codecarbon/blob/master/examples/notebooks/codecarbon_workshop.ipynb) for a comprehensive hands-on experience
+
+## Need help?
+
+Have questions about tracking, want to share your results, or contribute to CodeCarbon? **[Join our Discord community](https://discord.gg/GS9js2XkJR)** – we're here to help!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ copyright: "&copy; CodeCarbon"
 
 theme:
   name: zensical
+  custom_dir: overrides
   favicon: images/favicon.ico
   logo: images/codecarbon-logo.svg
   palette:
@@ -95,6 +96,7 @@ extra_css:
 extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+  - javascripts/discord-link.js
 
 markdown_extensions:
   - abbr
@@ -182,3 +184,4 @@ nav:
     - Output Formats: reference/output.md
     - CLI Reference: reference/cli.md
   - Track GenAI API Calls (EcoLogits) ↗: https://ecologits.ai/latest/?utm_source=codecarbon&utm_medium=docs
+  - Join Our Discord 💬 ↗: https://discord.gg/GS9js2XkJR

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,6 @@ copyright: "&copy; CodeCarbon"
 
 theme:
   name: zensical
-  custom_dir: overrides
   favicon: images/favicon.ico
   logo: images/codecarbon-logo.svg
   palette:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,7 +95,6 @@ extra_css:
 extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
-  - javascripts/discord-link.js
 
 markdown_extensions:
   - abbr


### PR DESCRIPTION
## Summary

Added Discord community links to key documentation and README sections to make it easier for users to get help, contribute, and connect with the community.

## Changes

- **README**: Discord badge + community callout + quick links
- **Navigation**: "Join Our Discord" link in main menu
- **Landing page**: Discord in quick links table
- **FAQ**: Added Discord references for help and bug reporting  
- **Code of Conduct**: Updated reporting mechanism to include Discord
- **Contributing**: Added Discord to questions section + new community help section
- **First tracking tutorial**: "Need help?" section with Discord link
- **Visualization guide**: Discord in next steps for sharing results

## Design decision

Moved Discord reference from Cloud API guide (overly technical) to Visualization guide (team/community-oriented) for better fit. Discord now visible at multiple entry points throughout docs.

## Testing

- Docs build successfully: `uv run task docs`
- Links verified

🌐 Discord: https://discord.gg/GS9js2XkJR