### PR TITLE
fix(api): handle organizations with no emissions in /sums (#693)

### DIFF
--- a/carbonserver/carbonserver/api/usecases/organization/organization_sum.py
+++ b/carbonserver/carbonserver/api/usecases/organization/organization_sum.py
@@ -16,4 +16,27 @@ class OrganizationSumsUsecase:
             start_date,
             end_date,
         )
-        return sums
+        if sums is not None:
+            return sums
+
+        # No emissions in the requested period. Return zeros so the dashboard
+        # still gets a valid report rather than a 500.
+        organization = self._organization_repository.get_one_organization(
+            organization_id
+        )
+        return OrganizationReport(
+            organization_id=organization.id,
+            name=organization.name,
+            description=organization.description,
+            emissions=0.0,
+            cpu_power=0.0,
+            gpu_power=0.0,
+            ram_power=0.0,
+            cpu_energy=0.0,
+            gpu_energy=0.0,
+            ram_energy=0.0,
+            energy_consumed=0.0,
+            duration=0,
+            emissions_rate=0.0,
+            emissions_count=0,
+        )

--- a/carbonserver/tests/api/usecase/organization/test_organization_detailed_sums.py
+++ b/carbonserver/tests/api/usecase/organization/test_organization_detailed_sums.py
@@ -1,11 +1,13 @@
 from datetime import datetime
 from unittest import mock
+from uuid import UUID
 
 import dateutil.relativedelta
 
 from carbonserver.api.infra.repositories.repository_organizations import (
     SqlAlchemyRepository,
 )
+from carbonserver.api.schemas import Organization
 from carbonserver.api.usecases.organization.organization_sum import (
     OrganizationSumsUsecase,
 )
@@ -53,3 +55,27 @@ def test_sum_computes_for_organization_id():
         actual_organization_global_sum_by_experiment[0]["emissions"]
         == expected_emission_sum
     )
+
+
+def test_sum_returns_zero_report_when_organization_has_no_emissions():
+    """Issue #693: an organization with no emissions in the requested period
+    should get back a zero-valued report instead of triggering the global
+    "Generic error" handler.
+    """
+    repository_mock = mock.Mock(spec=SqlAlchemyRepository)
+    repository_mock.get_organization_detailed_sums.return_value = None
+    repository_mock.get_one_organization.return_value = Organization(
+        id=UUID(ORG_ID),
+        name="Quiet Org",
+        description="An organization that has not logged anything yet.",
+    )
+    usecase = OrganizationSumsUsecase(repository_mock)
+
+    report = usecase.compute_detailed_sum(ORG_ID, START_DATE, END_DATE)
+
+    assert report.organization_id == UUID(ORG_ID)
+    assert report.name == "Quiet Org"
+    assert report.emissions == 0.0
+    assert report.energy_consumed == 0.0
+    assert report.duration == 0
+    assert report.emissions_count == 0


### PR DESCRIPTION
## Description

`GET /organizations/{organization_id}/sums` returns `{"detail": "Generic error"}` with status 500 for any organization that has no emissions logged in the requested period. The expected response, per the issue, is a report whose numeric fields are zero.

The fix lives in `OrganizationSumsUsecase.compute_detailed_sum`. When the repository returns `None` (which happens because the timestamp filter on `Emission` cancels the outer joins for an empty organization), the usecase now uses the existing `get_one_organization` helper to fetch the organization metadata and returns a zero-valued `OrganizationReport`.

I left the SQL in `get_organization_detailed_sums` untouched. Rewriting the joins would be a larger, more invasive change; handling the empty result in the usecase keeps the patch focused on what the issue asks for.

## Related Issue

Closes #693.

## Motivation and Context

Anyone who creates an organization and inspects the sums endpoint before logging any emissions hits a 500. From the outside it looks like the API is broken. Returning zeros is what the issue describes as the ideal response, and it matches the shape the dashboard expects for a quiet period.

## How Has This Been Tested?

I ran the affected suite locally on Python 3.12.4 with the dev extras installed:

```
pytest tests/api/usecase/organization/test_organization_detailed_sums.py -vv
```

Both tests pass. To make sure the new test actually catches the bug I temporarily reverted the fix and re-ran it. Without the fix it fails on `AttributeError: 'NoneType' object has no attribute 'organization_id'`, which is exactly the path that ends up in the global exception handler. With the fix back in place it passes.

I also ran the broader unit suite to check for regressions:

```
pytest tests/api/usecase tests/api/service tests/api/routers -q
```

86 passed, 1 skipped, 1 xfailed, 4 warnings (all pre-existing and unrelated to this change). I did not run the integration suite because I am not running PostgreSQL locally; CI will exercise it.

## Screenshots (if appropriate):

n/a — server-side bug fix, no UI change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure

- [ ] 🟥 AI-vibecoded
- [ ] 🟠 AI-generated
- [x] ⭐ AI-assisted
- [ ] ♻️ No AI used

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[docs/how-to/contributing.md](https://docs.codecarbon.io/latest/how-to/contributing/)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.