### PR TITLE
fix: amdsmi import when libamd_smi is missing (macOS / no ROCm)

### DIFF
--- a/codecarbon/core/gpu_amd.py
+++ b/codecarbon/core/gpu_amd.py
@@ -28,12 +28,14 @@ except ImportError:
             "Please install amdsmi to get GPU metrics."
         )
     AMDSMI_AVAILABLE = False
-except (AttributeError, OSError, KeyError) as error:
+except (AttributeError, OSError, KeyError) as e:
     amdsmi = None
+    # In some environments, amdsmi may be present but not properly configured, leading to AttributeError when importing
     logger.warning(
-        "amdsmi is installed but could not load libamd_smi (ROCm drivers missing "
-        "or incompatible). AMD GPU metrics will be unavailable. Error: %s",
-        error,
+        "AMD GPU detected but amdsmi is not properly configured. "
+        "Please ensure amdsmi is correctly installed to get GPU metrics."
+        "Tips : check consistency between Python amdsmi package and ROCm versions, and ensure AMD drivers are up to date."
+        f" Error: {e}"
     )
     AMDSMI_AVAILABLE = False
 

--- a/codecarbon/core/gpu_amd.py
+++ b/codecarbon/core/gpu_amd.py
@@ -28,14 +28,12 @@ except ImportError:
             "Please install amdsmi to get GPU metrics."
         )
     AMDSMI_AVAILABLE = False
-except AttributeError as e:
+except (AttributeError, OSError, KeyError) as error:
     amdsmi = None
-    # In some environments, amdsmi may be present but not properly configured, leading to AttributeError when importing
     logger.warning(
-        "AMD GPU detected but amdsmi is not properly configured. "
-        "Please ensure amdsmi is correctly installed to get GPU metrics."
-        "Tips : check consistency between Python amdsmi package and ROCm versions, and ensure AMD drivers are up to date."
-        f" Error: {e}"
+        "amdsmi is installed but could not load libamd_smi (ROCm drivers missing "
+        "or incompatible). AMD GPU metrics will be unavailable. Error: %s",
+        error,
     )
     AMDSMI_AVAILABLE = False
 

--- a/tests/test_gpu_amd.py
+++ b/tests/test_gpu_amd.py
@@ -395,6 +395,75 @@ class TestAmdGpu:
             assert device._get_graphics_processes() == []
 
 
+class TestAmdsmiImportFailures:
+    """Tests for module-level amdsmi import error handling in gpu_amd.py."""
+
+    def _import_gpu_amd_with_amdsmi_error(self, error_to_raise):
+        """
+        Simulate a fresh import of codecarbon.core.gpu_amd where importing amdsmi
+        raises *error_to_raise*.  Returns the freshly imported module object.
+        """
+        import builtins
+        import importlib
+        import sys
+
+        # Remove cached modules so the module body is re-executed
+        saved = {}
+        for name in ("amdsmi", "codecarbon.core.gpu_amd"):
+            if name in sys.modules:
+                saved[name] = sys.modules.pop(name)
+
+        _real_import = builtins.__import__
+
+        def _patched_import(name, *args, **kwargs):
+            if name == "amdsmi":
+                raise error_to_raise
+            return _real_import(name, *args, **kwargs)
+
+        try:
+            with mock.patch("builtins.__import__", side_effect=_patched_import):
+                module = importlib.import_module("codecarbon.core.gpu_amd")
+            return module
+        finally:
+            # Drop the freshly created module entries and restore original state
+            sys.modules.pop("amdsmi", None)
+            sys.modules.pop("codecarbon.core.gpu_amd", None)
+            sys.modules.update(saved)
+
+    def test_oserror_sets_amdsmi_unavailable(self):
+        """OSError during amdsmi import (e.g. missing libamd_smi.so) must disable AMD GPU support."""
+        module = self._import_gpu_amd_with_amdsmi_error(
+            OSError("libamd_smi.so: cannot open shared object file: No such file or directory")
+        )
+        assert module.amdsmi is None
+        assert module.AMDSMI_AVAILABLE is False
+
+    def test_keyerror_sets_amdsmi_unavailable(self):
+        """KeyError during amdsmi import (e.g. macOS with amdsmi installed but no ROCm) must disable AMD GPU support."""
+        module = self._import_gpu_amd_with_amdsmi_error(KeyError("missing_rocm_key"))
+        assert module.amdsmi is None
+        assert module.AMDSMI_AVAILABLE is False
+
+    def test_attributeerror_sets_amdsmi_unavailable(self):
+        """AttributeError during amdsmi import must disable AMD GPU support."""
+        module = self._import_gpu_amd_with_amdsmi_error(
+            AttributeError("module 'amdsmi' has no attribute 'amdsmi_init'")
+        )
+        assert module.amdsmi is None
+        assert module.AMDSMI_AVAILABLE is False
+
+    def test_import_failure_logs_warning(self):
+        """Each import-time failure (OSError/KeyError/AttributeError) must log a warning."""
+        for error in (
+            OSError("libamd_smi.so not found"),
+            KeyError("rocm_key"),
+            AttributeError("missing attr"),
+        ):
+            with mock.patch("codecarbon.external.logger.logger.warning") as warning_mock:
+                self._import_gpu_amd_with_amdsmi_error(error)
+            warning_mock.assert_called()
+
+
 class TestAllGPUDevicesAmd:
     def test_init_with_no_amd_handles(self):
         from codecarbon.core.gpu import AllGPUDevices

--- a/tests/test_gpu_amd.py
+++ b/tests/test_gpu_amd.py
@@ -433,7 +433,9 @@ class TestAmdsmiImportFailures:
     def test_oserror_sets_amdsmi_unavailable(self):
         """OSError during amdsmi import (e.g. missing libamd_smi.so) must disable AMD GPU support."""
         module = self._import_gpu_amd_with_amdsmi_error(
-            OSError("libamd_smi.so: cannot open shared object file: No such file or directory")
+            OSError(
+                "libamd_smi.so: cannot open shared object file: No such file or directory"
+            )
         )
         assert module.amdsmi is None
         assert module.AMDSMI_AVAILABLE is False
@@ -459,7 +461,9 @@ class TestAmdsmiImportFailures:
             KeyError("rocm_key"),
             AttributeError("missing attr"),
         ):
-            with mock.patch("codecarbon.external.logger.logger.warning") as warning_mock:
+            with mock.patch(
+                "codecarbon.external.logger.logger.warning"
+            ) as warning_mock:
                 self._import_gpu_amd_with_amdsmi_error(error)
             warning_mock.assert_called()
 


### PR DESCRIPTION
## Summary

On systems where the `amdsmi` Python package is installed but ROCm / `libamd_smi.so` is not available (common on macOS), importing CodeCarbon could crash with `KeyError` during `import amdsmi` inside `gpu_amd.py`, breaking the CLI and any code path that loads GPU support.

This change broadens the existing `AttributeError` handler to also catch `OSError` and `KeyError`, sets `amdsmi = None` and `AMDSMI_AVAILABLE = False`, and logs a clear warning so AMD GPU metrics are skipped instead of failing import.

## Test plan

- [ ] On macOS (or any host without ROCm) with `amdsmi` installed: `codecarbon --help` and `python -c "import codecarbon"` succeed with a warning, no traceback.
- [ ] On a ROCm system with working `amdsmi`: AMD GPU metrics still work as before.

Made with [Cursor](https://cursor.com)