### PR TITLE
Document hardware measurement scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Configuration precedence and examples: [configuration guide](https://docs.codeca
 
 We created a Python package that estimates your hardware electricity power consumption (GPU + CPU + RAM) and we apply to it the carbon intensity of the region where the computing is done.
 
-CodeCarbon focuses on the main compute components it can measure or estimate directly. It does not separately model disk I/O, network transfers, displays, cooling, or other peripherals.
+CodeCarbon focuses on the main compute components it can measure or estimate directly: CPU, GPU, and RAM. It does not separately model disk I/O, network transfers, displays, cooling, or other peripherals because those sources are usually much smaller for local code-level experiments and are not exposed through the same low-overhead measurement interfaces.
 
 ![calculation Summary](docs/images/calculation.png)
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Configuration precedence and examples: [configuration guide](https://docs.codeca
 
 We created a Python package that estimates your hardware electricity power consumption (GPU + CPU + RAM) and we apply to it the carbon intensity of the region where the computing is done.
 
+CodeCarbon focuses on the main compute components it can measure or estimate directly. It does not separately model disk I/O, network transfers, displays, cooling, or other peripherals.
+
 ![calculation Summary](docs/images/calculation.png)
 
 We explain more about this calculation in the [**Methodology**](https://docs.codecarbon.io/latest/explanation/methodology/) section of the documentation.

--- a/docs/explanation/methodology.md
+++ b/docs/explanation/methodology.md
@@ -85,6 +85,13 @@ intervals. This is a configurable parameter `measure_power_secs`, with
 default value 15 seconds, that can be passed when instantiating the
 emissions tracker.
 
+CodeCarbon focuses on the main compute components it can measure or
+estimate directly: CPU, GPU, and RAM. It does not separately model disk
+I/O, network transfers, displays, cooling, or other peripherals. For
+most local code-level experiments, those sources are usually smaller
+than CPU, GPU, and RAM consumption, but they can matter for workloads
+that are dominated by data movement, storage, or distributed systems.
+
 Currently, the package supports the following hardware infrastructure.
 
 ### Tracking Modes

--- a/docs/explanation/methodology.md
+++ b/docs/explanation/methodology.md
@@ -87,10 +87,12 @@ emissions tracker.
 
 CodeCarbon focuses on the main compute components it can measure or
 estimate directly: CPU, GPU, and RAM. It does not separately model disk
-I/O, network transfers, displays, cooling, or other peripherals. For
-most local code-level experiments, those sources are usually smaller
-than CPU, GPU, and RAM consumption, but they can matter for workloads
-that are dominated by data movement, storage, or distributed systems.
+I/O, network transfers, displays, cooling, or other peripherals because
+those sources are usually much smaller, and often negligible, for local
+code-level experiments. They are also not exposed through the same
+low-overhead measurement interfaces as CPU, GPU, and RAM. However, they
+can matter for workloads dominated by data movement, storage, or
+distributed systems.
 
 Currently, the package supports the following hardware infrastructure.
 


### PR DESCRIPTION
## Summary
- document that CodeCarbon directly focuses on CPU, GPU, and RAM power
- clarify that disk I/O, network transfers, displays, cooling, and peripherals are not separately modeled
- note that data movement or distributed workloads may need extra consideration

Fixes #154

## Tests
- `git diff --check`
- `uv run --only-group doc task docs`