### PR TITLE
fix(cli): warn when auth validation falls back to API

### DIFF
--- a/codecarbon/cli/auth.py
+++ b/codecarbon/cli/auth.py
@@ -6,6 +6,7 @@ PKCE), credential storage, JWKS validation, and transparent refresh.
 """
 
 import json
+import logging
 import os
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -31,6 +32,7 @@ AUTH_SERVER_WELL_KNOWN = os.environ.get(
 _REDIRECT_PORT = 8090
 _REDIRECT_URI = f"http://localhost:{_REDIRECT_PORT}/callback"
 _CREDENTIALS_FILE = Path("./credentials.json")
+logger = logging.getLogger(__name__)
 
 
 # ── OAuth callback server ───────────────────────────────────────────
@@ -112,7 +114,12 @@ def _validate_access_token(access_token: str) -> bool:
         claims = jose_jwt.decode(access_token, keyset)
         claims.validate()
         return True
-    except requests.RequestException:
+    except requests.RequestException as exc:
+        logger.warning(
+            "Skipping local access token validation because the auth server is "
+            "unreachable; the API will validate the token. Error: %s",
+            exc,
+        )
         return True  # Can't reach auth server — let the API handle it
     except Exception:
         return False

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -112,7 +112,10 @@ class TestAuthMethods(unittest.TestCase):
     def test_validate_access_token_network_error_returns_true(
         self, mock_get, mock_discover
     ):
-        self.assertTrue(auth._validate_access_token("token"))
+        with self.assertLogs("codecarbon.cli.auth", level="WARNING") as logs:
+            self.assertTrue(auth._validate_access_token("token"))
+
+        self.assertIn("Skipping local access token validation", logs.output[0])
 
     @patch("codecarbon.cli.auth._discover_endpoints", return_value={"jwks_uri": "jwks"})
     @patch("codecarbon.cli.auth.requests.get")


### PR DESCRIPTION
## Description
Log a warning when local CLI access-token validation is skipped because the auth server cannot be reached. This preserves the existing offline/flaky-network fallback while making it explicit that token freshness was not proven locally and the API will make the final authorization decision.

## Related Issue
Fixes #1208

## Motivation and Context
The existing fallback is useful for availability, but silent success makes the path look like a completed local validation. A warning keeps the behavior unchanged while surfacing the caveat from the issue.

## How Has This Been Tested?
Red before implementation:

```sh
uv run --group dev python -m pytest -q tests/cli/test_cli_auth.py::TestAuthMethods::test_validate_access_token_network_error_returns_true
```

Green after implementation:

```sh
uv run --group dev python -m pytest -q tests/cli/test_cli_auth.py::TestAuthMethods::test_validate_access_token_network_error_returns_true
uv run --group dev python -m pytest -q tests/cli/test_cli_auth.py tests/cli/test_cli.py tests/cli/test_cli_main.py
uv run --group dev black --check codecarbon/cli/auth.py tests/cli/test_cli_auth.py
uv run --group dev ruff check codecarbon/cli/auth.py tests/cli/test_cli_auth.py
git diff HEAD^ --check
```

## Screenshots (if appropriate):

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure

OpenAI GPT-5 generated the small code/test change and PR text under explicit human-directed issue-fix constraints. I reviewed the touched auth path, preserved existing fallback behavior, and verified the change with the commands listed above.

- [ ] 🟥 AI-vibecoded: You cannot explain the logic. Car analogy : the car drive by itself, you are outside it and just tell it where to go.
- [x] 🟠 AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [ ] ⭐ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] ♻️ No AI used. Car analogy : you drive the car.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[docs/how-to/contributing.md](https://docs.codecarbon.io/latest/how-to/contributing/)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
