### PR TITLE
Fix OSX psutil detection

### DIFF
--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -217,19 +217,19 @@ def is_psutil_available():
                 return True
             else:
                 logger.debug(
-                    f"is_psutil_available(): psutil.cpu_times().nice is too small: {nice}"
+                    f"is_psutil_available(): psutil.cpu_times().nice is too small: {nice}; "
+                    "using fallback check."
                 )
-                return False
 
         else:
-            # Fallback: check if psutil works by calling cpu_percent
             logger.debug(
                 "is_psutil_available(): no 'nice' attribute, using fallback check."
             )
 
-            # check CPU utilization usable
-            psutil.cpu_percent(interval=0.0, percpu=False)
-            return True
+        # Fallback: check if psutil CPU utilization is usable. This covers
+        # platforms like Windows and macOS where cpu_times().nice is absent or 0.
+        psutil.cpu_percent(interval=0.0, percpu=False)
+        return True
 
     except Exception as e:
         logger.debug(

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -78,6 +78,12 @@ class TestCPU(unittest.TestCase):
     def test_is_psutil_not_available_on_exception(self, mock_cpu_times):
         self.assertFalse(is_psutil_available())
 
+    def test_cpu_repr_includes_generic_tdp_marker(self):
+        cpu = CPU(output_dir="", mode="constant", model="My CPU", tdp=12)
+        cpu._is_generic_tdp = True
+
+        assert repr(cpu) == "CPU(My CPU > 12W [generic])"
+
 
 class TestRAPLHelperFunctions(unittest.TestCase):
     def test_get_candidate_bases_for_custom_dir(self):

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -78,12 +78,6 @@ class TestCPU(unittest.TestCase):
     def test_is_psutil_not_available_on_exception(self, mock_cpu_times):
         self.assertFalse(is_psutil_available())
 
-    def test_cpu_repr_includes_generic_tdp_marker(self):
-        cpu = CPU(output_dir="", mode="constant", model="My CPU", tdp=12)
-        cpu._is_generic_tdp = True
-
-        assert repr(cpu) == "CPU(My CPU > 12W [generic])"
-
 
 class TestRAPLHelperFunctions(unittest.TestCase):
     def test_get_candidate_bases_for_custom_dir(self):
@@ -377,6 +371,18 @@ class TestTDP(unittest.TestCase):
         model = "AMD Ryzen Threadripper 1950X 16-Core Processor"
         self.assertEqual(tdp._get_cpu_power_from_registry(model), 180)
 
+    def test_get_cpu_power_from_registry_returns_none_without_match(self):
+        tdp = TDP.__new__(TDP)
+        with (
+            mock.patch("codecarbon.core.cpu.DataSource") as mock_data_source,
+            mock.patch.object(tdp, "_get_matching_cpu", return_value=None),
+        ):
+            mock_data_source.return_value.get_cpu_power_data.return_value = (
+                mock.sentinel.cpu_power_df
+            )
+
+            self.assertIsNone(tdp._get_cpu_power_from_registry("Mystery CPU"))
+
     def test_get_matching_cpu(self):
         tdp = TDP()
         cpu_data = DataSource().get_cpu_power_data()
@@ -563,6 +569,13 @@ class TestTDP(unittest.TestCase):
 
         self.assertEqual(tdp.model, "Mystery CPU")
         self.assertEqual(tdp.tdp, 8 * DEFAULT_POWER_PER_CORE)
+
+    def test_main_returns_unknown_when_cpu_detection_fails(self):
+        with mock.patch("codecarbon.core.cpu.detect_cpu_model", return_value=None):
+            tdp = TDP()
+
+        self.assertEqual(tdp.model, "Unknown")
+        self.assertIsNone(tdp.tdp)
 
 
 class TestResourceTrackerCPUTracking(unittest.TestCase):

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -46,12 +46,24 @@ class TestCPU(unittest.TestCase):
         self.assertTrue(is_psutil_available())
 
     @mock.patch("psutil.cpu_times")
-    def test_is_psutil_available_with_small_nice(self, mock_cpu_times):
-        # Test when nice attribute is too small
+    def test_is_psutil_available_with_small_nice_uses_fallback(self, mock_cpu_times):
+        # Test when nice attribute is too small, as on macOS
         mock_times = mock.Mock()
         mock_times.nice = 0.00001
         mock_cpu_times.return_value = mock_times
-        self.assertFalse(is_psutil_available())
+        with mock.patch("psutil.cpu_percent") as mock_cpu_percent:
+            self.assertTrue(is_psutil_available())
+            mock_cpu_percent.assert_called_once_with(interval=0.0, percpu=False)
+
+    @mock.patch("psutil.cpu_times")
+    def test_is_psutil_not_available_when_small_nice_fallback_fails(
+        self, mock_cpu_times
+    ):
+        mock_times = mock.Mock()
+        mock_times.nice = 0.00001
+        mock_cpu_times.return_value = mock_times
+        with mock.patch("psutil.cpu_percent", side_effect=Exception("Test error")):
+            self.assertFalse(is_psutil_available())
 
     @mock.patch("psutil.cpu_times")
     def test_is_psutil_available_without_nice(self, mock_cpu_times):


### PR DESCRIPTION
## Description
Fix OSX psutil detection

## Related Issue
This PR resolves: [#1012]

## Motivation and Context
psutil.nice() return 0.0 on OSX.

## How Has This Been Tested?
Only unit test. I don't have a Mac.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure

Please refer to [docs/how-to/ai-policy.md](https://docs.codecarbon.io/latest/how-to/ai_policy/) for detailed guidelines on how to disclose AI usage in your PR. Accurately completing this section is mandatory.

- [ ] 🟥 AI-vibecoded: You cannot explain the logic. Car analogy : the car drive by itself, you are outside it and just tell it where to go.
- [ ] 🟠 AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [X] ⭐ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] ♻️ No AI used. Car analogy : you drive the car.

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[docs/how-to/contributing.md](https://docs.codecarbon.io/latest/how-to/contributing/)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.