### PR TITLE
Fix: Look up failure for nordic regions using online emissions tracker

### DIFF
--- a/codecarbon/core/emissions.py
+++ b/codecarbon/core/emissions.py
@@ -179,8 +179,7 @@ class Emissions:
             geo.country_iso_code.upper() if geo.country_iso_code is not None else None
         )
         compute_with_regional_data: bool = (geo.region is not None) and (
-            country_iso_code in ["USA", "CAN"]
-            or self._is_supported_nordic_region(geo)
+            country_iso_code in ["USA", "CAN"] or self._is_supported_nordic_region(geo)
         )
 
         if compute_with_regional_data:

--- a/codecarbon/core/emissions.py
+++ b/codecarbon/core/emissions.py
@@ -16,6 +16,12 @@ from codecarbon.external.geography import CloudMetadata, GeoMetadata
 from codecarbon.external.logger import logger
 from codecarbon.input import DataSource, DataSourceException
 
+_NORDIC_REGIONS_BY_COUNTRY = {
+    "SWE": {"SE1", "SE2", "SE3", "SE4"},
+    "NOR": {"NO1", "NO2", "NO3", "NO4", "NO5"},
+    "FIN": {"FI"},
+}
+
 
 class Emissions:
     def __init__(
@@ -169,8 +175,12 @@ class Emissions:
                     + " >>> Using CodeCarbon's data."
                 )
 
+        country_iso_code = (
+            geo.country_iso_code.upper() if geo.country_iso_code is not None else None
+        )
         compute_with_regional_data: bool = (geo.region is not None) and (
-            geo.country_iso_code.upper() in ["USA", "CAN", "SWE", "NOR", "FIN"]
+            country_iso_code in ["USA", "CAN"]
+            or self._is_supported_nordic_region(geo)
         )
 
         if compute_with_regional_data:
@@ -187,24 +197,10 @@ class Emissions:
     def _try_get_nordic_region_emissions(
         self, energy: Energy, geo: GeoMetadata
     ) -> Optional[float]:
-        nordic_regions = {
-            "SE1",
-            "SE2",
-            "SE3",
-            "SE4",
-            "NO1",
-            "NO2",
-            "NO3",
-            "NO4",
-            "NO5",
-            "FI",
-        }
-        if geo.region is None:
+        if not self._is_supported_nordic_region(geo):
             return None
 
         region_upper = geo.region.upper()
-        if region_upper not in nordic_regions:
-            return None
 
         try:
             nordic_data = self._data_source.get_nordic_country_energy_mix_data()
@@ -224,6 +220,16 @@ class Emissions:
                 + "Falling back to default emission calculation."
             )
         return None
+
+    @staticmethod
+    def _is_supported_nordic_region(geo: GeoMetadata) -> bool:
+        if geo.country_iso_code is None or geo.region is None:
+            return False
+
+        country_regions = _NORDIC_REGIONS_BY_COUNTRY.get(
+            geo.country_iso_code.upper(), set()
+        )
+        return geo.region.upper() in country_regions
 
     def get_region_emissions(self, energy: Energy, geo: GeoMetadata) -> float:
         """
@@ -248,6 +254,11 @@ class Emissions:
         nordic_emissions = self._try_get_nordic_region_emissions(energy, geo)
         if nordic_emissions is not None:
             return nordic_emissions
+        if (
+            geo.country_iso_code is not None
+            and geo.country_iso_code.upper() in _NORDIC_REGIONS_BY_COUNTRY
+        ):
+            return self.get_country_emissions(energy, geo)
 
         # Handle USA and Canada regional data
         try:

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -174,6 +174,15 @@ class TestEmissions(unittest.TestCase):
         assert isinstance(emissions, float)
         self.assertAlmostEqual(emissions, 0.475, places=2)
 
+    def test_get_emissions_PRIVATE_INFRA_without_country_metadata(self):
+        emissions = self._emissions.get_private_infra_emissions(
+            Energy.from_energy(kWh=1),
+            GeoMetadata(country_iso_code=None, country_name=None, region=None),
+        )
+
+        assert isinstance(emissions, float)
+        self.assertAlmostEqual(emissions, 0.475, places=2)
+
     @patch("codecarbon.core.electricitymaps_api.get_emissions")
     def test_private_infra_uses_forced_intensity_when_set(self, mocked_get_emissions):
         emissions_calculator = Emissions(
@@ -269,6 +278,71 @@ class TestEmissions(unittest.TestCase):
 
         # THEN
         self.assertIsNone(emissions)
+
+    def test_nordic_admin_regions_fall_back_to_country_without_regional_lookup(self):
+        energy = Energy.from_energy(kWh=1.0)
+        admin_regions = [
+            ("SWE", "Sweden", "Stockholm County"),
+            ("NOR", "Norway", "Oslo"),
+            ("FIN", "Finland", "Uusimaa"),
+        ]
+
+        for country_iso_code, country_name, region in admin_regions:
+            with self.subTest(country_iso_code=country_iso_code, region=region):
+                geo = GeoMetadata(
+                    country_iso_code=country_iso_code,
+                    country_name=country_name,
+                    region=region,
+                )
+                expected_emissions = self._emissions.get_country_emissions(energy, geo)
+
+                with (
+                    patch.object(
+                        self._data_source, "get_nordic_country_energy_mix_data"
+                    ) as get_nordic_data,
+                    patch.object(
+                        self._data_source, "get_country_emissions_data"
+                    ) as get_regional_emissions_data,
+                    patch.object(
+                        self._data_source, "get_country_energy_mix_data"
+                    ) as get_regional_energy_mix_data,
+                    patch("codecarbon.core.emissions.logger.error") as log_error,
+                    patch("codecarbon.core.emissions.logger.warning") as log_warning,
+                ):
+                    emissions = self._emissions.get_private_infra_emissions(energy, geo)
+
+                self.assertAlmostEqual(emissions, expected_emissions, places=6)
+                get_nordic_data.assert_not_called()
+                get_regional_emissions_data.assert_not_called()
+                get_regional_energy_mix_data.assert_not_called()
+                log_error.assert_not_called()
+                log_warning.assert_not_called()
+
+    def test_nordic_region_missing_static_data_falls_back_to_country(self):
+        energy = Energy.from_energy(kWh=1.0)
+        geo = GeoMetadata(
+            country_iso_code="SWE", country_name="Sweden", region="SE2"
+        )
+        expected_emissions = self._emissions.get_country_emissions(energy, geo)
+
+        with (
+            patch.object(
+                self._data_source,
+                "get_nordic_country_energy_mix_data",
+                return_value={"data": {}},
+            ),
+            patch.object(
+                self._data_source, "get_country_emissions_data"
+            ) as get_regional_emissions_data,
+            patch.object(
+                self._data_source, "get_country_energy_mix_data"
+            ) as get_regional_energy_mix_data,
+        ):
+            emissions = self._emissions.get_private_infra_emissions(energy, geo)
+
+        self.assertAlmostEqual(emissions, expected_emissions, places=6)
+        get_regional_emissions_data.assert_not_called()
+        get_regional_energy_mix_data.assert_not_called()
 
     def test_try_get_nordic_region_emissions_returns_none_if_region_data_missing(self):
         # GIVEN

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -320,9 +320,7 @@ class TestEmissions(unittest.TestCase):
 
     def test_nordic_region_missing_static_data_falls_back_to_country(self):
         energy = Energy.from_energy(kWh=1.0)
-        geo = GeoMetadata(
-            country_iso_code="SWE", country_name="Sweden", region="SE2"
-        )
+        geo = GeoMetadata(country_iso_code="SWE", country_name="Sweden", region="SE2")
         expected_emissions = self._emissions.get_country_emissions(energy, geo)
 
         with (


### PR DESCRIPTION
## Description
Administrative regions returned by IP geolocation, such as "stockholm county", now fall back directly to country-level emissions. Mismatch between regions returned by geolocation and electricity zones no longer triggers lookups for nonexistent paths such as swe_energy_mix_data_path, fixing the noisy fallback and KeyError issue.

Tests were added for Nordic administrative regions, missing regional data, and absent country metadata.

## Related Issue

Fixes #1223

## Motivation and Context
Previously any region detected for Sweden, Norway or Finland entered the regional calculation path. An mismatch between these administrative regions and the expected electricity zones in the regional path could therefore cause a KeyError before CodeCarbon eventually correctly fell back to country-level emissions.

## How Has This Been Tested?
All existing and new tests are passing.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure

- [ ] 🟥 AI-vibecoded: You cannot explain the logic. Car analogy : the car drive by itself, you are outside it and just tell it where to go.
- [ ] 🟠 AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [x] ⭐ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] ♻️ No AI used. Car analogy : you drive the car.

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **[docs/how-to/contributing.md](https://docs.codecarbon.io/latest/how-to/contributing/)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.