### PR TITLE
perf: cache hardware detection and optimize warm-path reuse (2/4)

### DIFF
--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -4,14 +4,16 @@ using Intel Power Gadget
 https://software.intel.com/content/www/us/en/develop/articles/intel-power-gadget.html
 """
 
+from __future__ import annotations
+
 import os
 import re
 import shutil
 import subprocess
 import sys
-from typing import Dict, Optional, Tuple
+from functools import lru_cache
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
-import pandas as pd
 import psutil
 from rapidfuzz import fuzz, process, utils
 
@@ -19,12 +21,15 @@ from codecarbon.core.rapl import RAPLFile
 from codecarbon.core.units import Time
 from codecarbon.core.util import count_cpus, detect_cpu_model
 from codecarbon.external.logger import logger
-from codecarbon.input import DataSource
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 # default W value per core for a CPU if no model is found in the ref csv
 DEFAULT_POWER_PER_CORE = 4
 
 
+@lru_cache(maxsize=1)
 def is_powergadget_available() -> bool:
     """
     Checks if Intel Power Gadget is available on the system.
@@ -42,6 +47,10 @@ def is_powergadget_available() -> bool:
             e,
         )
         return False
+
+
+def clear_powergadget_cache() -> None:
+    is_powergadget_available.cache_clear()
 
 
 def _get_candidate_bases(rapl_dir: str) -> list:
@@ -366,6 +375,8 @@ class IntelPowerGadget:
         self._log_values()
         cpu_details = {}
         try:
+            import pandas as pd
+
             cpu_data = pd.read_csv(self._log_file_path).dropna()
             for col_name in cpu_data.columns:
                 if col_name in ["System Time", "Elapsed Time (sec)", "RDTSC"]:
@@ -892,6 +903,8 @@ class TDP:
         return float(cpu_power_df[cpu_power_df["Name"] == match]["TDP"].values[0])
 
     def _get_cpu_power_from_registry(self, cpu_model_raw: str) -> Optional[int]:
+        from codecarbon.input import DataSource
+
         cpu_power_df = DataSource().get_cpu_power_data()
         cpu_matching = self._get_matching_cpu(cpu_model_raw, cpu_power_df)
         if cpu_matching:

--- a/codecarbon/core/emissions.py
+++ b/codecarbon/core/emissions.py
@@ -6,15 +6,16 @@ https://github.com/mlco2/impact
 https://github.com/responsibleproblemsolving/energy-usage
 """
 
-from typing import Dict, Optional
-
-import pandas as pd
+from typing import TYPE_CHECKING, Dict, Optional
 
 from codecarbon.core import electricitymaps_api
 from codecarbon.core.units import EmissionsPerKWh, Energy
 from codecarbon.external.geography import CloudMetadata, GeoMetadata
 from codecarbon.external.logger import logger
 from codecarbon.input import DataSource, DataSourceException
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 _NORDIC_REGIONS_BY_COUNTRY = {
     "SWE": {"SE1", "SE2", "SE3", "SE4"},

--- a/codecarbon/core/gpu_amd.py
+++ b/codecarbon/core/gpu_amd.py
@@ -1,19 +1,24 @@
 import subprocess
 from collections import namedtuple
+from functools import lru_cache
 from typing import Callable
 
 from codecarbon.core.gpu_device import GPUDevice
 from codecarbon.external.logger import logger
 
 
+@lru_cache(maxsize=1)
 def is_rocm_system():
     """Returns True if the system has an rocm-smi interface."""
     try:
-        # Check if rocm-smi is available
         subprocess.check_output(["rocm-smi", "--help"])
         return True
     except (subprocess.CalledProcessError, OSError):
         return False
+
+
+def clear_rocm_system_cache() -> None:
+    is_rocm_system.cache_clear()
 
 
 try:

--- a/codecarbon/core/gpu_nvidia.py
+++ b/codecarbon/core/gpu_nvidia.py
@@ -1,19 +1,24 @@
 import subprocess
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Union
 
 from codecarbon.core.gpu_device import GPUDevice
 from codecarbon.external.logger import logger
 
 
+@lru_cache(maxsize=1)
 def is_nvidia_system():
     """Returns True if the system has an nvidia-smi interface."""
     try:
-        # Check if nvidia-smi is available
         subprocess.check_output(["nvidia-smi", "--help"])
         return True
     except Exception:
         return False
+
+
+def clear_nvidia_system_cache() -> None:
+    is_nvidia_system.cache_clear()
 
 
 try:

--- a/codecarbon/core/hardware_cache.py
+++ b/codecarbon/core/hardware_cache.py
@@ -1,0 +1,249 @@
+"""
+Process-level cache for hardware detection and setup.
+
+Reuses the outcome of the first tracker hardware probe so additional runs on
+the same device (same process) skip repeated powermetrics, cpuinfo, and GPU
+detection work.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+from codecarbon.core.config import normalize_gpu_ids
+
+if TYPE_CHECKING:
+    from codecarbon.core.resource_tracker import ResourceTracker
+
+DEFAULT_RAPL_DIR = "/sys/class/powercap/intel-rapl/subsystem"
+
+CONF_KEYS = (
+    "ram_total_size",
+    "cpu_count",
+    "cpu_physical_count",
+    "cpu_model",
+    "gpu_count",
+    "gpu_model",
+    "gpu_ids",
+)
+
+
+class HardwareKind(str, Enum):
+    RAM = "ram"
+    CPU = "cpu"
+    APPLE_CHIP = "apple_chip"
+    GPU = "gpu"
+
+
+_cache_lock = threading.Lock()
+_plans: Dict["_HardwareCacheKey", "_HardwarePlan"] = {}
+_tdp = None
+
+
+@dataclass(frozen=True)
+class _HardwareCacheKey:
+    tracking_mode: str
+    force_cpu_power: Any
+    force_ram_power: Any
+    force_mode_cpu_load: bool
+    gpu_ids: Any
+    rapl_include_dram: bool
+    rapl_prefer_psys: bool
+
+
+@dataclass
+class _HardwarePlan:
+    ram_tracker: str
+    cpu_tracker: str
+    gpu_tracker: str
+    conf: Dict[str, Any] = field(default_factory=dict)
+    hardware_specs: List[Dict[str, Any]] = field(default_factory=list)
+
+
+def _canonical_gpu_ids(
+    gpu_ids: Optional[List],
+) -> Optional[Tuple[str, ...]]:
+    """Normalize GPU ids to a stable cache-key form (tuple of strings)."""
+    if gpu_ids is None:
+        return None
+    if not isinstance(gpu_ids, (list, tuple)):
+        gpu_ids = [gpu_ids]
+    normalized = normalize_gpu_ids(list(gpu_ids))
+    if not normalized:
+        return None
+    return tuple(str(gpu_id) for gpu_id in normalized)
+
+
+def make_key(tracker) -> _HardwareCacheKey:
+    return _HardwareCacheKey(
+        tracking_mode=tracker._tracking_mode,
+        force_cpu_power=tracker._force_cpu_power,
+        force_ram_power=tracker._force_ram_power,
+        force_mode_cpu_load=bool(tracker._conf.get("force_mode_cpu_load", False)),
+        gpu_ids=_canonical_gpu_ids(tracker._gpu_ids),
+        rapl_include_dram=bool(tracker._rapl_include_dram),
+        rapl_prefer_psys=bool(tracker._rapl_prefer_psys),
+    )
+
+
+def get_cached_tdp(cpu_module):
+    """Return a shared cpu.TDP() instance for this process."""
+    global _tdp
+    if _tdp is None:
+        _tdp = cpu_module.TDP()
+    return _tdp
+
+
+def _hardware_kind(hw) -> HardwareKind:
+    """Classify hardware without isinstance (safe if modules were reloaded)."""
+    name = type(hw).__name__
+    if name == "RAM":
+        return HardwareKind.RAM
+    if name == "CPU":
+        return HardwareKind.CPU
+    if name == "AppleSiliconChip":
+        return HardwareKind.APPLE_CHIP
+    if name == "GPU":
+        return HardwareKind.GPU
+    raise TypeError(f"Unsupported hardware type for cache: {type(hw)}")
+
+
+def _spec_from_hardware(hw) -> Dict[str, Any]:
+    kind = _hardware_kind(hw)
+    if kind == HardwareKind.RAM:
+        return {
+            "kind": kind.value,
+            "tracking_mode": hw._tracking_mode,
+            "force_ram_power": hw._force_ram_power,
+        }
+    if kind == HardwareKind.CPU:
+        spec: Dict[str, Any] = {
+            "kind": kind.value,
+            "mode": hw._mode,
+            "model": hw._model,
+            "tdp": hw._tdp,
+            "tracking_mode": hw._tracking_mode,
+            "rapl_include_dram": False,
+            "rapl_prefer_psys": False,
+        }
+        if hw._mode == "intel_rapl" and hasattr(hw, "_intel_interface"):
+            intel = hw._intel_interface
+            spec["rapl_include_dram"] = getattr(intel, "rapl_include_dram", False)
+            spec["rapl_prefer_psys"] = getattr(intel, "rapl_prefer_psys", False)
+            spec["rapl_dir"] = getattr(intel, "_lin_rapl_dir", DEFAULT_RAPL_DIR)
+        return spec
+    if kind == HardwareKind.APPLE_CHIP:
+        return {
+            "kind": kind.value,
+            "model": hw._model,
+            "chip_part": hw.chip_part,
+        }
+    if kind == HardwareKind.GPU:
+        gpu_ids = _canonical_gpu_ids(hw.gpu_ids)
+        return {"kind": kind.value, "gpu_ids": list(gpu_ids) if gpu_ids else None}
+    raise TypeError(f"Unsupported hardware type for cache: {type(hw)}")
+
+
+def _hardware_from_spec(spec: Dict[str, Any], output_dir: str):
+    from codecarbon.external.hardware import CPU, GPU, AppleSiliconChip
+    from codecarbon.external.ram import RAM
+
+    try:
+        kind = HardwareKind(spec["kind"])
+    except ValueError as exc:
+        raise ValueError(f"Unknown hardware spec kind: {spec['kind']}") from exc
+
+    if kind == HardwareKind.RAM:
+        return RAM(
+            tracking_mode=spec["tracking_mode"],
+            force_ram_power=spec.get("force_ram_power"),
+        )
+    if kind == HardwareKind.CPU:
+        return CPU(
+            output_dir=output_dir,
+            mode=spec["mode"],
+            model=spec["model"],
+            tdp=spec["tdp"],
+            tracking_mode=spec["tracking_mode"],
+            rapl_dir=spec.get("rapl_dir", DEFAULT_RAPL_DIR),
+            rapl_include_dram=spec.get("rapl_include_dram", False),
+            rapl_prefer_psys=spec.get("rapl_prefer_psys", False),
+        )
+    if kind == HardwareKind.APPLE_CHIP:
+        return AppleSiliconChip(
+            output_dir=output_dir,
+            model=spec["model"],
+            chip_part=spec["chip_part"],
+        )
+    if kind == HardwareKind.GPU:
+        gpu_ids = _canonical_gpu_ids(spec.get("gpu_ids"))
+        return GPU.from_utils(gpu_ids=list(gpu_ids) if gpu_ids else None)
+    raise ValueError(f"Unknown hardware spec kind: {kind}")
+
+
+def capture(resource_tracker: "ResourceTracker") -> _HardwarePlan:
+    tracker = resource_tracker.tracker
+    conf = {k: tracker._conf[k] for k in CONF_KEYS if k in tracker._conf}
+    return _HardwarePlan(
+        ram_tracker=resource_tracker.ram_tracker,
+        cpu_tracker=resource_tracker.cpu_tracker,
+        gpu_tracker=resource_tracker.gpu_tracker,
+        conf=conf,
+        hardware_specs=[_spec_from_hardware(hw) for hw in tracker._hardware],
+    )
+
+
+def apply(resource_tracker: "ResourceTracker", plan: _HardwarePlan) -> None:
+    tracker = resource_tracker.tracker
+    resource_tracker.ram_tracker = plan.ram_tracker
+    resource_tracker.cpu_tracker = plan.cpu_tracker
+    resource_tracker.gpu_tracker = plan.gpu_tracker
+    tracker._conf.update(plan.conf)
+    if "gpu_ids" in plan.conf:
+        tracker._gpu_ids = plan.conf["gpu_ids"]
+    tracker._hardware = [
+        _hardware_from_spec(spec, tracker._output_dir) for spec in plan.hardware_specs
+    ]
+
+
+def get_or_run_setup(
+    resource_tracker: "ResourceTracker",
+    setup_fn,
+) -> None:
+    """Apply cached hardware plan or run full setup once per cache key."""
+    key = make_key(resource_tracker.tracker)
+    with _cache_lock:
+        plan = _plans.get(key)
+        if plan is not None:
+            apply(resource_tracker, plan)
+            return
+        setup_fn()
+        _plans[key] = capture(resource_tracker)
+
+
+def clear_cache() -> None:
+    """Clear cached plans (for tests)."""
+    global _tdp
+    import sys
+
+    with _cache_lock:
+        _plans.clear()
+    _tdp = None
+
+    for mod_name, clear_fn in (
+        ("codecarbon.core.gpu_nvidia", "clear_nvidia_system_cache"),
+        ("codecarbon.core.gpu_amd", "clear_rocm_system_cache"),
+        ("codecarbon.core.cpu", "clear_powergadget_cache"),
+        ("codecarbon.core.powermetrics", "clear_powermetrics_cache"),
+    ):
+        mod = sys.modules.get(mod_name)
+        if mod is not None:
+            getattr(mod, clear_fn)()
+
+    if "codecarbon.external.hardware" in sys.modules:
+        from codecarbon.external.hardware import clear_cpu_load_prime_cache
+
+        clear_cpu_load_prime_cache()

--- a/codecarbon/core/powermetrics.py
+++ b/codecarbon/core/powermetrics.py
@@ -3,6 +3,8 @@ import re
 import shutil
 import subprocess
 import sys
+import time
+from functools import lru_cache
 from typing import Dict
 
 import numpy as np
@@ -11,17 +13,21 @@ from codecarbon.core.util import detect_cpu_model
 from codecarbon.external.logger import logger
 
 
+@lru_cache(maxsize=1)
 def is_powermetrics_available() -> bool:
     try:
         ApplePowermetrics()
-        response = _has_powermetrics_sudo()
-        return response
+        return _has_powermetrics_sudo()
     except Exception as e:
         logger.debug(
             "Not using PowerMetrics, an exception occurred while instantiating"
             + f" Powermetrics : {e}",
         )
         return False
+
+
+def clear_powermetrics_cache() -> None:
+    is_powermetrics_available.cache_clear()
 
 
 def _has_powermetrics_sudo() -> bool:
@@ -51,6 +57,13 @@ def _has_powermetrics_sudo() -> bool:
         stderr=subprocess.PIPE,
         text=True,
     ) as process:
+        deadline = time.time() + 3
+        while process.poll() is None and time.time() < deadline:
+            time.sleep(0.05)
+        if process.poll() is None:
+            process.kill()
+            logger.debug("PowerMetrics sudo check timed out.")
+            return False
         _, stderr = process.communicate()
 
         if re.search(r"[sudo].*password", stderr):

--- a/codecarbon/core/resource_tracker.py
+++ b/codecarbon/core/resource_tracker.py
@@ -1,8 +1,10 @@
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Union
 
 from codecarbon.core import cpu, gpu, powermetrics
 from codecarbon.core.config import normalize_gpu_ids
+from codecarbon.core.hardware_cache import get_cached_tdp, get_or_run_setup
 from codecarbon.core.util import (
     detect_cpu_model,
     is_linux_os,
@@ -62,7 +64,11 @@ class ResourceTracker:
         """Set up CPU tracking using Intel Power Gadget."""
         logger.info("Tracking Intel CPU via Power Gadget")
         self.cpu_tracker = "Power Gadget"
-        hardware_cpu = CPU.from_utils(self.tracker._output_dir, "intel_power_gadget")
+        hardware_cpu = CPU.from_utils(
+            self.tracker._output_dir,
+            "intel_power_gadget",
+            tracking_mode=self.tracker._tracking_mode,
+        )
         self.tracker._hardware.append(hardware_cpu)
         self.tracker._conf["cpu_model"] = hardware_cpu.get_model()
         return True
@@ -74,6 +80,7 @@ class ResourceTracker:
         hardware_cpu = CPU.from_utils(
             output_dir=self.tracker._output_dir,
             mode="intel_rapl",
+            tracking_mode=self.tracker._tracking_mode,
             rapl_include_dram=self.tracker._rapl_include_dram,
             rapl_prefer_psys=self.tracker._rapl_prefer_psys,
         )
@@ -116,6 +123,23 @@ class ResourceTracker:
         elif is_linux_os():
             return "Linux OS detected: Please ensure RAPL files exist, and are readable, at /sys/class/powercap/intel-rapl/subsystem to measure CPU"
         return ""
+
+    def _setup_cpu_load_fast(self, model: str) -> bool:
+        """Set up cpu_load mode without loading the TDP registry (faster cold start)."""
+        if not cpu.is_psutil_available():
+            return False
+        logger.warning("No CPU tracking mode found. Falling back on CPU load mode.")
+        hardware_cpu = CPU.from_utils(
+            self.tracker._output_dir,
+            MODE_CPU_LOAD,
+            model or "Unknown CPU",
+            None,
+            tracking_mode=self.tracker._tracking_mode,
+        )
+        self.cpu_tracker = MODE_CPU_LOAD
+        self.tracker._conf["cpu_model"] = hardware_cpu.get_model()
+        self.tracker._hardware.append(hardware_cpu)
+        return True
 
     def _setup_fallback_tracking(self, tdp, max_power):
         """Set up fallback CPU tracking using TDP estimation."""
@@ -179,6 +203,30 @@ class ResourceTracker:
                 hardware_cpu = CPU.from_utils(self.tracker._output_dir, "constant")
             self.tracker._hardware.append(hardware_cpu)
 
+    def _try_platform_cpu_backend(self) -> bool:
+        """Try platform-preferred CPU backends when force_cpu_power is unset."""
+        if is_linux_os() and cpu.is_rapl_available():
+            self._setup_rapl()
+            return True
+        if is_mac_os():
+            cpu_model = detect_cpu_model() or ""
+            if is_mac_arm(cpu_model):
+                if self._setup_cpu_load_fast(cpu_model):
+                    return True
+                if powermetrics.is_powermetrics_available():
+                    self._setup_powermetrics()
+                    return True
+            elif cpu.is_powergadget_available():
+                self._setup_power_gadget()
+                return True
+            elif powermetrics.is_powermetrics_available():
+                self._setup_powermetrics()
+                return True
+        elif is_windows_os() and cpu.is_powergadget_available():
+            self._setup_power_gadget()
+            return True
+        return False
+
     def set_CPU_tracking(self):
         logger.info("[setup] CPU Tracking...")
         cpu_number = self.tracker._conf.get("cpu_physical_count")
@@ -195,29 +243,21 @@ class ResourceTracker:
         # Try force CPU load mode if requested
         if self.tracker._conf.get("force_mode_cpu_load", False):
             if tdp is None:
-                tdp = cpu.TDP()
+                tdp = get_cached_tdp(cpu)
             if max_power is None:
                 max_power = tdp.tdp * cpu_number if tdp.tdp is not None else None
             if tdp.tdp is not None or self.tracker._force_cpu_power is not None:
                 if self._setup_cpu_load_mode(tdp, max_power):
                     return
 
-        # Try various tracking methods in order of preference
-        if cpu.is_powergadget_available() and self.tracker._force_cpu_power is None:
-            self._setup_power_gadget()
-        elif cpu.is_rapl_available() and self.tracker._force_cpu_power is None:
-            self._setup_rapl()
-        elif (
-            powermetrics.is_powermetrics_available()
-            and self.tracker._force_cpu_power is None
-        ):
-            self._setup_powermetrics()
-        else:
-            if tdp is None:
-                tdp = cpu.TDP()
-            if max_power is None:
-                max_power = tdp.tdp * cpu_number if tdp.tdp is not None else None
-            self._setup_fallback_tracking(tdp, max_power)
+        if self.tracker._force_cpu_power is None and self._try_platform_cpu_backend():
+            return
+
+        if tdp is None:
+            tdp = get_cached_tdp(cpu)
+        if max_power is None:
+            max_power = tdp.tdp * cpu_number if tdp.tdp is not None else None
+        self._setup_fallback_tracking(tdp, max_power)
 
     def set_GPU_tracking(self):
         logger.info("[setup] GPU Tracking...")
@@ -250,14 +290,13 @@ class ResourceTracker:
             self.tracker._conf.setdefault("gpu_count", 0)
             self.tracker._conf.setdefault("gpu_model", "")
 
-    def set_CPU_GPU_ram_tracking(self):
-        """
-        Set up CPU, GPU and RAM tracking based on the user's configuration.
-        param tracker: BaseEmissionsTracker object
-        """
+    def _run_full_hardware_setup(self) -> None:
         self.set_RAM_tracking()
-        self.set_CPU_tracking()
-        self.set_GPU_tracking()
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            cpu_future = pool.submit(self.set_CPU_tracking)
+            gpu_future = pool.submit(self.set_GPU_tracking)
+            cpu_future.result()
+            gpu_future.result()
 
         logger.info(
             f"""The below tracking methods have been set up:
@@ -266,3 +305,10 @@ class ResourceTracker:
                 GPU Tracking Method: {self.gpu_tracker}
             """
         )
+
+    def set_CPU_GPU_ram_tracking(self):
+        """
+        Set up CPU, GPU and RAM tracking based on the user's configuration.
+        param tracker: BaseEmissionsTracker object
+        """
+        get_or_run_setup(self, self._run_full_hardware_setup)

--- a/codecarbon/external/hardware.py
+++ b/codecarbon/external/hardware.py
@@ -28,6 +28,14 @@ B_TO_GB = 1024 * 1024 * 1024
 
 MODE_CPU_LOAD = "cpu_load"
 
+# psutil.cpu_percent blocks on first sample; prime once per process for cpu_load mode.
+_cpu_load_percent_primed = False
+
+
+def clear_cpu_load_prime_cache() -> None:
+    global _cpu_load_percent_primed
+    _cpu_load_percent_primed = False
+
 
 @dataclass
 class BaseHardware(ABC):
@@ -210,6 +218,8 @@ class CPU(BaseHardware):
         # For process tracking: store last measurement time and CPU times
         self._last_measurement_time: Optional[float] = None
         self._last_cpu_times: Dict[int, float] = {}  # pid -> total cpu time
+        # First cpu_percent sample blocks briefly; later calls use interval=None.
+        self._cpu_percent_interval: Optional[float] = 0.05
 
         if self._mode == "intel_power_gadget":
             self._intel_interface = IntelPowerGadget(self._output_dir)
@@ -263,8 +273,10 @@ class CPU(BaseHardware):
         if self._tracking_mode == "machine":
             tdp = self._tdp
             cpu_load = psutil.cpu_percent(
-                interval=0.5, percpu=False
-            )  # Convert to 0-1 range
+                interval=self._cpu_percent_interval, percpu=False
+            )
+            if self._cpu_percent_interval is not None:
+                self._cpu_percent_interval = None
             logger.debug(f"CPU load : {self._tdp=} W and {cpu_load:.1f} %")
             # Cubic relationship with minimum 10% of TDP
             load_factor = 0.1 + 0.9 * ((cpu_load / 100.0) ** 3)
@@ -395,15 +407,18 @@ class CPU(BaseHardware):
         return super().measure_power_and_energy(last_duration=last_duration)
 
     def start(self):
+        global _cpu_load_percent_primed
         if self._mode in ["intel_power_gadget", "intel_rapl", "apple_powermetrics"]:
             self._intel_interface.start()
         # Reset process tracking state for fresh measurements
         self._last_measurement_time = None
         self._last_cpu_times = {}
         if self._mode == MODE_CPU_LOAD:
-            # The first time this is called it will return a meaningless 0.0 value which you are supposed to ignore.
-            _ = self._get_power_from_cpu_load()
-            _ = self._get_power_from_cpu_load()
+            if not _cpu_load_percent_primed:
+                _ = self._get_power_from_cpu_load()
+                _cpu_load_percent_primed = True
+            else:
+                self._cpu_percent_interval = None
 
     def monitor_power(self):
         cpu_power = self._get_power_from_cpus()
@@ -435,6 +450,7 @@ class CPU(BaseHardware):
                 mode=mode,
                 model=model,
                 tdp=tdp,
+                tracking_mode=tracking_mode,
                 rapl_include_dram=rapl_include_dram,
                 rapl_prefer_psys=rapl_prefer_psys,
             )

--- a/docs/explanation/faq.md
+++ b/docs/explanation/faq.md
@@ -45,6 +45,10 @@ If you find any functionality missing in the CodeCarbon repo, please [open an is
 
 By default, CodeCarbon saves emissions data locally. You can configure HTTP output to send data to your own endpoints. We do send data to our API when the user allows it and logs in. No data is sent to third parties without explicit configuration.
 
+## Why is my second tracker faster than the first?
+
+In a single Python process, the first tracker pays a one-time cost to detect hardware (CPU model, GPU devices, RAM, power backends, and related setup). Later trackers in the same process reuse that cached setup, so `start()` and `stop()` are much faster on warm runs. This is expected: each new process still performs a full cold setup once.
+
 ## What hardware does CodeCarbon support?
 
 CodeCarbon supports various CPU architectures, GPUs, and cloud providers. For details on measurement priority and supported hardware, see the [Methodology](methodology.md#cpu-metrics-priority) page.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,11 @@ from codecarbon.core.hardware_cache import clear_cache as clear_hardware_cache
 @pytest.fixture(autouse=True)
 def _reset_process_hardware_cache():
     """Isolate hardware/TDP/GPU probe caches between tests."""
+    # Import probe modules so clear_cache() can reset their lru_cache state.
+    import codecarbon.core.cpu  # noqa: F401
+    import codecarbon.core.gpu_amd  # noqa: F401
+    import codecarbon.core.gpu_nvidia  # noqa: F401
+    import codecarbon.core.powermetrics  # noqa: F401
     from codecarbon.core.util import detect_cpu_model
 
     clear_hardware_cache()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared pytest fixtures for the CodeCarbon test suite."""
+
+import pytest
+
+from codecarbon.core.hardware_cache import clear_cache as clear_hardware_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_process_hardware_cache():
+    """Isolate hardware/TDP/GPU probe caches between tests."""
+    from codecarbon.core.util import detect_cpu_model
+
+    clear_hardware_cache()
+    detect_cpu_model.cache_clear()
+    yield
+    clear_hardware_cache()
+    detect_cpu_model.cache_clear()

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -35,7 +35,24 @@ class TestCPU(unittest.TestCase):
     def test_is_powergadget_available_returns_false_on_exception(
         self, mock_powergadget
     ):
+        from codecarbon.core.cpu import clear_powergadget_cache
+
+        clear_powergadget_cache()
         self.assertFalse(is_powergadget_available())
+        clear_powergadget_cache()
+
+    def test_is_powergadget_available_returns_cached_value(self):
+        from codecarbon.core.cpu import clear_powergadget_cache
+
+        clear_powergadget_cache()
+        with mock.patch("codecarbon.core.cpu.IntelPowerGadget"):
+            self.assertTrue(is_powergadget_available())
+        with mock.patch(
+            "codecarbon.core.cpu.IntelPowerGadget",
+            side_effect=Exception("should not instantiate"),
+        ):
+            self.assertTrue(is_powergadget_available())
+        clear_powergadget_cache()
 
     @mock.patch("psutil.cpu_times")
     def test_is_psutil_available_with_nice(self, mock_cpu_times):
@@ -294,7 +311,7 @@ class TestIntelPowerGadget(unittest.TestCase):
         mock_warning.assert_called_once()
 
     @mock.patch("codecarbon.core.cpu.IntelPowerGadget._log_values")
-    @mock.patch("codecarbon.core.cpu.pd.read_csv", side_effect=Exception("bad csv"))
+    @mock.patch("pandas.read_csv", side_effect=Exception("bad csv"))
     @mock.patch("codecarbon.core.cpu.IntelPowerGadget._setup_cli")
     def test_get_cpu_details_returns_empty_dict_on_read_error(
         self, mock_setup, mock_read_csv, mock_log_values
@@ -374,7 +391,7 @@ class TestTDP(unittest.TestCase):
     def test_get_cpu_power_from_registry_returns_none_without_match(self):
         tdp = TDP.__new__(TDP)
         with (
-            mock.patch("codecarbon.core.cpu.DataSource") as mock_data_source,
+            mock.patch("codecarbon.input.DataSource") as mock_data_source,
             mock.patch.object(tdp, "_get_matching_cpu", return_value=None),
         ):
             mock_data_source.return_value.get_cpu_power_data.return_value = (
@@ -597,11 +614,20 @@ class TestResourceTrackerCPUTracking(unittest.TestCase):
 
         with (
             mock.patch(
-                "codecarbon.core.resource_tracker.cpu.TDP",
+                "codecarbon.core.resource_tracker.get_cached_tdp",
                 side_effect=AssertionError(
                     "TDP should not be instantiated when RAPL is active"
                 ),
             ) as mocked_tdp,
+            mock.patch(
+                "codecarbon.core.resource_tracker.is_linux_os", return_value=True
+            ),
+            mock.patch(
+                "codecarbon.core.resource_tracker.is_mac_os", return_value=False
+            ),
+            mock.patch(
+                "codecarbon.core.resource_tracker.is_windows_os", return_value=False
+            ),
             mock.patch(
                 "codecarbon.core.resource_tracker.cpu.is_powergadget_available",
                 return_value=False,
@@ -625,6 +651,7 @@ class TestResourceTrackerCPUTracking(unittest.TestCase):
         mocked_from_utils.assert_called_once_with(
             output_dir=tracker._output_dir,
             mode="intel_rapl",
+            tracking_mode=tracker._tracking_mode,
             rapl_include_dram=tracker._rapl_include_dram,
             rapl_prefer_psys=tracker._rapl_prefer_psys,
         )
@@ -650,7 +677,8 @@ class TestResourceTrackerCPUTracking(unittest.TestCase):
 
         with (
             mock.patch(
-                "codecarbon.core.resource_tracker.cpu.TDP", return_value=fake_tdp
+                "codecarbon.core.resource_tracker.get_cached_tdp",
+                return_value=fake_tdp,
             ) as mocked_tdp,
             mock.patch(
                 "codecarbon.core.resource_tracker.ResourceTracker._setup_cpu_load_mode",
@@ -674,7 +702,7 @@ class TestResourceTrackerCPUTracking(unittest.TestCase):
         ):
             resource_tracker.set_CPU_tracking()
 
-        mocked_tdp.assert_called_once_with()
+        mocked_tdp.assert_called_once()
         mocked_setup_cpu_load.assert_called_once_with(fake_tdp, 100)
         mocked_fallback.assert_not_called()
 
@@ -697,11 +725,21 @@ class TestResourceTrackerCPUTracking(unittest.TestCase):
 
         with (
             mock.patch(
-                "codecarbon.core.resource_tracker.cpu.TDP", return_value=fake_tdp
+                "codecarbon.core.resource_tracker.get_cached_tdp",
+                return_value=fake_tdp,
             ) as mocked_tdp,
             mock.patch(
                 "codecarbon.core.resource_tracker.ResourceTracker._setup_fallback_tracking"
             ) as mocked_fallback,
+            mock.patch(
+                "codecarbon.core.resource_tracker.is_mac_os", return_value=False
+            ),
+            mock.patch(
+                "codecarbon.core.resource_tracker.is_linux_os", return_value=False
+            ),
+            mock.patch(
+                "codecarbon.core.resource_tracker.is_windows_os", return_value=False
+            ),
             mock.patch(
                 "codecarbon.core.resource_tracker.cpu.is_powergadget_available",
                 return_value=False,
@@ -717,7 +755,7 @@ class TestResourceTrackerCPUTracking(unittest.TestCase):
         ):
             resource_tracker.set_CPU_tracking()
 
-        mocked_tdp.assert_called_once_with()
+        mocked_tdp.assert_called_once()
         mocked_fallback.assert_called_once_with(fake_tdp, 80)
 
 

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -159,6 +159,13 @@ class TestGpuImportWarnings:
 
 
 class TestGpuMethods:
+    def setup_method(self):
+        from codecarbon.core.gpu_amd import clear_rocm_system_cache
+        from codecarbon.core.gpu_nvidia import clear_nvidia_system_cache
+
+        clear_rocm_system_cache()
+        clear_nvidia_system_cache()
+
     @mock.patch("codecarbon.core.gpu_amd.subprocess.check_output")
     def test_is_rocm_system(self, mock_subprocess):
         from codecarbon.core.gpu import is_rocm_system

--- a/tests/test_hardware_cache.py
+++ b/tests/test_hardware_cache.py
@@ -249,3 +249,40 @@ def test_get_cached_tdp_reuses_instance():
     first = hardware_cache.get_cached_tdp(fake_cpu)
     second = hardware_cache.get_cached_tdp(fake_cpu)
     assert first is second
+
+
+def test_canonical_gpu_ids_accepts_scalar():
+    assert hardware_cache._canonical_gpu_ids(0) == ("0",)
+
+
+def test_spec_from_hardware_raises_for_unhandled_kind():
+    class UnhandledKind:
+        value = "unhandled"
+
+    with patch.object(hardware_cache, "_hardware_kind", return_value=UnhandledKind()):
+        with pytest.raises(TypeError, match="Unsupported hardware type"):
+            hardware_cache._spec_from_hardware(object())
+
+
+def test_hardware_from_spec_raises_when_kind_not_handled():
+    sentinel = object()
+    real = hardware_cache.HardwareKind
+
+    with patch("codecarbon.core.hardware_cache.HardwareKind") as mock_cls:
+        mock_cls.side_effect = lambda value: sentinel
+        mock_cls.RAM = real.RAM
+        mock_cls.CPU = real.CPU
+        mock_cls.APPLE_CHIP = real.APPLE_CHIP
+        mock_cls.GPU = real.GPU
+
+        with pytest.raises(ValueError, match="Unknown hardware spec kind"):
+            hardware_cache._hardware_from_spec({"kind": "ram"}, "out")
+
+
+def test_spec_and_rebuild_roundtrip_for_ram():
+    ram_hw = RAM(tracking_mode="machine", force_ram_power=12.5)
+    spec = hardware_cache._spec_from_hardware(ram_hw)
+    rebuilt = hardware_cache._hardware_from_spec(spec, "out2")
+    assert type(rebuilt).__name__ == "RAM"
+    assert rebuilt._tracking_mode == "machine"
+    assert rebuilt._force_ram_power == 12.5

--- a/tests/test_hardware_cache.py
+++ b/tests/test_hardware_cache.py
@@ -1,0 +1,251 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from codecarbon.core import hardware_cache
+from codecarbon.external.hardware import CPU
+from codecarbon.external.ram import RAM
+
+
+def make_tracker(**overrides):
+    defaults = {
+        "_tracking_mode": "machine",
+        "_force_cpu_power": None,
+        "_force_ram_power": None,
+        "_conf": {},
+        "_gpu_ids": None,
+        "_rapl_include_dram": False,
+        "_rapl_prefer_psys": False,
+        "_output_dir": "out",
+        "_hardware": [],
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_make_key_normalizes_gpu_ids():
+    tracker = make_tracker(_gpu_ids=[0, 1])
+    key = hardware_cache.make_key(tracker)
+    assert key.gpu_ids == ("0", "1")
+
+
+def test_make_key_treats_equivalent_gpu_id_types_as_same_key():
+    key_int = hardware_cache.make_key(make_tracker(_gpu_ids=[0]))
+    key_str = hardware_cache.make_key(make_tracker(_gpu_ids=["0"]))
+    assert key_int == key_str
+
+
+def test_spec_and_rebuild_roundtrip_for_cpu():
+    cpu_hw = CPU.from_utils("out", "cpu_load", "Test CPU", 100)
+    spec = hardware_cache._spec_from_hardware(cpu_hw)
+    rebuilt = hardware_cache._hardware_from_spec(spec, "out2")
+    assert type(rebuilt).__name__ == "CPU"
+    assert rebuilt._model == "Test CPU"
+    assert rebuilt._mode == "cpu_load"
+
+
+def test_spec_from_hardware_gpu_and_rapl_cpu():
+    gpu_hw = type("GPU", (), {"gpu_ids": [0, 1]})()
+    assert hardware_cache._spec_from_hardware(gpu_hw) == {
+        "kind": "gpu",
+        "gpu_ids": ["0", "1"],
+    }
+
+    gpu_hw_no_ids = type("GPU", (), {"gpu_ids": None})()
+    assert hardware_cache._spec_from_hardware(gpu_hw_no_ids) == {
+        "kind": "gpu",
+        "gpu_ids": None,
+    }
+
+    gpu_hw_empty_ids = type("GPU", (), {"gpu_ids": []})()
+    assert hardware_cache._spec_from_hardware(gpu_hw_empty_ids) == {
+        "kind": "gpu",
+        "gpu_ids": None,
+    }
+
+
+def test_capture_serializes_gpu_hardware():
+    gpu_hw = type("GPU", (), {"gpu_ids": (0, 1)})()
+    tracker = make_tracker(_hardware=[gpu_hw])
+    resource_tracker = SimpleNamespace(
+        tracker=tracker,
+        ram_tracker="ram",
+        cpu_tracker="cpu",
+        gpu_tracker="gpu",
+    )
+
+    plan = hardware_cache.capture(resource_tracker)
+
+    assert plan.hardware_specs == [{"kind": "gpu", "gpu_ids": ["0", "1"]}]
+
+
+def test_hardware_kind_apple_chip():
+    apple_hw = type("AppleSiliconChip", (), {})()
+    assert hardware_cache._hardware_kind(apple_hw) == "apple_chip"
+
+
+def test_spec_from_hardware_apple_chip():
+    apple_hw = type(
+        "AppleSiliconChip",
+        (),
+        {"_model": "Apple M1", "chip_part": "CPU"},
+    )()
+    assert hardware_cache._spec_from_hardware(apple_hw) == {
+        "kind": "apple_chip",
+        "model": "Apple M1",
+        "chip_part": "CPU",
+    }
+
+
+def test_hardware_from_spec_rebuilds_gpu():
+    fake_gpu = SimpleNamespace(gpu_ids=[0])
+    with patch(
+        "codecarbon.external.hardware.GPU.from_utils",
+        return_value=fake_gpu,
+    ) as mock_from_utils:
+        rebuilt = hardware_cache._hardware_from_spec(
+            {"kind": "gpu", "gpu_ids": ["0"]},
+            "out",
+        )
+    mock_from_utils.assert_called_once_with(gpu_ids=["0"])
+    assert rebuilt is fake_gpu
+
+
+def test_hardware_from_spec_rejects_unknown_kind():
+    with pytest.raises(ValueError, match="Unknown hardware spec kind"):
+        hardware_cache._hardware_from_spec({"kind": "unknown"}, "out")
+
+
+def test_spec_from_hardware_intel_rapl_cpu():
+    cpu_hw = type(
+        "CPU",
+        (),
+        {
+            "_mode": "intel_rapl",
+            "_model": "Intel CPU",
+            "_tdp": 65,
+            "_tracking_mode": "machine",
+            "_intel_interface": SimpleNamespace(
+                rapl_include_dram=True,
+                rapl_prefer_psys=True,
+            ),
+        },
+    )()
+    spec = hardware_cache._spec_from_hardware(cpu_hw)
+    assert spec["rapl_include_dram"] is True
+    assert spec["rapl_prefer_psys"] is True
+    assert spec["rapl_dir"] == "/sys/class/powercap/intel-rapl/subsystem"
+
+
+def test_spec_and_rebuild_roundtrip_for_apple_chip():
+    spec = {"kind": "apple_chip", "model": "Apple M1", "chip_part": "CPU"}
+    fake_chip = SimpleNamespace(_model="Apple M1")
+    with patch(
+        "codecarbon.external.hardware.AppleSiliconChip",
+        return_value=fake_chip,
+    ) as mock_chip_cls:
+        rebuilt = hardware_cache._hardware_from_spec(spec, "out")
+    mock_chip_cls.assert_called_once_with(
+        output_dir="out",
+        model="Apple M1",
+        chip_part="CPU",
+    )
+    assert rebuilt._model == "Apple M1"
+
+
+def test_capture_and_apply_restore_hardware_plan():
+    tracker = make_tracker(
+        _conf={
+            "cpu_count": 8,
+            "cpu_physical_count": 4,
+            "cpu_model": "Cached CPU",
+            "gpu_count": 0,
+            "gpu_model": "",
+            "gpu_ids": ["0"],
+        },
+        _gpu_ids=[0],
+        _hardware=[RAM(tracking_mode="machine")],
+    )
+    resource_tracker = SimpleNamespace(
+        tracker=tracker,
+        ram_tracker="cached_ram",
+        cpu_tracker="cached_cpu",
+        gpu_tracker="cached_gpu",
+    )
+    plan = hardware_cache.capture(resource_tracker)
+
+    tracker2 = make_tracker()
+    rt2 = SimpleNamespace(
+        tracker=tracker2,
+        ram_tracker="old",
+        cpu_tracker="old",
+        gpu_tracker="old",
+    )
+    hardware_cache.apply(rt2, plan)
+
+    assert rt2.ram_tracker == "cached_ram"
+    assert rt2.cpu_tracker == "cached_cpu"
+    assert tracker2._conf["cpu_model"] == "Cached CPU"
+    assert tracker2._conf["cpu_count"] == 8
+    assert tracker2._conf["cpu_physical_count"] == 4
+    assert tracker2._gpu_ids == ["0"]
+    assert len(tracker2._hardware) == 1
+    assert type(tracker2._hardware[0]).__name__ == "RAM"
+
+
+def test_get_or_run_setup_runs_setup_once():
+    tracker = make_tracker()
+    resource_tracker = SimpleNamespace(
+        tracker=tracker,
+        ram_tracker="Unspecified",
+        cpu_tracker="Unspecified",
+        gpu_tracker="Unspecified",
+    )
+    calls = {"count": 0}
+
+    def setup_fn():
+        calls["count"] += 1
+        resource_tracker.ram_tracker = "ran"
+
+    hardware_cache.clear_cache()
+    hardware_cache.get_or_run_setup(resource_tracker, setup_fn)
+    hardware_cache.get_or_run_setup(resource_tracker, setup_fn)
+
+    assert calls["count"] == 1
+    assert resource_tracker.ram_tracker == "ran"
+
+
+def test_hardware_kind_rejects_unknown_type():
+    with pytest.raises(TypeError):
+        hardware_cache._hardware_kind(object())
+
+
+def test_clear_cache_resets_probe_caches():
+    from codecarbon.core.cpu import clear_powergadget_cache, is_powergadget_available
+    from codecarbon.core.powermetrics import (
+        clear_powermetrics_cache,
+        is_powermetrics_available,
+    )
+
+    clear_powergadget_cache()
+    clear_powermetrics_cache()
+    with patch("codecarbon.core.cpu.IntelPowerGadget", side_effect=Exception("nope")):
+        assert is_powergadget_available() is False
+    with patch(
+        "codecarbon.core.powermetrics.ApplePowermetrics", side_effect=Exception("nope")
+    ):
+        assert is_powermetrics_available() is False
+
+    hardware_cache.clear_cache()
+
+    assert is_powergadget_available.cache_info().currsize == 0
+    assert is_powermetrics_available.cache_info().currsize == 0
+
+
+def test_get_cached_tdp_reuses_instance():
+    hardware_cache.clear_cache()
+    fake_cpu = SimpleNamespace(TDP=lambda: SimpleNamespace(model="cached"))
+    first = hardware_cache.get_cached_tdp(fake_cpu)
+    second = hardware_cache.get_cached_tdp(fake_cpu)
+    assert first is second

--- a/tests/test_powermetrics.py
+++ b/tests/test_powermetrics.py
@@ -15,6 +15,32 @@ class FakeProcess:
     def communicate(self):
         return ("", self._stderr)
 
+    def poll(self):
+        return self.returncode
+
+    def kill(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class HangingProcess:
+    def __init__(self):
+        self.killed = False
+
+    def poll(self):
+        return None
+
+    def kill(self):
+        self.killed = True
+
+    def communicate(self):
+        return ("", "")
+
     def __enter__(self):
         return self
 
@@ -48,11 +74,68 @@ class TestApplePowerMetrics:
         assert cpu_details == expected_details
 
     def test_is_powermetrics_available_returns_false_on_instantiation_error(self):
+        from codecarbon.core.powermetrics import clear_powermetrics_cache
+
+        clear_powermetrics_cache()
         with mock.patch(
             "codecarbon.core.powermetrics.ApplePowermetrics",
             side_effect=Exception("boom"),
         ):
             assert is_powermetrics_available() is False
+        clear_powermetrics_cache()
+
+    def test_is_powermetrics_available_returns_cached_value(self):
+        from codecarbon.core.powermetrics import clear_powermetrics_cache
+
+        clear_powermetrics_cache()
+        with (
+            mock.patch("codecarbon.core.powermetrics.ApplePowermetrics"),
+            mock.patch(
+                "codecarbon.core.powermetrics._has_powermetrics_sudo",
+                return_value=True,
+            ),
+        ):
+            assert is_powermetrics_available() is True
+        with mock.patch(
+            "codecarbon.core.powermetrics.ApplePowermetrics",
+            side_effect=Exception("should not instantiate"),
+        ):
+            assert is_powermetrics_available() is True
+        clear_powermetrics_cache()
+
+    def test_is_powermetrics_available_probes_sudo_when_uncached(self):
+        from codecarbon.core.powermetrics import clear_powermetrics_cache
+
+        clear_powermetrics_cache()
+        with (
+            mock.patch("codecarbon.core.powermetrics.ApplePowermetrics"),
+            mock.patch(
+                "codecarbon.core.powermetrics._has_powermetrics_sudo",
+                return_value=True,
+            ) as mock_sudo,
+        ):
+            assert is_powermetrics_available() is True
+        mock_sudo.assert_called_once()
+        clear_powermetrics_cache()
+
+    def test_has_powermetrics_sudo_kills_process_on_timeout(self):
+        hanging = HangingProcess()
+        with (
+            mock.patch(
+                "codecarbon.core.powermetrics.shutil.which",
+                side_effect=["sudo-path", "powermetrics-path"],
+            ),
+            mock.patch(
+                "codecarbon.core.powermetrics.subprocess.Popen",
+                return_value=hanging,
+            ),
+            mock.patch(
+                "codecarbon.core.powermetrics.time.time", side_effect=[0, 0, 10]
+            ),
+            mock.patch("codecarbon.core.powermetrics.time.sleep"),
+        ):
+            assert powermetrics_module._has_powermetrics_sudo() is False
+        assert hanging.killed is True
 
     def test_has_powermetrics_sudo_returns_false_when_sudo_missing(self):
         with mock.patch("codecarbon.core.powermetrics.shutil.which", return_value=None):

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -204,7 +204,7 @@ def test_set_cpu_tracking_force_mode_uses_cpu_load_and_returns():
     fake_tdp = SimpleNamespace(tdp=20, model="CPU")
 
     with (
-        patch("codecarbon.core.resource_tracker.cpu.TDP", return_value=fake_tdp),
+        patch("codecarbon.core.resource_tracker.get_cached_tdp", return_value=fake_tdp),
         patch.object(
             resource_tracker, "_setup_cpu_load_mode", return_value=True
         ) as mock_setup,
@@ -219,6 +219,9 @@ def test_set_cpu_tracking_prefers_power_gadget():
     resource_tracker = ResourceTracker(tracker)
 
     with (
+        patch("codecarbon.core.resource_tracker.is_mac_os", return_value=False),
+        patch("codecarbon.core.resource_tracker.is_linux_os", return_value=False),
+        patch("codecarbon.core.resource_tracker.is_windows_os", return_value=True),
         patch(
             "codecarbon.core.resource_tracker.cpu.is_powergadget_available",
             return_value=True,
@@ -237,11 +240,134 @@ def test_set_cpu_tracking_prefers_power_gadget():
     mock_power_gadget.assert_called_once_with()
 
 
+def test_set_cpu_tracking_mac_arm_prefers_cpu_load_over_powermetrics():
+    tracker = make_tracker()
+    resource_tracker = ResourceTracker(tracker)
+
+    with (
+        patch("codecarbon.core.resource_tracker.is_mac_os", return_value=True),
+        patch("codecarbon.core.resource_tracker.is_linux_os", return_value=False),
+        patch("codecarbon.core.resource_tracker.is_windows_os", return_value=False),
+        patch(
+            "codecarbon.core.resource_tracker.detect_cpu_model",
+            return_value="Apple M1 Max",
+        ),
+        patch(
+            "codecarbon.core.resource_tracker.cpu.is_powergadget_available",
+            return_value=True,
+        ),
+        patch(
+            "codecarbon.core.resource_tracker.powermetrics.is_powermetrics_available",
+            return_value=True,
+        ),
+        patch.object(resource_tracker, "_setup_power_gadget") as mock_power_gadget,
+        patch.object(resource_tracker, "_setup_powermetrics") as mock_powermetrics,
+        patch.object(
+            resource_tracker, "_setup_cpu_load_fast", return_value=True
+        ) as mock_cpu_load,
+    ):
+        resource_tracker.set_CPU_tracking()
+
+    mock_power_gadget.assert_not_called()
+    mock_powermetrics.assert_not_called()
+    mock_cpu_load.assert_called_once_with("Apple M1 Max")
+
+
+def test_setup_cpu_load_fast_returns_false_without_psutil():
+    tracker = make_tracker()
+    resource_tracker = ResourceTracker(tracker)
+
+    with patch(
+        "codecarbon.core.resource_tracker.cpu.is_psutil_available",
+        return_value=False,
+    ):
+        assert resource_tracker._setup_cpu_load_fast("Intel CPU") is False
+
+
+def test_try_platform_cpu_backend_mac_intel_uses_power_gadget():
+    tracker = make_tracker()
+    resource_tracker = ResourceTracker(tracker)
+
+    with (
+        patch("codecarbon.core.resource_tracker.is_mac_os", return_value=True),
+        patch("codecarbon.core.resource_tracker.is_linux_os", return_value=False),
+        patch("codecarbon.core.resource_tracker.is_windows_os", return_value=False),
+        patch(
+            "codecarbon.core.resource_tracker.detect_cpu_model",
+            return_value="Intel(R) Core(TM) i7",
+        ),
+        patch("codecarbon.core.resource_tracker.is_mac_arm", return_value=False),
+        patch(
+            "codecarbon.core.resource_tracker.cpu.is_powergadget_available",
+            return_value=True,
+        ),
+        patch.object(resource_tracker, "_setup_power_gadget") as mock_power_gadget,
+    ):
+        assert resource_tracker._try_platform_cpu_backend() is True
+
+    mock_power_gadget.assert_called_once_with()
+
+
+def test_try_platform_cpu_backend_mac_intel_falls_back_to_powermetrics():
+    tracker = make_tracker()
+    resource_tracker = ResourceTracker(tracker)
+
+    with (
+        patch("codecarbon.core.resource_tracker.is_mac_os", return_value=True),
+        patch("codecarbon.core.resource_tracker.is_linux_os", return_value=False),
+        patch("codecarbon.core.resource_tracker.is_windows_os", return_value=False),
+        patch(
+            "codecarbon.core.resource_tracker.detect_cpu_model",
+            return_value="Intel(R) Core(TM) i7",
+        ),
+        patch("codecarbon.core.resource_tracker.is_mac_arm", return_value=False),
+        patch(
+            "codecarbon.core.resource_tracker.cpu.is_powergadget_available",
+            return_value=False,
+        ),
+        patch(
+            "codecarbon.core.resource_tracker.powermetrics.is_powermetrics_available",
+            return_value=True,
+        ),
+        patch.object(resource_tracker, "_setup_powermetrics") as mock_powermetrics,
+    ):
+        assert resource_tracker._try_platform_cpu_backend() is True
+
+    mock_powermetrics.assert_called_once_with()
+
+
+def test_set_cpu_tracking_mac_arm_falls_back_to_powermetrics_when_cpu_load_unavailable():
+    tracker = make_tracker()
+    resource_tracker = ResourceTracker(tracker)
+
+    with (
+        patch("codecarbon.core.resource_tracker.is_mac_os", return_value=True),
+        patch("codecarbon.core.resource_tracker.is_linux_os", return_value=False),
+        patch("codecarbon.core.resource_tracker.is_windows_os", return_value=False),
+        patch(
+            "codecarbon.core.resource_tracker.detect_cpu_model",
+            return_value="Apple M4",
+        ),
+        patch(
+            "codecarbon.core.resource_tracker.powermetrics.is_powermetrics_available",
+            return_value=True,
+        ),
+        patch.object(resource_tracker, "_setup_cpu_load_fast", return_value=False),
+        patch.object(resource_tracker, "_setup_powermetrics") as mock_powermetrics,
+    ):
+        resource_tracker.set_CPU_tracking()
+
+    mock_powermetrics.assert_called_once_with()
+
+
 def test_set_cpu_tracking_prefers_rapl_before_powermetrics():
     tracker = make_tracker()
     resource_tracker = ResourceTracker(tracker)
 
     with (
+        patch("codecarbon.core.resource_tracker.is_linux_os", return_value=True),
+        patch("codecarbon.core.resource_tracker.is_mac_os", return_value=False),
+        patch("codecarbon.core.resource_tracker.is_windows_os", return_value=False),
         patch(
             "codecarbon.core.resource_tracker.cpu.is_powergadget_available",
             return_value=False,
@@ -277,7 +403,7 @@ def test_set_cpu_tracking_falls_back_when_forced_power_is_set():
             "codecarbon.core.resource_tracker.powermetrics.is_powermetrics_available",
             return_value=True,
         ),
-        patch("codecarbon.core.resource_tracker.cpu.TDP", return_value=fake_tdp),
+        patch("codecarbon.core.resource_tracker.get_cached_tdp", return_value=fake_tdp),
         patch.object(resource_tracker, "_setup_fallback_tracking") as mock_fallback,
     ):
         resource_tracker.set_CPU_tracking()
@@ -350,3 +476,33 @@ def test_set_cpu_gpu_ram_tracking_calls_all_setup_steps():
     mock_ram.assert_called_once_with()
     mock_cpu.assert_called_once_with()
     mock_gpu.assert_called_once_with()
+
+
+def test_hardware_cache_reuses_setup():
+    from codecarbon.core import hardware_cache
+
+    hardware_cache.clear_cache()
+    key = hardware_cache.make_key(make_tracker())
+    hardware_cache._plans[key] = hardware_cache._HardwarePlan(
+        ram_tracker="cached_ram",
+        cpu_tracker="cached_cpu",
+        gpu_tracker="cached_gpu",
+        conf={"cpu_model": "Cached CPU", "gpu_count": 0, "gpu_model": ""},
+        hardware_specs=[],
+    )
+
+    tracker2 = make_tracker()
+    rt2 = ResourceTracker(tracker2)
+    with (
+        patch.object(rt2, "set_RAM_tracking") as mock_ram,
+        patch.object(rt2, "set_CPU_tracking") as mock_cpu,
+        patch.object(rt2, "set_GPU_tracking") as mock_gpu,
+    ):
+        rt2.set_CPU_GPU_ram_tracking()
+        mock_ram.assert_not_called()
+        mock_cpu.assert_not_called()
+        mock_gpu.assert_not_called()
+
+    assert rt2.cpu_tracker == "cached_cpu"
+    assert tracker2._conf.get("cpu_model") == "Cached CPU"
+    hardware_cache.clear_cache()

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -506,3 +506,91 @@ def test_hardware_cache_reuses_setup():
     assert rt2.cpu_tracker == "cached_cpu"
     assert tracker2._conf.get("cpu_model") == "Cached CPU"
     hardware_cache.clear_cache()
+
+
+def test_setup_power_gadget_configures_tracker():
+    tracker = make_tracker()
+    resource_tracker = ResourceTracker(tracker)
+    hardware_cpu = MagicMock()
+    hardware_cpu.get_model.return_value = "Intel CPU"
+
+    with patch(
+        "codecarbon.core.resource_tracker.CPU.from_utils", return_value=hardware_cpu
+    ) as mock_from_utils:
+        assert resource_tracker._setup_power_gadget() is True
+
+    mock_from_utils.assert_called_once_with(
+        "out",
+        "intel_power_gadget",
+        tracking_mode="machine",
+    )
+    assert resource_tracker.cpu_tracker == "Power Gadget"
+    assert tracker._conf["cpu_model"] == "Intel CPU"
+    assert tracker._hardware == [hardware_cpu]
+
+
+def test_setup_fallback_tracking_uses_forced_cpu_power():
+    tracker = make_tracker(_force_cpu_power=99)
+    resource_tracker = ResourceTracker(tracker)
+    hardware_cpu = MagicMock()
+    tdp = SimpleNamespace(model="Matched CPU")
+
+    with (
+        patch(
+            "codecarbon.core.resource_tracker.cpu.is_psutil_available",
+            return_value=True,
+        ),
+        patch(
+            "codecarbon.core.resource_tracker.CPU.from_utils", return_value=hardware_cpu
+        ) as mock_from_utils,
+        patch.object(
+            resource_tracker, "_get_install_instructions", return_value="instructions"
+        ),
+    ):
+        resource_tracker._setup_fallback_tracking(tdp, None)
+
+    mock_from_utils.assert_called_once_with(
+        "out",
+        MODE_CPU_LOAD,
+        "Matched CPU",
+        99,
+        tracking_mode="machine",
+    )
+    assert resource_tracker.cpu_tracker == MODE_CPU_LOAD
+    assert tracker._conf["cpu_model"] == "Matched CPU"
+
+
+def test_setup_fallback_tracking_cpu_load_when_tdp_falsy():
+    tracker = make_tracker()
+    resource_tracker = ResourceTracker(tracker)
+    hardware_cpu = MagicMock()
+
+    class FalseyTDP:
+        model = "Unknown CPU"
+
+        def __bool__(self):
+            return False
+
+    with (
+        patch(
+            "codecarbon.core.resource_tracker.cpu.is_psutil_available",
+            return_value=True,
+        ),
+        patch(
+            "codecarbon.core.resource_tracker.CPU.from_utils", return_value=hardware_cpu
+        ) as mock_from_utils,
+        patch.object(
+            resource_tracker, "_get_install_instructions", return_value="instructions"
+        ),
+    ):
+        resource_tracker._setup_fallback_tracking(FalseyTDP(), None)
+
+    mock_from_utils.assert_called_once_with(
+        "out",
+        MODE_CPU_LOAD,
+        "Unknown CPU",
+        None,
+        tracking_mode="machine",
+    )
+    assert resource_tracker.cpu_tracker == MODE_CPU_LOAD
+    assert tracker._hardware == [hardware_cpu]


### PR DESCRIPTION
## Summary

Part **2/4** of the tracker performance stack. **Depends on #1251.**

cc @inimaz — this is the hardware-cache layer of the #1246 split.

Adds process-level hardware reuse and faster detection so repeat tracker runs in the same Python process skip repeated probing:

- New `hardware_cache.py` with `HardwareKind` enum and per-process setup cache
- Reuse CPU/GPU/RAM detection across tracker instances (`get_or_run_setup`)
- Cache probe results via `@lru_cache` (Power Gadget, PowerMetrics, NVIDIA, ROCm)
- Platform-aware CPU backend order (Mac ARM prefers fast `cpu_load` before PowerMetrics)
- Parallel CPU/GPU setup with `ThreadPoolExecutor`
- Global `cpu_percent` prime once per process for `cpu_load` mode
- PowerMetrics sudo check timeout (3 s)
- FAQ note on warm hardware reuse within one process

## Benchmarks (measured locally, offline Mac ARM, 2026-06-21)

Cumulative with #1251; fresh subprocess for cold metrics.

| Metric | master | #1251 only | **#1251 + this PR** | Δ vs master |
|--------|--------|------------|---------------------|-------------|
| Tracker `__init__` p50 | 190 ms | 1.9 ms | **1.2 ms** | ~99% faster |
| Cold lifecycle p50 (`init→start→stop`) | 1,685 ms | 1,767 ms | **408 ms** | **~76% faster (~4×)** |
| Warm lifecycle best (same process) | 1,565 ms | 1,561 ms | **4.8 ms** | **~325× faster** |
| CLI monitor subprocess p50 | 850 ms | 786 ms | 694 ms | ~18% faster |

## Stack

1. #1251 — lazy initialization & import slimming
2. **This PR** — hardware detection cache & warm-path reuse
3. #1253 — lazy API run creation
4. #1254 — CLI monitor startup

## CI / quality

- [x] `pre-commit run` on all changed files — passed
- [x] `pytest tests/test_hardware_cache.py tests/test_resource_tracker.py tests/test_cpu.py tests/test_powermetrics.py tests/test_gpu.py` — 106 passed
- [x] Full stacked suite (#1254 tip) — 535 passed locally

## Test plan

- [ ] Reviewer: second tracker in same process should reuse cached hardware, not re-probe

## Replaces

Split from #1246.