### PR TITLE
fix: requirements-api.txt tested in ci

### DIFF
--- a/.github/workflows/test-api-requirements.yml
+++ b/.github/workflows/test-api-requirements.yml
@@ -1,0 +1,25 @@
+# Keep the generated API requirements file installable with pip.
+# This is done to prevent issues where the pyproject is fine in local
+# But the requirements file generated is not installable
+permissions:
+  contents: read
+name: test-api-requirements
+
+on:
+  pull_request:
+    paths:
+      - "requirements/requirements-api.txt"
+  push:
+    paths:
+      - "requirements/requirements-api.txt"
+
+jobs:
+  pip-install-api-requirements:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: "3.12"
+    - name: Install API requirements
+      run: python -m pip install -r requirements/requirements-api.txt

--- a/.github/workflows/test-api-requirements.yml
+++ b/.github/workflows/test-api-requirements.yml
@@ -6,9 +6,6 @@ permissions:
 name: test-api-requirements
 
 on:
-  pull_request:
-    paths:
-      - "requirements/requirements-api.txt"
   push:
     paths:
       - "requirements/requirements-api.txt"

--- a/carbonserver/pyproject.toml
+++ b/carbonserver/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "bcrypt<5.0.0",
     "python-dateutil<3.0.0",
     "dependency-injector<5.0.0",
-    "fastapi<1.0.0",
+    "fastapi<1.0.0,>=0.138.1",
     "fastapi[standard]",
     "httpx",
     "pydantic[email]>=2.0.0,<3.0.0",

--- a/requirements/requirements-api.txt
+++ b/requirements/requirements-api.txt
@@ -47,7 +47,7 @@ email-validator==2.3.0
     # via
     #   fastapi
     #   pydantic
-fastapi==0.123.0
+fastapi==0.138.1
     # via
     #   carbonserver (carbonserver/pyproject.toml)
     #   fastapi-oidc
@@ -61,7 +61,9 @@ fastapi-oidc==0.0.9
 fastapi-pagination==0.15.0
     # via carbonserver (carbonserver/pyproject.toml)
 fastar==0.9.0
-    # via fastapi-cloud-cli
+    # via
+    #   fastapi
+    #   fastapi-cloud-cli
 greenlet==3.5.1
     # via sqlalchemy
 h11==0.16.0
@@ -120,11 +122,16 @@ pydantic==2.12.5
     #   fastapi-cloud-cli
     #   fastapi-oidc
     #   fastapi-pagination
+    #   pydantic-extra-types
     #   pydantic-settings
 pydantic-core==2.41.5
     # via pydantic
+pydantic-extra-types==2.11.1
+    # via fastapi
 pydantic-settings==2.14.2
-    # via carbonserver (carbonserver/pyproject.toml)
+    # via
+    #   carbonserver (carbonserver/pyproject.toml)
+    #   fastapi
 pygments==2.19.2
     # via rich
 pyjwt==2.13.0
@@ -187,12 +194,14 @@ typing-extensions==4.15.0
     #   fastapi-pagination
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   rich-toolkit
     #   starlette
     #   typer
     #   typing-inspection
 typing-inspection==0.4.2
     # via
+    #   fastapi
     #   pydantic
     #   pydantic-settings
 urllib3==2.7.0


### PR DESCRIPTION
## Description
Fix issues like this one https://github.com/mlco2/codecarbon/actions/runs/28317928989/job/83894562865. Where in local and ci works because they use the pyproject.toml, but the server uses `requirements/requirements-api.txt` so it fails.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure

Please refer to [docs/how-to/ai-policy.md](https://docs.codecarbon.io/latest/how-to/ai_policy/) for detailed guidelines on how to disclose AI usage in your PR. Accurately completing this section is mandatory.

- [ ] 🟥 AI-vibecoded: You cannot explain the logic. Car analogy : the car drive by itself, you are outside it and just tell it where to go.
- [ ] 🟠 AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [x] ⭐ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] ♻️ No AI used. Car analogy : you drive the car.
