### PR TITLE
fix: deduplicate mirrored Linux RAPL counters

### DIFF
--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -17,7 +17,12 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple
 import psutil
 from rapidfuzz import fuzz, process, utils
 
-from codecarbon.core.rapl import RAPLFile, find_mirrored_counters
+from codecarbon.core.rapl import (
+    SEQUENTIAL_READ_TOLERANCE_KWH,
+    RAPLFile,
+    counters_match,
+    find_mirrored_counters,
+)
 from codecarbon.core.units import Time
 from codecarbon.core.util import count_cpus, detect_cpu_model
 from codecarbon.external.logger import logger
@@ -846,6 +851,8 @@ class IntelRAPL:
             for rapl_file in self._rapl_files:
                 rapl_file.delta(duration)
 
+            self._confirm_mirrored_files()
+
             for rapl_file in self._rapl_files:
                 if rapl_file.path in self._mirrored_candidates:
                     # Still suspected of duplicating another counter
@@ -887,7 +894,9 @@ class IntelRAPL:
             for rapl_file in self._rapl_files
             if "dram" not in rapl_file.name.lower()
         ]
-        self._mirrored_candidates = find_mirrored_counters(counters)
+        self._mirrored_candidates = find_mirrored_counters(
+            counters, SEQUENTIAL_READ_TOLERANCE_KWH
+        )
         for path, reference_path in self._mirrored_candidates.items():
             logger.warning(
                 "\tRAPL - Energy counter at %s looks like a mirror of %s, it is "
@@ -895,6 +904,55 @@ class IntelRAPL:
                 path,
                 reference_path,
             )
+
+    def _confirm_mirrored_files(self) -> None:
+        """
+        Decide the fate of the files flagged as duplicates at ``start()``.
+
+        Two independent meters could hold indistinguishable counters at the
+        single instant of the initial reading, so a candidate is only dropped
+        for good once it has also accumulated the very same energy over a
+        measurement interval. A candidate whose energy delta differs is a real
+        meter and is restored, and a candidate that has not accumulated
+        anything yet stays pending until an interval is conclusive.
+        """
+        if not self._mirrored_candidates:
+            return
+        files_by_path = {rapl_file.path: rapl_file for rapl_file in self._rapl_files}
+        pending = {}
+        confirmed = set()
+        for path, reference_path in self._mirrored_candidates.items():
+            rapl_file = files_by_path.get(path)
+            reference = files_by_path.get(reference_path)
+            if rapl_file is None or reference is None:
+                continue
+            delta = float(rapl_file.energy_delta)
+            reference_delta = float(reference.energy_delta)
+            if delta <= 0 and reference_delta <= 0:
+                # Nothing was accumulated: the interval is not conclusive
+                pending[path] = reference_path
+            elif counters_match(delta, reference_delta, SEQUENTIAL_READ_TOLERANCE_KWH):
+                confirmed.add(path)
+                logger.warning(
+                    "\tRAPL - Energy counter at %s mirrors the one at %s, it is "
+                    "dropped to avoid double-counting the CPU power (multi-die "
+                    "CPUs mirror the package counter on each die)",
+                    path,
+                    reference_path,
+                )
+            else:
+                logger.info(
+                    "\tRAPL - Energy counter at %s accumulates energy on its own, "
+                    "it is an independent meter and is measured again",
+                    path,
+                )
+        self._mirrored_candidates = pending
+        if confirmed:
+            self._rapl_files = [
+                rapl_file
+                for rapl_file in self._rapl_files
+                if rapl_file.path not in confirmed
+            ]
 
 
 class TDP:

--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -450,6 +450,10 @@ class IntelRAPL:
         self._lin_rapl_dir = rapl_dir
         self._system = sys.platform.lower()
         self._rapl_files = []
+        # Files that look like a duplicate of another counter, but whose
+        # energy deltas have not confirmed it yet. They are left out of the
+        # measurement while pending. Maps file path -> mirrored file path.
+        self._mirrored_candidates: Dict[str, str] = {}
         self.rapl_include_dram = rapl_include_dram
         self.rapl_prefer_psys = rapl_prefer_psys
         self._setup_rapl()
@@ -843,6 +847,9 @@ class IntelRAPL:
                 rapl_file.delta(duration)
 
             for rapl_file in self._rapl_files:
+                if rapl_file.path in self._mirrored_candidates:
+                    # Still suspected of duplicating another counter
+                    continue
                 logger.debug(rapl_file)
                 cpu_details[rapl_file.name] = rapl_file.energy_delta.kWh
                 # We fake the name used by Power Gadget when using RAPL
@@ -880,18 +887,14 @@ class IntelRAPL:
             for rapl_file in self._rapl_files
             if "dram" not in rapl_file.name.lower()
         ]
-        mirrored = find_mirrored_counters(counters)
-        for path in mirrored:
+        self._mirrored_candidates = find_mirrored_counters(counters)
+        for path, reference_path in self._mirrored_candidates.items():
             logger.warning(
-                "\tRAPL - Ignoring mirrored energy counter at %s to avoid double-counting",
+                "\tRAPL - Energy counter at %s looks like a mirror of %s, it is "
+                "left out of the measurement to avoid double-counting",
                 path,
+                reference_path,
             )
-        if mirrored:
-            self._rapl_files = [
-                rapl_file
-                for rapl_file in self._rapl_files
-                if rapl_file.path not in mirrored
-            ]
 
 
 class TDP:

--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -6,7 +6,6 @@ https://software.intel.com/content/www/us/en/develop/articles/intel-power-gadget
 
 from __future__ import annotations
 
-import math
 import os
 import re
 import shutil
@@ -18,7 +17,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple
 import psutil
 from rapidfuzz import fuzz, process, utils
 
-from codecarbon.core.rapl import RAPLFile
+from codecarbon.core.rapl import RAPLFile, find_mirrored_counters
 from codecarbon.core.units import Time
 from codecarbon.core.util import count_cpus, detect_cpu_model
 from codecarbon.external.logger import logger
@@ -873,30 +872,26 @@ class IntelRAPL:
         """
         Starts monitoring CPU energy consumption.
         """
-        retained_rapl_files = []
-        observed_energies = []
         for rapl_file in self._rapl_files:
             rapl_file.start()
-            energy = float(rapl_file.last_energy)
-            is_dram = "dram" in rapl_file.name.lower()
-            is_mirrored = (
-                energy
-                and not is_dram
-                and any(
-                    math.isclose(energy, observed_energy, rel_tol=1e-6)
-                    for observed_energy in observed_energies
-                )
+        # DRAM domains are a different measurement, never a duplicate
+        counters = [
+            (rapl_file.path, float(rapl_file.last_energy))
+            for rapl_file in self._rapl_files
+            if "dram" not in rapl_file.name.lower()
+        ]
+        mirrored = find_mirrored_counters(counters)
+        for path in mirrored:
+            logger.warning(
+                "\tRAPL - Ignoring mirrored energy counter at %s to avoid double-counting",
+                path,
             )
-            if is_mirrored:
-                logger.warning(
-                    "\tRAPL - Ignoring mirrored energy counter at %s to avoid double-counting",
-                    rapl_file.path,
-                )
-                continue
-            retained_rapl_files.append(rapl_file)
-            if energy and not is_dram:
-                observed_energies.append(energy)
-        self._rapl_files = retained_rapl_files
+        if mirrored:
+            self._rapl_files = [
+                rapl_file
+                for rapl_file in self._rapl_files
+                if rapl_file.path not in mirrored
+            ]
 
 
 class TDP:

--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -6,6 +6,7 @@ https://software.intel.com/content/www/us/en/develop/articles/intel-power-gadget
 
 from __future__ import annotations
 
+import math
 import os
 import re
 import shutil
@@ -872,8 +873,30 @@ class IntelRAPL:
         """
         Starts monitoring CPU energy consumption.
         """
+        retained_rapl_files = []
+        observed_energies = []
         for rapl_file in self._rapl_files:
             rapl_file.start()
+            energy = float(rapl_file.last_energy)
+            is_dram = "dram" in rapl_file.name.lower()
+            is_mirrored = (
+                energy
+                and not is_dram
+                and any(
+                    math.isclose(energy, observed_energy, rel_tol=1e-6)
+                    for observed_energy in observed_energies
+                )
+            )
+            if is_mirrored:
+                logger.warning(
+                    "\tRAPL - Ignoring mirrored energy counter at %s to avoid double-counting",
+                    rapl_file.path,
+                )
+                continue
+            retained_rapl_files.append(rapl_file)
+            if energy and not is_dram:
+                observed_energies.append(energy)
+        self._rapl_files = retained_rapl_files
 
 
 class TDP:

--- a/codecarbon/core/rapl.py
+++ b/codecarbon/core/rapl.py
@@ -11,6 +11,14 @@ from codecarbon.external.logger import logger
 # See https://github.com/mlco2/codecarbon/issues/1274
 MIRRORED_COUNTER_TOLERANCE = 1e-6
 
+# Unlike EMI, which snapshots all the channels of a device atomically, the
+# powercap sysfs files are read one after the other: two views of the same
+# hardware counter differ by the energy the package accrued between the two
+# reads. One joule covers several milliseconds at full load, while staying
+# far below what independent packages drift apart by over a measurement
+# interval.
+SEQUENTIAL_READ_TOLERANCE_KWH = float(Energy.from_ujoules(1_000_000))  # 1 J
+
 
 def counters_match(first, second, abs_tolerance=0.0) -> bool:
     """Tell whether two cumulative counter values are indistinguishable."""

--- a/codecarbon/core/rapl.py
+++ b/codecarbon/core/rapl.py
@@ -3,6 +3,46 @@ from dataclasses import dataclass, field
 from codecarbon.core.units import Energy, Power, Time
 from codecarbon.external.logger import logger
 
+# Maximum relative difference between two cumulative energy counters for them
+# to be considered two views of the same hardware counter. Multi-die CPUs
+# (e.g. AMD Ryzen Threadripper / EPYC) can expose one package domain per die
+# that all mirror the same socket-wide counter, which would multiply the
+# reported CPU power by the number of dies.
+# See https://github.com/mlco2/codecarbon/issues/1274
+MIRRORED_COUNTER_TOLERANCE = 1e-6
+
+
+def counters_match(first, second, abs_tolerance=0.0) -> bool:
+    """Tell whether two cumulative counter values are indistinguishable."""
+    return abs(first - second) <= max(
+        MIRRORED_COUNTER_TOLERANCE * max(first, second), abs_tolerance
+    )
+
+
+def find_mirrored_counters(counters, abs_tolerance=0.0) -> dict:
+    """
+    Identify the counters that report the same underlying energy value.
+
+    ``counters`` is an ordered list of ``(key, absolute_energy)`` pairs whose
+    energies share a unit. Two independent meters are extremely unlikely to
+    hold the very same cumulative count, so equal counters point at duplicated
+    ones. A zero counter carries no information and is never flagged.
+
+    Returns a mapping of each duplicating key to the earlier key it mirrors.
+    """
+    references = []
+    mirrored = {}
+    for key, energy in counters:
+        if energy <= 0:
+            continue
+        for reference_key, reference in references:
+            if counters_match(energy, reference, abs_tolerance):
+                mirrored[key] = reference_key
+                break
+        else:
+            references.append((key, energy))
+    return mirrored
+
 
 @dataclass
 class RAPLFile:

--- a/codecarbon/core/windows_emi.py
+++ b/codecarbon/core/windows_emi.py
@@ -19,6 +19,7 @@ import sys
 from functools import lru_cache
 from typing import Dict, List, Tuple
 
+from codecarbon.core.rapl import counters_match, find_mirrored_counters
 from codecarbon.core.units import Time
 from codecarbon.external.logger import logger
 
@@ -41,10 +42,6 @@ GUID_DEVICE_ENERGY_METER = "{45BD8344-7ED6-49CF-A440-C276C933B053}"
 PWH_TO_KWH = 1e-15
 PWH_TO_WH = 1e-12
 HNS_TO_S = 1e-7
-
-# Maximum relative difference between two absolute energy counters for them to
-# be considered two views of the same hardware counter.
-MIRRORED_CHANNEL_TOLERANCE = 1e-6
 
 _GENERIC_READ = 0x80000000
 _FILE_SHARE_READ = 0x1
@@ -304,7 +301,7 @@ def select_channels(
 
 def _counters_match(first: int, second: int) -> bool:
     """Tell whether two counter values are indistinguishable."""
-    return abs(first - second) <= MIRRORED_CHANNEL_TOLERANCE * max(first, second)
+    return counters_match(first, second)
 
 
 def find_mirrored_channels(
@@ -319,25 +316,9 @@ def find_mirrored_channels(
     channel per die, but every die mirrors the same socket-wide RAPL counter.
     Summing those channels multiplies the reported CPU power by the number of
     dies, exactly like the ``package-0-die-0`` / ``package-0-die-1`` duplicates
-    seen through the Linux powercap interface. Two independent meters are
-    extremely unlikely to hold the very same picowatt-hour count, so equal
-    counters point at duplicated ones.
-
-    Returns a mapping of each duplicating channel to the earlier channel it
-    mirrors.
+    seen through the Linux powercap interface.
     """
-    references: List[Tuple[Tuple[str, int], int]] = []
-    mirrored: Dict[Tuple[str, int], Tuple[str, int]] = {}
-    for key, energy in channels:
-        if energy <= 0:
-            continue
-        for reference_key, reference in references:
-            if _counters_match(energy, reference):
-                mirrored[key] = reference_key
-                break
-        else:
-            references.append((key, energy))
-    return mirrored
+    return find_mirrored_counters(channels)
 
 
 class WindowsEMI:

--- a/docs/explanation/methodology.md
+++ b/docs/explanation/methodology.md
@@ -279,6 +279,10 @@ information.
 Despite the name "Intel RAPL", it supports AMD processors since Linux
 kernel 5.8.
 
+On multi-die CPUs, package domains can mirror the same socket-wide energy
+counter. CodeCarbon detects matching nonzero counters at startup and keeps one
+of them, preventing CPU energy from being counted once per die.
+
 Read more about how we use it in [RAPL Metrics](rapl.md).
 
 ## CPU metrics priority

--- a/docs/explanation/methodology.md
+++ b/docs/explanation/methodology.md
@@ -310,6 +310,10 @@ information.
 Despite the name "Intel RAPL", it supports AMD processors since Linux
 kernel 5.8.
 
+On multi-die CPUs, package domains can mirror the same socket-wide energy
+counter. CodeCarbon detects matching nonzero counters at startup and keeps one
+of them, preventing CPU energy from being counted once per die.
+
 Read more about how we use it in [RAPL Metrics](rapl.md).
 
 ## CPU metrics priority

--- a/docs/explanation/methodology.md
+++ b/docs/explanation/methodology.md
@@ -311,8 +311,10 @@ Despite the name "Intel RAPL", it supports AMD processors since Linux
 kernel 5.8.
 
 On multi-die CPUs, package domains can mirror the same socket-wide energy
-counter. CodeCarbon detects matching nonzero counters at startup and keeps one
-of them, preventing CPU energy from being counted once per die.
+counter. CodeCarbon flags counters holding the same value at startup and drops
+a duplicate only once it has also accumulated the very same energy over a
+measurement interval, so CPU energy is neither counted once per die nor
+missing a genuine package that coincidentally held the same value.
 
 Read more about how we use it in [RAPL Metrics](rapl.md).
 

--- a/docs/explanation/rapl.md
+++ b/docs/explanation/rapl.md
@@ -124,7 +124,7 @@ and consistent measurements:
 -   `core` reports very low energy values
 -   Unclear if `core` is included in `package` (vendor documentation is
     sparse)
--   On some multi-die CPUs (e.g., Threadripper), separate package domains mirror the same socket-wide counter. CodeCarbon keeps one mirrored counter so CPU energy is not multiplied by the number of dies.
+-   On some multi-die CPUs (e.g., Threadripper), separate package domains mirror the same socket-wide counter. CodeCarbon flags counters holding the same value at startup, confirms with the energy deltas of the first measurement interval that they are true mirrors, and keeps only one, so CPU energy is not multiplied by the number of dies.
 
 **What RAPL Does NOT Measure**:
 

--- a/docs/explanation/rapl.md
+++ b/docs/explanation/rapl.md
@@ -124,7 +124,7 @@ and consistent measurements:
 -   `core` reports very low energy values
 -   Unclear if `core` is included in `package` (vendor documentation is
     sparse)
--   Multiple dies may report as separate packages (e.g., Threadripper)
+-   On some multi-die CPUs (e.g., Threadripper), separate package domains mirror the same socket-wide counter. CodeCarbon keeps one mirrored counter so CPU energy is not multiplied by the number of dies.
 
 **What RAPL Does NOT Measure**:
 

--- a/tests/test_rapl_mmio_scanning.py
+++ b/tests/test_rapl_mmio_scanning.py
@@ -11,46 +11,90 @@ import sys
 import pytest
 
 from codecarbon.core.cpu import IntelRAPL, is_rapl_available
+from codecarbon.core.units import Time
+
+
+def _make_rapl_tree(tmp_path, domains):
+    """Create a fake powercap tree with the given (name, energy_uj) domains."""
+    provider = tmp_path / "intel-rapl"
+    provider.mkdir()
+    paths = []
+    for index, (name, energy) in enumerate(domains):
+        domain = provider / f"intel-rapl:{index}"
+        domain.mkdir()
+        (domain / "name").write_text(name)
+        (domain / "energy_uj").write_text(str(energy))
+        (domain / "max_energy_range_uj").write_text("262143328850")
+        paths.append(domain / "energy_uj")
+    return paths
+
+
+def _counted_domains(details):
+    """The domains measured in a get_cpu_details() result (one key per domain,
+    ignoring the extra Power keys mirroring the Energy ones)."""
+    return [key for key in details if "Power" not in key]
 
 
 @pytest.mark.parametrize(
-    ("energies", "expected_count"),
-    [((1000000, 1000000), 1), ((1000000, 2000000), 2), ((0, 0), 2)],
+    ("energies", "expected_candidates"),
+    [((1000000, 1000000), 1), ((1000000, 2000000), 0), ((0, 0), 0)],
 )
-def test_rapl_start_deduplicates_only_nonzero_mirrored_package_counters(
-    tmp_path, monkeypatch, energies, expected_count
+def test_rapl_start_flags_only_nonzero_mirrored_package_counters(
+    tmp_path, monkeypatch, energies, expected_candidates
 ):
     monkeypatch.setattr(sys, "platform", "linux")
-    provider = tmp_path / "intel-rapl"
-    provider.mkdir()
-    for index, energy in enumerate(energies):
-        domain = provider / f"intel-rapl:{index}"
-        domain.mkdir()
-        (domain / "name").write_text(f"package-{index}-die-0")
-        (domain / "energy_uj").write_text(str(energy))
-        (domain / "max_energy_range_uj").write_text("262143328850")
+    _make_rapl_tree(
+        tmp_path,
+        [(f"package-{index}-die-0", energy) for index, energy in enumerate(energies)],
+    )
 
     rapl = IntelRAPL(rapl_dir=str(tmp_path))
     rapl.start()
 
-    assert len(rapl._rapl_files) == expected_count
+    # Suspected mirrors are flagged, not dropped: the files are all kept so
+    # a wrongly flagged counter can be restored later.
+    assert len(rapl._rapl_files) == len(energies)
+    assert len(rapl._mirrored_candidates) == expected_candidates
+
+    details = rapl.get_cpu_details(Time.from_seconds(1))
+    assert len(_counted_domains(details)) == len(energies) - expected_candidates
 
 
 def test_rapl_start_keeps_dram_when_it_matches_a_package_counter(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "platform", "linux")
-    provider = tmp_path / "intel-rapl"
-    provider.mkdir()
-    for index, name in enumerate(("package-0-die-0", "package-0-die-1", "dram")):
-        domain = provider / f"intel-rapl:{index}"
-        domain.mkdir()
-        (domain / "name").write_text(name)
-        (domain / "energy_uj").write_text("1000000")
-        (domain / "max_energy_range_uj").write_text("262143328850")
+    _make_rapl_tree(
+        tmp_path,
+        [("package-0-die-0", 1000000), ("package-0-die-1", 1000000), ("dram", 1000000)],
+    )
 
     rapl = IntelRAPL(rapl_dir=str(tmp_path), rapl_include_dram=True)
     rapl.start()
 
+    assert len(rapl._mirrored_candidates) == 1
+    details = rapl.get_cpu_details(Time.from_seconds(1))
+    assert len(_counted_domains(details)) == 2
+    assert "dram" in details
+
+
+def test_rapl_start_reevaluates_mirror_candidates(tmp_path, monkeypatch):
+    """A new start() re-runs the detection instead of compounding drops."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    energy_files = _make_rapl_tree(
+        tmp_path, [("package-0", 1000000), ("package-1", 1000000)]
+    )
+
+    rapl = IntelRAPL(rapl_dir=str(tmp_path))
+    rapl.start()
+    assert len(rapl._mirrored_candidates) == 1
+
+    # The counters diverge: they were two independent meters after all
+    energy_files[1].write_text("5000000")
+    rapl.start()
+
     assert len(rapl._rapl_files) == 2
+    assert len(rapl._mirrored_candidates) == 0
+    details = rapl.get_cpu_details(Time.from_seconds(1))
+    assert len(_counted_domains(details)) == 2
 
 
 @pytest.mark.skipif(not sys.platform.lower().startswith("lin"), reason="requires Linux")

--- a/tests/test_rapl_mmio_scanning.py
+++ b/tests/test_rapl_mmio_scanning.py
@@ -37,7 +37,7 @@ def _counted_domains(details):
 
 @pytest.mark.parametrize(
     ("energies", "expected_candidates"),
-    [((1000000, 1000000), 1), ((1000000, 2000000), 0), ((0, 0), 0)],
+    [((1000000000, 1000000000), 1), ((1000000000, 2000000000), 0), ((0, 0), 0)],
 )
 def test_rapl_start_flags_only_nonzero_mirrored_package_counters(
     tmp_path, monkeypatch, energies, expected_candidates
@@ -95,6 +95,101 @@ def test_rapl_start_reevaluates_mirror_candidates(tmp_path, monkeypatch):
     assert len(rapl._mirrored_candidates) == 0
     details = rapl.get_cpu_details(Time.from_seconds(1))
     assert len(_counted_domains(details)) == 2
+
+
+def test_rapl_confirmed_mirror_is_dropped_after_identical_deltas(tmp_path, monkeypatch):
+    """A candidate accumulating the very same energy as its reference is a
+    true mirror and is dropped for good."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    energy_files = _make_rapl_tree(
+        tmp_path, [("package-0-die-0", 1000000000), ("package-0-die-1", 1000000000)]
+    )
+
+    rapl = IntelRAPL(rapl_dir=str(tmp_path))
+    rapl.start()
+    assert len(rapl._mirrored_candidates) == 1
+
+    # Both views advance by the same 500 J: same underlying counter
+    for energy_file in energy_files:
+        energy_file.write_text("1500000000")
+    details = rapl.get_cpu_details(Time.from_seconds(15))
+
+    assert len(_counted_domains(details)) == 1
+    assert len(rapl._rapl_files) == 1
+    assert len(rapl._mirrored_candidates) == 0
+
+
+def test_rapl_coincidental_match_is_restored_after_diverging_deltas(
+    tmp_path, monkeypatch
+):
+    """Two independent packages that coincidentally held the same counter at
+    start() are both measured again once their deltas diverge."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    energy_files = _make_rapl_tree(
+        tmp_path, [("package-0", 1000000000), ("package-1", 1000000000)]
+    )
+
+    rapl = IntelRAPL(rapl_dir=str(tmp_path))
+    rapl.start()
+    assert len(rapl._mirrored_candidates) == 1
+
+    # One package accumulates 10 J while the other accumulates 1000 J
+    energy_files[0].write_text("1010000000")
+    energy_files[1].write_text("2000000000")
+    details = rapl.get_cpu_details(Time.from_seconds(15))
+
+    # The restored counter is measured from this very interval on
+    assert len(_counted_domains(details)) == 2
+    assert len(rapl._rapl_files) == 2
+    assert len(rapl._mirrored_candidates) == 0
+
+
+def test_rapl_mirrors_near_counter_wrap_are_still_detected(tmp_path, monkeypatch):
+    """Right after a wrap the counters are tiny, so mirrored views read
+    sequentially can differ by more than the relative tolerance. The absolute
+    sequential-read tolerance still flags them, and the identical deltas
+    confirm the drop."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    energy_files = _make_rapl_tree(
+        tmp_path, [("package-0-die-0", 1000), ("package-0-die-1", 30000)]
+    )
+
+    rapl = IntelRAPL(rapl_dir=str(tmp_path))
+    rapl.start()
+    assert len(rapl._mirrored_candidates) == 1
+
+    # Both views advance by the same 400 J
+    energy_files[0].write_text("400001000")
+    energy_files[1].write_text("400030000")
+    details = rapl.get_cpu_details(Time.from_seconds(15))
+
+    assert len(_counted_domains(details)) == 1
+    assert len(rapl._rapl_files) == 1
+
+
+def test_rapl_inconclusive_candidate_stays_pending(tmp_path, monkeypatch):
+    """A candidate that has not accumulated anything is neither dropped nor
+    restored, and is resolved by a later conclusive interval."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    energy_files = _make_rapl_tree(
+        tmp_path, [("package-0", 1000000000), ("package-1", 1000000000)]
+    )
+
+    rapl = IntelRAPL(rapl_dir=str(tmp_path))
+    rapl.start()
+
+    # No energy accumulated: the interval is not conclusive
+    details = rapl.get_cpu_details(Time.from_seconds(15))
+    assert len(_counted_domains(details)) == 1
+    assert len(rapl._rapl_files) == 2
+    assert len(rapl._mirrored_candidates) == 1
+
+    # The counters then diverge: the candidate was an independent meter
+    energy_files[0].write_text("1010000000")
+    energy_files[1].write_text("2000000000")
+    details = rapl.get_cpu_details(Time.from_seconds(15))
+    assert len(_counted_domains(details)) == 2
+    assert len(rapl._mirrored_candidates) == 0
 
 
 @pytest.mark.skipif(not sys.platform.lower().startswith("lin"), reason="requires Linux")

--- a/tests/test_rapl_mmio_scanning.py
+++ b/tests/test_rapl_mmio_scanning.py
@@ -13,6 +13,46 @@ import pytest
 from codecarbon.core.cpu import IntelRAPL, is_rapl_available
 
 
+@pytest.mark.parametrize(
+    ("energies", "expected_count"),
+    [((1000000, 1000000), 1), ((1000000, 2000000), 2), ((0, 0), 2)],
+)
+def test_rapl_start_deduplicates_only_nonzero_mirrored_package_counters(
+    tmp_path, monkeypatch, energies, expected_count
+):
+    monkeypatch.setattr(sys, "platform", "linux")
+    provider = tmp_path / "intel-rapl"
+    provider.mkdir()
+    for index, energy in enumerate(energies):
+        domain = provider / f"intel-rapl:{index}"
+        domain.mkdir()
+        (domain / "name").write_text(f"package-{index}-die-0")
+        (domain / "energy_uj").write_text(str(energy))
+        (domain / "max_energy_range_uj").write_text("262143328850")
+
+    rapl = IntelRAPL(rapl_dir=str(tmp_path))
+    rapl.start()
+
+    assert len(rapl._rapl_files) == expected_count
+
+
+def test_rapl_start_keeps_dram_when_it_matches_a_package_counter(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    provider = tmp_path / "intel-rapl"
+    provider.mkdir()
+    for index, name in enumerate(("package-0-die-0", "package-0-die-1", "dram")):
+        domain = provider / f"intel-rapl:{index}"
+        domain.mkdir()
+        (domain / "name").write_text(name)
+        (domain / "energy_uj").write_text("1000000")
+        (domain / "max_energy_range_uj").write_text("262143328850")
+
+    rapl = IntelRAPL(rapl_dir=str(tmp_path), rapl_include_dram=True)
+    rapl.start()
+
+    assert len(rapl._rapl_files) == 2
+
+
 @pytest.mark.skipif(not sys.platform.lower().startswith("lin"), reason="requires Linux")
 def test_multiple_rapl_providers_with_mixed_permissions(tmp_path):
     """
@@ -188,14 +228,14 @@ def test_rapl_deduplication_prefers_mmio(tmp_path):
 
     # Verify package-0 is from MMIO (newer interface)
     package_files = [f for f in rapl._rapl_files if "Processor Energy" in f.name]
-    assert (
-        len(package_files) == 1
-    ), "Should have exactly one package domain after deduplication"
+    assert len(package_files) == 1, (
+        "Should have exactly one package domain after deduplication"
+    )
 
     # The package file should be from intel-rapl-mmio
-    assert (
-        "intel-rapl-mmio" in package_files[0].path
-    ), f"Expected MMIO path, got: {package_files[0].path}"
+    assert "intel-rapl-mmio" in package_files[0].path, (
+        f"Expected MMIO path, got: {package_files[0].path}"
+    )
 
 
 @pytest.mark.skipif(not sys.platform.lower().startswith("lin"), reason="requires Linux")
@@ -247,17 +287,19 @@ def test_psys_not_preferred_when_package_available(tmp_path):
 
     # Should have 1 RAPL file: package-0 (not psys)
     # Package domains are preferred over psys for reliability
-    assert (
-        len(rapl._rapl_files) == 1
-    ), f"Expected 1 file (package), got {len(rapl._rapl_files)}"
+    assert len(rapl._rapl_files) == 1, (
+        f"Expected 1 file (package), got {len(rapl._rapl_files)}"
+    )
 
     # Verify it's the package domain (not psys)
     assert (
         "Processor Energy" in rapl._rapl_files[0].name
         and "intel-rapl:0" in rapl._rapl_files[0].path
-    ), f"Expected package-0 domain, got: {rapl._rapl_files[0].name} at {rapl._rapl_files[0].path}"
+    ), (
+        f"Expected package-0 domain, got: {rapl._rapl_files[0].name} at {rapl._rapl_files[0].path}"
+    )
 
     # Verify psys is NOT used (should be logged as detected but not used)
-    assert (
-        "intel-rapl:1" not in rapl._rapl_files[0].path
-    ), "psys should not be used when package domains are available"
+    assert "intel-rapl:1" not in rapl._rapl_files[0].path, (
+        "psys should not be used when package domains are available"
+    )

--- a/tests/test_rapl_mmio_scanning.py
+++ b/tests/test_rapl_mmio_scanning.py
@@ -228,14 +228,14 @@ def test_rapl_deduplication_prefers_mmio(tmp_path):
 
     # Verify package-0 is from MMIO (newer interface)
     package_files = [f for f in rapl._rapl_files if "Processor Energy" in f.name]
-    assert len(package_files) == 1, (
-        "Should have exactly one package domain after deduplication"
-    )
+    assert (
+        len(package_files) == 1
+    ), "Should have exactly one package domain after deduplication"
 
     # The package file should be from intel-rapl-mmio
-    assert "intel-rapl-mmio" in package_files[0].path, (
-        f"Expected MMIO path, got: {package_files[0].path}"
-    )
+    assert (
+        "intel-rapl-mmio" in package_files[0].path
+    ), f"Expected MMIO path, got: {package_files[0].path}"
 
 
 @pytest.mark.skipif(not sys.platform.lower().startswith("lin"), reason="requires Linux")
@@ -287,19 +287,17 @@ def test_psys_not_preferred_when_package_available(tmp_path):
 
     # Should have 1 RAPL file: package-0 (not psys)
     # Package domains are preferred over psys for reliability
-    assert len(rapl._rapl_files) == 1, (
-        f"Expected 1 file (package), got {len(rapl._rapl_files)}"
-    )
+    assert (
+        len(rapl._rapl_files) == 1
+    ), f"Expected 1 file (package), got {len(rapl._rapl_files)}"
 
     # Verify it's the package domain (not psys)
     assert (
         "Processor Energy" in rapl._rapl_files[0].name
         and "intel-rapl:0" in rapl._rapl_files[0].path
-    ), (
-        f"Expected package-0 domain, got: {rapl._rapl_files[0].name} at {rapl._rapl_files[0].path}"
-    )
+    ), f"Expected package-0 domain, got: {rapl._rapl_files[0].name} at {rapl._rapl_files[0].path}"
 
     # Verify psys is NOT used (should be logged as detected but not used)
-    assert "intel-rapl:1" not in rapl._rapl_files[0].path, (
-        "psys should not be used when package domains are available"
-    )
+    assert (
+        "intel-rapl:1" not in rapl._rapl_files[0].path
+    ), "psys should not be used when package domains are available"


### PR DESCRIPTION
## Description

Drop mirrored nonzero Linux RAPL package counters at monitoring startup while preserving distinct package counters, zero counters, and DRAM domains. The documentation explains the multi-die mirrored-counter behavior.

## Related Issue

Fixes #1274

## Motivation and Context

Some Linux multi-die systems expose mirrored package-energy counters. Counting each mirror separately overstates CPU energy consumption, while indiscriminate deduplication could incorrectly remove distinct or zero-valued counters.

## How Has This Been Tested?

- `uv run pytest tests/test_rapl_mmio_scanning.py -q`
- `uv run pytest tests/test_cpu.py tests/test_rapl_mmio_scanning.py tests/test_rapl_parameters.py -q`
- `uv run ruff check codecarbon/core/cpu.py tests/test_rapl_mmio_scanning.py`
- `uv run ruff format --check codecarbon/core/cpu.py tests/test_rapl_mmio_scanning.py`
- `git diff --check`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure

- [ ] 🟥 AI-vibecoded: You cannot explain the logic. Car analogy : the car drive by itself, you are outside it and just tell it where to go.
- [x] 🟠 AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [ ] ⭐ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] ♻️ No AI used. Car analogy : you drive the car.

OpenAI Codex assisted with implementation, tests, and documentation preparation. I personally reviewed and tested every submitted line, understand the implementation, and can explain and maintain it.

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[docs/how-to/contributing.md](https://docs.codecarbon.io/latest/how-to/contributing/)** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.