### PR TITLE
chore: use official pre-commit action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,13 +14,4 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-    - name: set PY
-      run: echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
-    - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - name: Run pre-commit
-      run: |
-        pip install pre-commit==3.7.0
-        pre-commit run --show-diff-on-failure --color=always --all-files
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
## Description
Instead of installing pre-commit in the ci, we can use the pre-commit action and dependabot will take care of updating it.

## AI Usage Disclosure

Please refer to [docs/how-to/ai-policy.md](https://docs.codecarbon.io/latest/how-to/ai_policy/) for detailed guidelines on how to disclose AI usage in your PR. Accurately completing this section is mandatory.

- [ ] 🟥 AI-vibecoded: You cannot explain the logic. Car analogy : the car drive by itself, you are outside it and just tell it where to go.
- [ ] 🟠 AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [x] ⭐ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] ♻️ No AI used. Car analogy : you drive the car.
