### PR TITLE
fix: keep None columns in CSV append

### DIFF
--- a/codecarbon/output_methods/file.py
+++ b/codecarbon/output_methods/file.py
@@ -102,7 +102,8 @@ class FileOutput(BaseOutput):
         if not file_exists:
             new_df.to_csv(self.save_file_path, index=False)
         elif self.on_csv_write == "append":
-            new_df = new_df.dropna(axis=1, how="all")
+            # Never drop all-NA columns here: the append is headerless, so column
+            # identity is positional and a missing column shifts every value after it.
             new_df.to_csv(self.save_file_path, mode="a", header=False, index=False)
         else:
             df = pd.read_csv(self.save_file_path)

--- a/tests/output_methods/test_file.py
+++ b/tests/output_methods/test_file.py
@@ -266,6 +266,41 @@ class TestFileOutput(unittest.TestCase):
         self.assertIn("gpu_count", df.columns)
         self.assertIn("gpu_model", df.columns)
 
+    def test_file_output_out_append_keeps_none_columns_aligned(self):
+        """Regression test: appended rows must have the same number of fields as the
+        header, even when some values are None.
+
+        The bug: dropna(axis=1, how="all") on the single-row new_df dropped every
+        None column.  The append is headerless, so the surviving values shifted left
+        and were read back under the wrong column names.
+        """
+        none_data = EmissionsData(
+            **{
+                **self.emissions_data.values,
+                "gpu_count": None,
+                "gpu_model": None,
+                "longitude": None,
+                "latitude": None,
+                "region": None,
+            }
+        )
+
+        file_output = FileOutput("test.csv", self.temp_dir, on_csv_write="append")
+        file_output.out(none_data, None)
+        file_output.out(none_data, None)
+
+        with open(file_output.save_file_path) as csv_file:
+            field_counts = {len(line.split(",")) for line in csv_file}
+        self.assertEqual(
+            len(field_counts),
+            1,
+            f"Rows have inconsistent field counts: {field_counts}",
+        )
+
+        df = pd.read_csv(file_output.save_file_path)
+        self.assertEqual(df["ram_total_size"].tolist(), [16.0, 16.0])
+        self.assertEqual(df["tracking_mode"].tolist(), ["machine", "machine"])
+
     def test_file_output_out_append_no_gpu_zero_defaults(self):
         """Test that gpu_count=0 and gpu_model="" (the new tracker defaults for
         CPU-only machines) produce consistent CSV columns across successive writes.


### PR DESCRIPTION
Closes #1304

## What changed

Removed the `dropna(axis=1, how="all")` from the `"append"` branch of `FileOutput.out()` (`codecarbon/output_methods/file.py:104`).

## Why

`new_df` in that branch is always a single row, so `dropna(axis=1, how="all")` really means "drop every column that is None for this run". The append is headerless, so column identity is positional — dropping a column shifts every value after it one place to the left, and `pd.read_csv` pads the short row instead of raising. `has_valid_headers` only reads the first line, so nothing detects it.

This hits ordinary runs: `longitude`/`latitude` are `None` for offline tracking, `region` is `None` without an explicit region, and `gpu_count`/`gpu_model` are `None` on CPU-only machines.

The `dropna` is legitimate in `task_out`, where it suppresses a pandas `FutureWarning` on a `concat`; it was not applicable here. Left `task_out` untouched.

## How it was verified

New test `test_file_output_out_append_keeps_none_columns_aligned` in `tests/output_methods/test_file.py`. It appends two rows built from an `EmissionsData` with `gpu_count`, `gpu_model`, `longitude`, `latitude` and `region` set to `None`, then asserts every line of the raw file has the same field count and that `ram_total_size` / `tracking_mode` read back correctly.

- Without the fix: fails with `{38, 33}` field counts.
- With the fix: `uv run pytest tests/output_methods/test_file.py -q` → 23 passed.

The existing `test_file_output_out_append_no_gpu_consistent_columns` passed before this change because it only asserts row count and header, neither of which the shift disturbs.

Rows now carry empty fields where the column previously vanished, matching the header-carrying first row. No API or config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)