### PR TITLE
fix: integrate GPU power when energy counter is absent

### DIFF
--- a/codecarbon/core/gpu_device.py
+++ b/codecarbon/core/gpu_device.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from codecarbon.core.units import Energy, Power, Time
+from codecarbon.external.logger import logger
 
 
 @dataclass
@@ -28,8 +29,9 @@ class GPUDevice:
     power: Power = field(default_factory=lambda: Power(0))
     # Energy consumed in kWh
     energy_delta: Energy = field(default_factory=lambda: Energy(0))
-    # Last energy reading in kWh
-    last_energy: Energy = field(default_factory=lambda: Energy(0))
+    # Last energy reading in kWh, None if the device has no energy counter
+    last_energy: Optional[Energy] = field(default_factory=lambda: Energy(0))
+    _warned_no_counter: bool = field(default=False, init=False)
 
     def start(self) -> None:
         self.last_energy = self._get_energy_kwh()
@@ -38,22 +40,45 @@ class GPUDevice:
         self.last_energy = self._get_energy_kwh()
         self._init_static_details()
 
-    def _get_energy_kwh(self) -> Energy:
+    def _get_energy_kwh(self) -> Optional[Energy]:
         total_energy_consumption = self._get_total_energy_consumption()
         if total_energy_consumption is None:
-            return self.last_energy
+            return None
         return Energy.from_millijoules(total_energy_consumption)
+
+    def _delta_from_power(self, duration: Time) -> None:
+        try:
+            self.power = Power.from_watts(self._get_power_usage())
+        except Exception:
+            logger.warning(
+                f"Failed to retrieve power usage of GPU {self.gpu_index}, "
+                "reporting 0 W for this measurement.",
+                exc_info=True,
+            )
+            self.power = Power.from_watts(0.0)
+        self.energy_delta = Energy.from_power_and_time(power=self.power, time=duration)
 
     def delta(self, duration: Time) -> dict:
         """
         Compute the energy/power used since last call.
         """
-        new_last_energy = energy = self._get_energy_kwh()
-        self.power = self.power.from_energies_and_delay(
-            energy, self.last_energy, duration
-        )
-        self.energy_delta = energy - self.last_energy
-        self.last_energy = new_last_energy
+        energy = self._get_energy_kwh()
+        if energy is None or self.last_energy is None:
+            # counter unsupported: integrate instantaneous power instead
+            if not self._warned_no_counter:
+                self._warned_no_counter = True
+                logger.warning(
+                    f"GPU {self.gpu_index} does not provide a total energy consumption counter, "
+                    "falling back to integrating instantaneous power usage. "
+                    "Measurements will be less accurate."
+                )
+            self._delta_from_power(duration)
+        else:
+            self.power = Power.from_energies_and_delay(
+                energy, self.last_energy, duration
+            )
+            self.energy_delta = energy - self.last_energy
+        self.last_energy = energy
         return {
             "name": self._gpu_name,
             "uuid": self._uuid,

--- a/codecarbon/core/gpu_nvidia.py
+++ b/codecarbon/core/gpu_nvidia.py
@@ -53,7 +53,7 @@ class NvidiaGPUDevice(GPUDevice):
         try:
             return pynvml.nvmlDeviceGetTotalEnergyConsumption(self.handle)
         except pynvml.NVMLError:
-            logger.warning(
+            logger.debug(
                 "Failed to retrieve gpu total energy consumption", exc_info=True
             )
             return None

--- a/tests/test_gpu_nvidia.py
+++ b/tests/test_gpu_nvidia.py
@@ -25,6 +25,7 @@ from copy import copy, deepcopy
 from unittest import TestCase, mock
 
 import pynvml as real_pynvml
+import pytest
 
 tc = TestCase()
 
@@ -265,6 +266,126 @@ class TestGpu(FakeGPUEnv):
             assert alldevices.get_gpu_details() == expected
         finally:
             pynvml.nvmlDeviceGetTotalEnergyConsumption = original_energy
+
+    def test_gpu_without_energy_counter_falls_back_to_power(self):
+        """
+        GPUs without a total energy consumption counter must integrate their
+        instantaneous power usage instead of reporting a zero delta.
+        """
+        import pynvml
+
+        from codecarbon.core.gpu import AllGPUDevices
+        from codecarbon.core.units import Time
+
+        def raise_exception(handle):
+            raise pynvml.NVMLError("Not Supported")
+
+        original_energy = pynvml.nvmlDeviceGetTotalEnergyConsumption
+        try:
+            pynvml.nvmlDeviceGetTotalEnergyConsumption = raise_exception
+            alldevices = AllGPUDevices()
+
+            devices_info = alldevices.get_delta(Time.from_seconds(3600))
+
+            # power_usage in the fake module is in milliwatts: 26000 and 29000
+            assert devices_info[0]["power_usage"].W == pytest.approx(26)
+            assert devices_info[1]["power_usage"].W == pytest.approx(29)
+            assert devices_info[0]["delta_energy_consumption"].kWh == pytest.approx(
+                0.026
+            )
+            assert devices_info[1]["delta_energy_consumption"].kWh == pytest.approx(
+                0.029
+            )
+        finally:
+            pynvml.nvmlDeviceGetTotalEnergyConsumption = original_energy
+
+    def test_gpu_energy_counter_recovery_does_not_double_count(self):
+        """
+        A device whose counter is intermittently unavailable must not report the
+        fallback window a second time when the counter comes back.
+        """
+        import pynvml
+
+        from codecarbon.core.gpu import AllGPUDevices
+        from codecarbon.core.units import Time
+
+        original_energy = pynvml.nvmlDeviceGetTotalEnergyConsumption
+        try:
+            alldevices = AllGPUDevices()  # baseline read: 1000 mJ
+
+            def raise_exception(handle):
+                raise pynvml.NVMLError("Not Supported")
+
+            pynvml.nvmlDeviceGetTotalEnergyConsumption = raise_exception
+            fallback = alldevices.get_delta(Time.from_seconds(3600))
+            assert fallback[0]["delta_energy_consumption"].kWh == pytest.approx(0.026)
+
+            # Counter comes back, having advanced by the 0.026 kWh we just
+            # reported, while the power draw dropped to 10 W.
+            pynvml.nvmlDeviceGetTotalEnergyConsumption = original_energy
+            self.DETAILS["handle_0"]["total_energy_consumption"] = 1000 + 93_600_000
+            self.DETAILS["handle_0"]["power_usage"] = 10000
+
+            recovered = alldevices.get_delta(Time.from_seconds(3600))
+            assert recovered[0]["delta_energy_consumption"].kWh == pytest.approx(0.010)
+
+            # Subsequent samples use the counter again, from the new baseline.
+            self.DETAILS["handle_0"]["total_energy_consumption"] = (
+                1000 + 93_600_000 + 36_000_000
+            )
+            after = alldevices.get_delta(Time.from_seconds(3600))
+            assert after[0]["delta_energy_consumption"].kWh == pytest.approx(0.010)
+        finally:
+            pynvml.nvmlDeviceGetTotalEnergyConsumption = original_energy
+
+    def test_gpu_without_power_usage_reports_zero_instead_of_raising(self):
+        """
+        When neither the energy counter nor the power reading is available, the
+        device must report 0 W rather than propagate the NVML error.
+        """
+        import pynvml
+
+        from codecarbon.core.gpu import AllGPUDevices
+        from codecarbon.core.units import Time
+
+        def raise_exception(handle):
+            raise pynvml.NVMLError("Not Supported")
+
+        original_energy = pynvml.nvmlDeviceGetTotalEnergyConsumption
+        original_power = pynvml.nvmlDeviceGetPowerUsage
+        try:
+            pynvml.nvmlDeviceGetTotalEnergyConsumption = raise_exception
+            alldevices = AllGPUDevices()
+            pynvml.nvmlDeviceGetPowerUsage = raise_exception
+
+            devices_info = alldevices.get_delta(Time.from_seconds(3600))
+
+            assert devices_info[0]["power_usage"].W == 0
+            assert devices_info[0]["delta_energy_consumption"].kWh == 0
+        finally:
+            pynvml.nvmlDeviceGetTotalEnergyConsumption = original_energy
+            pynvml.nvmlDeviceGetPowerUsage = original_power
+
+    def test_start_rebaselines_the_energy_counter(self):
+        """
+        Restarting a measurement must not bill the energy consumed before the
+        restart to the next delta.
+        """
+        from codecarbon.core.gpu import AllGPUDevices
+        from codecarbon.core.units import Time
+
+        alldevices = AllGPUDevices()  # baseline read: 1000 mJ
+
+        # Energy burnt outside of any measurement window.
+        self.DETAILS["handle_0"]["total_energy_consumption"] = 1000 + 93_600_000
+        alldevices.start()
+
+        self.DETAILS["handle_0"]["total_energy_consumption"] = (
+            1000 + 93_600_000 + 36_000_000
+        )
+        devices_info = alldevices.get_delta(Time.from_seconds(3600))
+
+        assert devices_info[0]["delta_energy_consumption"].kWh == pytest.approx(0.010)
 
     def test_gpu_metadata_total_power(self):
         """


### PR DESCRIPTION
## What

`GPUDevice.delta` now branches on the backend returning `None` for the cumulative energy counter. When it does, it computes `Power.from_watts(self._get_power_usage())` and `Energy.from_power_and_time(...)` instead of comparing two identical counter readings, and logs a single warning per device so users know which method produced their numbers.

The per-sample `logger.warning` in `NvidiaGPUDevice._get_total_energy_consumption` is demoted to `debug`, since the once-per-device warning now carries the signal.

## Why

On GPUs where NVML does not implement `nvmlDeviceGetTotalEnergyConsumption` (pre-Volta cards, many virtualised GPUs) the previous code returned `last_energy` unchanged, yielding `energy_delta = 0` and `power = 0` for the entire run — a GPU-bound job silently reported only CPU + RAM. The fallback lives in the shared `GPUDevice`, so the AMD backend (which returns `None` when no energy accumulator is present) is fixed by the same change.

Power integration is less accurate than the counter, but it is the same approximation the CPU path already uses and is dramatically better than zero.

## How verified

`tests/test_gpu_nvidia.py::TestGpu::test_gpu_without_energy_counter_falls_back_to_power` patches the NVML energy query to raise and asserts 26 W / 29 W and 0.026 / 0.029 kWh over an hour. It fails on master (`assert 0.0 == 26`) and passes here. `tests/test_gpu.py`, `tests/test_gpu_nvidia.py` and `tests/test_gpu_amd.py` all pass (51 tests).

Closes #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)