### PR TITLE
fix: send measurement time to the API

### DIFF
--- a/codecarbon/core/api_client.py
+++ b/codecarbon/core/api_client.py
@@ -8,7 +8,7 @@ TODO : use async call to API
 # from httpx import AsyncClient
 import dataclasses
 import json
-from datetime import timedelta, tzinfo
+from datetime import datetime, timedelta, tzinfo
 
 import requests
 
@@ -26,6 +26,24 @@ def get_datetime_with_timezone():
     import arrow
 
     return str(arrow.now().isoformat())
+
+
+def get_measurement_timestamp(timestamp=None):
+    """
+    Return the time the measurement was taken, as an offset-aware ISO string.
+
+    EmissionsData.timestamp is naive local time, so it is localised here.
+    Falls back to now for hand-built payloads without a timestamp.
+    """
+    if timestamp:
+        try:
+            return datetime.fromisoformat(timestamp).astimezone().isoformat()
+        except (TypeError, ValueError):
+            logger.warning(
+                f"ApiClient : could not parse emission timestamp {timestamp!r}, "
+                + "using current time."
+            )
+    return get_datetime_with_timezone()
 
 
 class ApiClient:  # (AsyncClient)
@@ -190,7 +208,7 @@ class ApiClient:  # (AsyncClient)
             )
             return False
         emission = EmissionCreate(
-            timestamp=get_datetime_with_timezone(),
+            timestamp=get_measurement_timestamp(carbon_emission.get("timestamp")),
             run_id=self.run_id,
             duration=int(carbon_emission["duration"]),
             emissions_sum=carbon_emission["emissions"],

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -1044,6 +1044,9 @@ class BaseEmissionsTracker(ABC):
         )
 
         total_emissions = EmissionsData(
+            # Naive local time. Consumers that need an offset-aware value
+            # (the API client) may assume the local zone -- `.astimezone()` --
+            # precisely because this is `datetime.now()`.
             timestamp=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
             project_name=self._project_name,
             run_id=str(self.run_id),

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -1,5 +1,6 @@
 import dataclasses
 import unittest
+from datetime import datetime
 from uuid import uuid4
 
 import requests
@@ -227,6 +228,40 @@ class TestApi(unittest.TestCase):
                 }
             )
         )
+
+    def test_add_emission_keeps_measurement_timestamp(self):
+        payload = {
+            "duration": 2,
+            "emissions": 1.0,
+            "emissions_rate": 1.0,
+            "cpu_power": 1.0,
+            "gpu_power": 0.0,
+            "ram_power": 0.5,
+            "cpu_energy": 0.1,
+            "gpu_energy": 0.0,
+            "ram_energy": 0.1,
+            "energy_consumed": 0.2,
+        }
+        with requests_mock.Mocker() as m:
+            m.post("http://test.com/emissions", text="ok", status_code=201)
+            api = ApiClient(
+                endpoint_url="http://test.com",
+                experiment_id="exp-1",
+                conf=conf,
+                create_run_automatically=False,
+            )
+            api.run_id = "run-1"
+
+            # The measurement timestamp is kept, not the time of the POST.
+            api.add_emission({**payload, "timestamp": "2020-01-01T00:00:00"})
+            sent = m.last_request.json()["timestamp"]
+            self.assertTrue(sent.startswith("2020-01-01T00:00:00"))
+            self.assertIsNotNone(datetime.fromisoformat(sent).tzinfo)
+
+            # No timestamp in the payload : fall back to now.
+            api.add_emission(payload)
+            sent = m.last_request.json()["timestamp"]
+            self.assertIsNotNone(datetime.fromisoformat(sent).tzinfo)
 
     def test_add_emission_raises_on_unsuccessful_post(self):
         with requests_mock.Mocker() as m:


### PR DESCRIPTION
## What changed

`ApiClient.add_emission` now sends the timestamp carried by the emission payload instead of generating a new one at payload-build time. A small `get_measurement_timestamp` helper localises the naive `EmissionsData.timestamp` to an offset-aware ISO string, falls back to `get_datetime_with_timezone()` when no timestamp is present (hand-built dicts), and logs a warning rather than failing on an unparseable value.

## Why

`EmissionsData.timestamp` records when the measurement window ended (`codecarbon/emissions_tracker.py:1063`), survives all the way into `HTTPOutput._emit` (`codecarbon/output_methods/http.py:65-68`), and was then thrown away by `add_emission`, which stamped `get_datetime_with_timezone()` instead (`codecarbon/core/api_client.py:191`). Every other field in the payload describes the measurement window; the one field that dates it described the HTTP call. Users running both `file` and `api` output methods see the CSV and the API disagree.

The stored value is left offset-aware, so no existing rows shift and the CSV output format is unchanged.

This is also a prerequisite for any future client-side batching or retry/spill-buffer work: without it, every replayed or batched emission would be stored at its send time, turning a sub-second skew into an outage-length one.

Closes #1312

## How it was verified

`tests/test_api_call.py::TestApi::test_add_emission_keeps_measurement_timestamp` asserts the POSTed `timestamp` starts with the supplied measurement time and is offset-aware, and that the no-timestamp payload still yields a parseable aware ISO string. It fails on master and passes here. `uv run pytest tests/test_api_call.py -q` → 27 passed.

Note: `uv run task format` reformats a large number of unrelated files on current master, so only the two files touched here are included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
