### PR TITLE
fix: apply PUE to reported power too

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -501,7 +501,9 @@ class BaseEmissionsTracker(ABC):
                                 `sudo lshw -C memory -short | grep DIMM` to get RAM slots,
                                 then RAM power (W) = Number of RAM Slots × 5 Watts.
         :param pue: PUE (Power Usage Effectiveness) of the data center where the
-                    experiment is being run.
+                    experiment is being run. It multiplies both the reported power
+                    and the reported energy, including forced values: with
+                    `force_cpu_power=100` and `pue=1.5` the CPU is reported at 150 W.
         :param wue: WUE (Water Usage Effectiveness) of the data center. Units of L/kWh:
                     litres of water consumed per kilowatt-hour of electricity consumed.
         :param force_carbon_intensity_g_co2e_kwh: Override grid carbon intensity
@@ -1174,7 +1176,8 @@ class BaseEmissionsTracker(ABC):
                 power,
                 energy,
             ) = hardware.measure_power_and_energy(last_duration=last_duration)
-            # Apply the PUE of the datacenter to the consumed energy
+            # Apply the PUE of the datacenter
+            power *= self._pue
             energy *= self._pue
             water = Water.from_litres(litres=self._wue * energy.kWh)
             self._total_energy += energy
@@ -1584,7 +1587,9 @@ def track_emissions(
     :param force_ram_power: Force the RAM power consumption in watts. Estimate with
                             `sudo lshw -C memory -short | grep DIMM` for RAM slots,
                             then RAM power (W) = Number of RAM Slots × 5 Watts.
-    :param pue: PUE (Power Usage Effectiveness) of the data center.
+    :param pue: PUE (Power Usage Effectiveness) of the data center. It multiplies both
+                the reported power and the reported energy, including forced values:
+                with `force_cpu_power=100` and `pue=1.5` the CPU is reported at 150 W.
     :param wue: WUE (Water Usage Effectiveness) of the data center. Units of L/kWh:
                 litres of water consumed per kilowatt-hour of electricity consumed.
     :param force_carbon_intensity_g_co2e_kwh: Override grid carbon intensity

--- a/docs/reference/output.md
+++ b/docs/reference/output.md
@@ -66,7 +66,7 @@ The package has an in-built logger that logs data into a CSV file named `emissio
 | ram_used_gb | Average RAM used during tracking period (GB) |
 
 !!! note "PUE and the power columns"
-    Since v3.4.0, the `pue` multiplier is applied to the reported power columns
+    Since v3.3.1, the `pue` multiplier is applied to the reported power columns
     (`cpu_power`, `gpu_power`, `ram_power`) as well as to the energy columns, so
     that `energy_consumed` stays reconstructible from the reported power. Before
     that, only the energy was scaled. With `pue=1.5`, a machine measured at 100 W

--- a/docs/reference/output.md
+++ b/docs/reference/output.md
@@ -65,6 +65,15 @@ The package has an in-built logger that logs data into a CSV file named `emissio
 | ram_utilization_percent | Average RAM utilization during tracking period (%) |
 | ram_used_gb | Average RAM used during tracking period (GB) |
 
+!!! note "PUE and the power columns"
+    Since v3.4.0, the `pue` multiplier is applied to the reported power columns
+    (`cpu_power`, `gpu_power`, `ram_power`) as well as to the energy columns, so
+    that `energy_consumed` stays reconstructible from the reported power. Before
+    that, only the energy was scaled. With `pue=1.5`, a machine measured at 100 W
+    is reported as 150 W, and that also applies to forced values: `force_cpu_power=100`
+    with `pue=1.5` reports a 150 W CPU. This is intended: the columns describe the
+    power drawn at the facility level, not at the socket.
+
 !!! note
     Developers can enhance the Output interface by implementing a custom class that extends `BaseOutput` at `codecarbon/output.py`. For example, to log into a database.
 

--- a/tests/test_emissions_tracker_constant.py
+++ b/tests/test_emissions_tracker_constant.py
@@ -88,6 +88,39 @@ class TestCarbonTrackerConstant(unittest.TestCase):
         assertdf = pd.read_csv(self.emissions_file_path)
         self.assertEqual(USER_INPUT_CPU_POWER / 2, assertdf["cpu_power"][0])
 
+    @mock.patch.object(cpu.TDP, "_get_cpu_power_from_registry")
+    @mock.patch.object(cpu, "is_psutil_available")
+    def test_carbon_tracker_offline_constant_pue(self, mock_tdp, mock_psutil):
+        # The PUE must be applied to the reported power as well as to the energy,
+        # so that energy_consumed stays consistent with the power columns.
+        USER_INPUT_CPU_POWER = 1_000
+        PUE = 2.0
+        mock_tdp.return_value = None
+        mock_psutil.return_value = False
+        tracker = OfflineEmissionsTracker(
+            country_iso_code="USA",
+            output_dir=self.emissions_path,
+            output_file=self.emissions_file,
+            force_cpu_power=USER_INPUT_CPU_POWER,
+            pue=PUE,
+        )
+        tracker.start()
+        heavy_computation(run_time_secs=1)
+        emissions = tracker.stop()
+        assert isinstance(emissions, float)
+        assertdf = pd.read_csv(self.emissions_file_path)
+        self.assertEqual(USER_INPUT_CPU_POWER / 2 * PUE, assertdf["cpu_power"][0])
+        # energy_consumed must be reconstructible from the reported power
+        total_power = (
+            assertdf["cpu_power"][0]
+            + assertdf["gpu_power"][0]
+            + assertdf["ram_power"][0]
+        )
+        expected_energy = total_power * assertdf["duration"][0] / 3600 / 1000
+        self.assertAlmostEqual(
+            expected_energy, assertdf["energy_consumed"][0], delta=expected_energy * 0.1
+        )
+
     @mock.patch("codecarbon.external.hardware.psutil.cpu_percent", return_value=50.0)
     @mock.patch.object(cpu.TDP, "_get_cpu_power_from_registry")
     @mock.patch.object(cpu, "is_psutil_available")


### PR DESCRIPTION
## What changed

`_do_measurements` now scales the measured `power` by `self._pue` at the same point where it already scales `energy` (`codecarbon/emissions_tracker.py:1177`). `Power.__mul__` already exists, so every hardware branch below picks up the scaled value automatically.

## Why

PUE was applied to energy (and, through it, to water) but not to the power values reported in the same record. With `pue != 1` the CSV row was internally inconsistent: `energy_consumed` did not match `(cpu_power + gpu_power + ram_power) x duration`, and nothing in the row explained the gap. PUE is a facility property, so it applies equally to instantaneous power and integrated energy.

## Verification

Added `tests/test_emissions_tracker_constant.py::TestCarbonTrackerConstant::test_carbon_tracker_offline_constant_pue`, which runs the offline tracker with a forced CPU power and `pue=2.0`, asserts the reported `cpu_power` includes the PUE, and asserts `energy_consumed` is reconstructible from the reported power columns and duration. The test fails on master and passes with this change. Full file: `uv run pytest tests/test_emissions_tracker_constant.py -q` -> 7 passed.

## Note on visible numbers

**This changes reported power values for users running with `pue != 1`** — `cpu_power`, `gpu_power` and `ram_power` (and the per-hardware `logger.info` lines) are now facility-level. `energy_consumed` and emissions are unchanged. The default `pue=1.0` means the overwhelming majority of runs see no difference, but the change is not silent and warrants a changelog entry. Anyone manually multiplying power by PUE downstream would now double-apply it.

Follow-up, out of scope here: `EmissionCreate` (`codecarbon/core/api_client.py`) carries `wue` but no `pue`, so the server cannot tell whether an incoming `cpu_power` is device- or facility-level.

Closes #1320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Changelog / release note

`CHANGELOG.md` is not on `master` yet (it arrives with `docs/traction-batch`), so the note lives in the docs instead: `docs/reference/output.md` now carries a "PUE and the power columns" admonition. When the changelog lands, copy this entry:

> **Changed** — the `pue` multiplier is now applied to the reported power columns (`cpu_power`, `gpu_power`, `ram_power`) as well as to the energy columns, so `energy_consumed` stays reconstructible from the reported power. Runs with `pue != 1` will see larger power values; energy and emissions are unchanged.

Consequence worth spelling out: `pue` also scales forced values, so `force_cpu_power=100` with `pue=1.5` now reports a 150 W CPU. That is consistent with treating the columns as facility-level, but it is surprising for a parameter named "force" — documented in `docs/reference/output.md` and in both `pue` docstrings.

Because this changes user-visible numbers, it should ride a **minor** release (3.4.0), not a patch.
