### PR TITLE
fix: raise on offline tracker configuration errors

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -1309,7 +1309,6 @@ class OfflineEmissionsTracker(BaseEmissionsTracker):
     _country_iso_code = None
     _country_name, _region, country_2letter_iso_code = None, None, None
 
-    @suppress(Exception)
     def __init__(
         self,
         *args,

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -8,6 +8,13 @@ Parameters can be set via `EmissionsTracker()`, `OfflineEmissionsTracker()`, the
     PUE is a multiplication factor provided by the user. Old datacenters have PUE
     up to 2.2, new greener ones as low as 1.1.
 
+!!! warning "Constructor errors (changed in v3.4.0)"
+    `OfflineEmissionsTracker(...)` used to swallow every exception raised while
+    building the tracker, returning a half-initialised object that silently
+    recorded nothing. It now propagates those errors, like `EmissionsTracker`
+    always did — for example an `output_dir` that does not exist raises instead of
+    logging. Code that relied on the constructor never raising needs a `try`/`except`.
+
 !!! note "GPU selection"
     If you use `CUDA_VISIBLE_DEVICES` or `ROCR_VISIBLE_DEVICES` to set GPUs, CodeCarbon will automatically
     populate `gpu_ids`. Manual `gpu_ids` overrides this.

--- a/tests/test_offline_emissions_tracker.py
+++ b/tests/test_offline_emissions_tracker.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pandas as pd
 
-from codecarbon.emissions_tracker import OfflineEmissionsTracker
+from codecarbon.emissions_tracker import EmissionsTracker, OfflineEmissionsTracker
 from tests.testutils import get_custom_mock_open, get_test_data_source
 
 
@@ -67,6 +67,24 @@ class TestOfflineEmissionsTracker(unittest.TestCase):
 
         self.assertGreater(task_emission_data.emissions, 0.0)
         self.assertEqual(task_emission_data.country_name, None)
+
+    def test_offline_tracker_raises_on_invalid_output_dir(self):
+        # Configuration errors must not be swallowed by the constructor,
+        # otherwise the user gets a half-built tracker that silently does
+        # nothing. Same semantics as the online EmissionsTracker.
+        with self.assertRaises(OSError):
+            OfflineEmissionsTracker(
+                country_iso_code="FRA",
+                output_dir=str(self.temp_path / "does_not_exist"),
+            )
+        with self.assertRaises(OSError):
+            EmissionsTracker(output_dir=str(self.temp_path / "does_not_exist"))
+
+    def test_offline_tracker_raises_on_invalid_region(self):
+        # A second, offline-specific constructor path: the region check runs
+        # before `super().__init__`, so it also has to reach the caller.
+        with self.assertRaises(AssertionError):
+            OfflineEmissionsTracker(country_iso_code="FRA", region=123)
 
     def test_resolve_offline_country_name_logs_on_invalid_iso(self):
         tracker = OfflineEmissionsTracker(


### PR DESCRIPTION
Closes #1311

## What changed

Removed `@suppress(Exception)` from `OfflineEmissionsTracker.__init__` (`codecarbon/emissions_tracker.py`).

## Why

The decorator swallowed configuration errors raised during construction, most visibly the `OSError` from `_set_from_conf` when `output_dir` does not exist. The constructor then returned an object that had never reached `_initialize_runtime_state()` / `_initialize_scheduler_state()`, so it had no `_start_time`, `_hardware`, `_scheduler` or `_output_handlers`. The subsequent `start()` and `stop()` calls are themselves suppressed, so they degraded into `AttributeError` warnings and the run finished with no emissions file and no exception. Under the CLI default `log_level="error"` nothing was printed at all.

The online `EmissionsTracker` already raises for the same input, so this also removes an asymmetry between the two constructors.

Suppression on `start`, `flush` and `stop` is deliberately left in place: runtime measurement errors must never crash a user job. Only construction, where the object invariants were never established, now fails loudly.

## Verification

Added `test_offline_tracker_raises_on_invalid_output_dir` in `tests/test_offline_emissions_tracker.py`, asserting both the offline and the online tracker raise `OSError` for a non-existent `output_dir`. It fails on master and passes with this change.

```
uv run pytest tests/test_offline_emissions_tracker.py tests/test_emissions_tracker.py -q
35 passed
```

## Note for reviewers

This is a behaviour change at a public boundary: code that today constructs a misconfigured offline tracker and carries on will now raise. That is the intended correction but it deserves a changelog entry, and ideally a minor release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Changelog / release note (added)

`CHANGELOG.md` is not on `master` yet (it lands with `docs/traction-batch`), so the entry lives in the docs: `docs/reference/api.md` now carries a "Constructor errors (changed in v3.4.0)" warning. When the changelog lands, copy:

> **Changed** — `OfflineEmissionsTracker` no longer swallows exceptions raised while constructing the tracker. Configuration errors (for example a non-existent `output_dir`) now propagate to the caller, matching `EmissionsTracker`. Suppression on `start`/`flush`/`stop` is unchanged.

This must ride a **minor** release (3.4.0), not a patch.

A second constructor-raise case is now covered: `test_offline_tracker_raises_on_invalid_region` exercises the offline-only region check, which runs before `super().__init__` and so was suppressed by a different code path than the `output_dir` `OSError`. Both new tests fail when `@suppress(Exception)` is put back on the constructor.
