### PR TITLE
fix(api): stamp emissions with measurement time, not send time

### DIFF
--- a/codecarbon/core/api_client.py
+++ b/codecarbon/core/api_client.py
@@ -8,7 +8,7 @@ TODO : use async call to API
 # from httpx import AsyncClient
 import dataclasses
 import json
-from datetime import timedelta, tzinfo
+from datetime import datetime, timedelta, tzinfo
 
 import requests
 
@@ -31,6 +31,22 @@ def get_datetime_with_timezone():
     import arrow
 
     return str(arrow.now().isoformat())
+
+
+def _measurement_timestamp(carbon_emission: dict) -> str:
+    """
+    Offset-aware ISO timestamp of *when the measurement was taken*, taken from
+    EmissionsData.timestamp. Falls back to now for hand-built payloads that
+    carry no usable timestamp.
+    """
+    try:
+        return (
+            datetime.fromisoformat(carbon_emission["timestamp"])
+            .astimezone()
+            .isoformat()
+        )
+    except (KeyError, TypeError, ValueError):
+        return get_datetime_with_timezone()
 
 
 class ApiClient:  # (AsyncClient)
@@ -195,7 +211,7 @@ class ApiClient:  # (AsyncClient)
             )
             return False
         emission = EmissionCreate(
-            timestamp=get_datetime_with_timezone(),
+            timestamp=_measurement_timestamp(carbon_emission),
             run_id=self.run_id,
             duration=int(carbon_emission["duration"]),
             emissions_sum=carbon_emission["emissions"],
@@ -237,6 +253,8 @@ class ApiClient:  # (AsyncClient)
             return None
         try:
             run = RunCreate(
+                # "now" is correct here: a run's timestamp is its creation time,
+                # unlike an emission's, which is its measurement time.
                 timestamp=get_datetime_with_timezone(),
                 experiment_id=experiment_id,
                 os=self.conf.get("os"),

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -1,5 +1,6 @@
 import dataclasses
 import unittest
+from datetime import datetime
 from uuid import uuid4
 
 import requests
@@ -260,6 +261,45 @@ class TestApi(unittest.TestCase):
                 }
             )
         )
+
+    def test_add_emission_keeps_measurement_timestamp(self):
+        """The row must carry when it was measured, not when it was sent."""
+        payload = {
+            "duration": 10,
+            "emissions": 1.0,
+            "emissions_rate": 1.0,
+            "cpu_power": 1.0,
+            "gpu_power": 0.0,
+            "ram_power": 0.5,
+            "cpu_energy": 0.1,
+            "gpu_energy": 0.0,
+            "ram_energy": 0.1,
+            "energy_consumed": 0.2,
+        }
+        with requests_mock.Mocker() as m:
+            m.post("http://test.com/emissions", status_code=201)
+            api = ApiClient(
+                endpoint_url="http://test.com",
+                experiment_id="exp-1",
+                conf=conf,
+                create_run_automatically=False,
+            )
+            api.run_id = "run-1"
+
+            # naive timestamp, as produced by EmissionsData
+            assert api.add_emission({**payload, "timestamp": "2020-01-01T00:00:00"})
+            sent = datetime.fromisoformat(m.last_request.json()["timestamp"])
+            self.assertEqual(
+                sent.replace(tzinfo=None).isoformat(), "2020-01-01T00:00:00"
+            )
+            self.assertIsNotNone(sent.tzinfo)
+
+            # missing / unparseable timestamps fall back to now
+            for bad in ({}, {"timestamp": None}, {"timestamp": "222"}):
+                assert api.add_emission({**payload, **bad})
+                sent = datetime.fromisoformat(m.last_request.json()["timestamp"])
+                self.assertIsNotNone(sent.tzinfo)
+                self.assertGreater(sent.year, 2020)
 
     def test_add_emission_raises_on_unsuccessful_post(self):
         with requests_mock.Mocker() as m:


### PR DESCRIPTION
Part of #1338.

`ApiClient.add_emission` built `EmissionCreate(timestamp=get_datetime_with_timezone(), ...)`, ignoring the `timestamp` the row already carries from measurement time (`emissions_tracker.py:1047`). So the hosted API and dashboard dated every point by *receipt*, and already disagreed with the CSV output for the same run.

## Proof

End-to-end repro against a real stdlib HTTP server, with `requests.post` wrapped in a 5s delay, driven through `CodeCarbonAPIOutput.live_out`:

```
measured at : 2026-08-12T09:00:00
BEFORE  stored as : 2026-08-12T16:55:39.446260+02:00   # off by 7h55m
AFTER   stored as : 2026-08-12T09:00:00+02:00          # exact
```

Unit test `test_add_emission_keeps_measurement_timestamp` is red before, green after.

## One deviation worth flagging

The original proposal preferred fixing this at the producer, by making `EmissionsData.timestamp` offset-aware. That changes the `timestamp` column format in everyone's `emissions.csv` — a user-visible output change for a bug that lives entirely in the API client. This takes the proposal's own fallback instead: normalise inside `api_client`, leave CSV untouched.

The fallback around the conversion is deliberately broad (`KeyError`/`TypeError`/`ValueError` → now), because `add_emission` is a public dict-taking method and an existing test already passes `timestamp="222"`.

`_create_run` still stamps "now", which is correct there; there's now a comment saying so, so it doesn't get "fixed".

## Tests

`uv run pytest tests/ -q -k "output or http or api or tracker"` → 252 passed, 2 skipped, over three consecutive runs. (`tests/test_viz_data.py` excluded — fails collection on master too, `dash` not installed.) One run showed two `test_emissions_tracker_flush` / `test_logging_output` failures; they pass consistently on re-run and in isolation on both branches — timing flakes. Ruff clean on both touched files, same as master.

## Risk

Server-side rows now carry measurement time rather than receipt time, so a dashboard spanning the upgrade sees a one-time discontinuity equal to the old send latency — sub-second in practice.

## Not included

Client-side batching, which the original proposal bundled with this. `carbonserver` has only the single-row `POST /emissions` — no `/emissions/batch` — so the batch path would be dead code that 404s and falls back to the loop it replaces, and the proposal's own `api_batch_size=1` default makes it a no-op for anyone who doesn't opt in. It should land with the server endpoint or not at all.

Also left alone: the `return False` dedent in `add_emission` (`api_client.py:186`) — a real separate bug, not something to smuggle into a timestamp commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)