### PR TITLE
ci: test every Python version the package promises

### DIFF
--- a/.github/workflows/package-validation-reusable.yml
+++ b/.github/workflows/package-validation-reusable.yml
@@ -105,5 +105,13 @@ jobs:
           tracker = OfflineEmissionsTracker(country_iso_code='FRA', measure_power_secs=1)
           tracker.start()
           time.sleep(2)
-          print('emissions:', tracker.stop())
+          emissions = tracker.stop()
+          print('emissions:', emissions)
+          # stop() returns None on every internal give-up path (tracker never
+          # started, another instance holding the lock, engine init failed), so
+          # a bare call would print None and still exit 0. Assert the shape, not
+          # the magnitude: a runner with no RAPL falls back to constant CPU
+          # power and 0.0 over 2s is a legitimate result.
+          assert isinstance(emissions, float), f'tracker.stop() returned {emissions!r}'
+          assert emissions >= 0.0, emissions
           "

--- a/.github/workflows/package-validation-reusable.yml
+++ b/.github/workflows/package-validation-reusable.yml
@@ -8,6 +8,8 @@ permissions:
 
 env:
   MAIN_PYTHON_VERSION: 3.12
+  # Lowest interpreter allowed by requires-python in pyproject.toml.
+  MIN_PYTHON_VERSION: "3.10"
 
 jobs:
   build-package:
@@ -69,3 +71,39 @@ jobs:
         run: |
           .venv/bin/codecarbon --help
           .venv/bin/python -c "from codecarbon import EmissionsTracker; print('Package import successful')"
+
+  # Proves `pip install codecarbon` works with only the declared runtime
+  # dependencies (no dev group, no extras), on the oldest supported
+  # interpreter. The job above installs the dev group first, so it cannot
+  # catch a runtime dependency that is declared nowhere but the lockfile.
+  bare-install-smoke:
+    runs-on: ubuntu-24.04
+    needs: [build-package]
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          version: "latest"
+      - name: Download built package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi_dist
+          path: dist
+      - name: Install wheel into a bare virtualenv
+        run: |
+          uv venv --python ${{ env.MIN_PYTHON_VERSION }} .venv
+          uv pip install --python .venv/bin/python dist/*.whl
+      - name: Smoke test
+        env:
+          CODECARBON_ALLOW_MULTIPLE_RUNS: "True"
+        run: |
+          .venv/bin/python -c "import codecarbon; print(codecarbon.__version__)"
+          .venv/bin/codecarbon --help
+          .venv/bin/python -c "
+          import time
+          from codecarbon import OfflineEmissionsTracker
+          tracker = OfflineEmissionsTracker(country_iso_code='FRA', measure_power_secs=1)
+          tracker.start()
+          time.sleep(2)
+          print('emissions:', tracker.stop())
+          "

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - "codecarbon/**"
       - "pyproject.toml"
+      - ".github/workflows/package.yml"
+      - ".github/workflows/package-validation-reusable.yml"
     branches: [master]
   push:
     paths:
       - "codecarbon/**"
       - "pyproject.toml"
+      - ".github/workflows/package.yml"
+      - ".github/workflows/package-validation-reusable.yml"
     branches: [master]
 jobs:
   validate-package:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -20,8 +20,11 @@ jobs:
       CODECARBON_API_KEY: ${{ secrets.CODECARBON_API_TOKEN }}
       CODECARBON_EXPERIMENT_ID: ${{ secrets.CODECARBON_EXPERIMENT_ID_TEST_PACKAGE }}
     strategy:
+        fail-fast: false
         matrix:
-          python-version: ["3.12", "3.13", "3.14"]
+          # Must cover every version allowed by requires-python / classifiers
+          # in pyproject.toml.
+          python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install uv

--- a/tests/test_gpu_amd.py
+++ b/tests/test_gpu_amd.py
@@ -429,6 +429,15 @@ class TestAmdsmiImportFailures:
             sys.modules.pop("amdsmi", None)
             sys.modules.pop("codecarbon.core.gpu_amd", None)
             sys.modules.update(saved)
+            # importlib also rebinds the submodule attribute on the parent
+            # package, and restoring sys.modules alone does not undo that.
+            # On Python < 3.12 mock.patch resolves "codecarbon.core.gpu_amd.x"
+            # through that attribute, so a stale binding would send later
+            # patches to the throwaway module. Put the real one back.
+            if "codecarbon.core.gpu_amd" in saved:
+                import codecarbon.core
+
+                codecarbon.core.gpu_amd = saved["codecarbon.core.gpu_amd"]
 
     def test_oserror_sets_amdsmi_unavailable(self):
         """OSError during amdsmi import (e.g. missing libamd_smi.so) must disable AMD GPU support."""


### PR DESCRIPTION
Part of #1338.

`requires-python = ">=3.10"` (`pyproject.toml:9`) and the classifiers advertise 3.10 through 3.14. The matrix ran `["3.12", "3.13", "3.14"]`. Two of five promised versions were exercised by nothing — confirmed across all workflows; `package-validation-reusable.yml` pins 3.12 for both its jobs and nothing else touches the SDK matrix.

## Honest framing: no user is broken today

I tried to produce a break on 3.10 and could not. A clean 3.10 venv resolved and installed from source with only declared runtime dependencies; `import codecarbon` worked; `codecarbon --help` worked; a real `OfflineEmissionsTracker` run returned emissions (5.95e-07 kg). Full non-integration suite on the same machine: 3.10 → 619 passed / 5 failed, 3.12 → 623 passed / 1 failed, with non-overlapping failure sets that all pass in isolation — macOS shared-state ordering flakes, not version incompatibilities. Same 624 tests collected on both. Grepping for the usual hazards (`datetime.UTC`, `tomllib`, `StrEnum`, `ExceptionGroup`, `itertools.batched`, `match`) found zero hits in `codecarbon/`.

So what is broken is the *enforcement*, not the code: nothing stops the first `datetime.UTC` from shipping. This is the cheapest moment to fix it, precisely because 3.10 is green and widening the matrix costs no fix-the-code work.

## Changes

- `test-package.yml` — matrix widened to `["3.10", "3.11", "3.12", "3.13", "3.14"]`, plus `fail-fast: false` so a single-version failure is diagnosable rather than confusing.
- `package-validation-reusable.yml` — new `MIN_PYTHON_VERSION: "3.10"` and a `bare-install-smoke` job that installs *only* the built wheel into an empty 3.10 venv, then runs import, `codecarbon --help`, and a 2s `OfflineEmissionsTracker`. This closes a second real gap: the existing `test-package-from-wheel` job runs `uv sync --group dev` *before* installing the wheel, so a runtime dependency missing from `[project.dependencies]` but present in the lockfile goes unnoticed. It runs on PRs, since `package.yml` calls this workflow on `pull_request`.
- **`tests/test_gpu_amd.py` — out of the stated scope of this PR, flagged explicitly so nobody is surprised by it in the diff.** It is not a matrix change; it is the fix required to make 3.10 and 3.11 green, and without it this PR cannot go in. `_import_gpu_amd_with_amdsmi_error` re-imports `codecarbon.core.gpu_amd` with a poisoned `__import__` and then restores `sys.modules`. That is not enough: `importlib.import_module` *also* rebinds `gpu_amd` as an attribute of the parent `codecarbon.core` package, and on Python < 3.12 `mock.patch("codecarbon.core.gpu_amd.<x>")` resolves its target by walking that attribute chain rather than by `sys.modules` lookup. The stale binding therefore sent every *later* test's patches to the throwaway module, so the AMD tests failed on 3.10/3.11 while passing on 3.12+. The teardown now restores the parent attribute too. Nine lines, test-only, no runtime code touched.

## `bare-install-smoke` asserts a result, not just the absence of a crash

The first revision only printed `tracker.stop()`. Since `stop()` returns `None` on every internal give-up path — tracker never started, another instance holding the lock, emissions engine failed to initialise — that job would have printed `emissions: None` and still exited 0, i.e. stayed green on a wheel whose tracker does not work at all. It now asserts the *shape* of the result and deliberately tolerates a zero:

```python
assert isinstance(emissions, float), f'tracker.stop() returned {emissions!r}'
assert emissions >= 0.0, emissions
```

No magnitude assertion. A runner with no RAPL falls back to constant CPU power, and `0.0` over a 2-second window is a legitimate outcome there; asserting `> 0` would be the flaky version of this check. Verified locally on a bare install: returns `5.46e-07`, assertions pass.

## Cost

Three matrix jobs become five. Roughly +12-18 CI minutes per triggering PR, plus ~2 min for the smoke job; wall clock unchanged since matrix jobs run in parallel, and this is a public repo so the minutes are free.

## Choices against the original proposal

- **Widened the matrix rather than raising the floor to 3.12.** Raising it is user-visible breakage justified by evidence I could not find — the code demonstrably runs on 3.10.
- **Skipped the Ruff `UP` rule change.** `ruff check --select UP --target-version py310 codecarbon/` reports **552 errors, 521 auto-fixable**, essentially all cosmetic (`Tuple` → `tuple`) — and `UP` does not flag `from datetime import UTC` at all, so it would not catch the hazard used to motivate it. A 500-line stylistic diff that misses the stated threat isn't a cheap first line of defence.
- **Skipped the coverage `include`/`primary` split.** Codecov merges matrix uploads rather than double-counting; the repo already uploads three times today.

## Verified vs. unverified

Verified locally: both workflow files parse as YAML, the matrix expands to exactly five entries, the smoke script survives YAML block-scalar *and* `python -c "…"` shell quoting (round-tripped through `yaml.safe_load`), and its substance succeeds on a bare install here. Full suite `626 passed, 21 skipped`; `uv run pre-commit run --all-files` passes.

Unverified (cannot run Actions locally): that `uv python install 3.10`/`3.11` resolve on `ubuntu-24.04` (very likely — uv ships its own builds); that the suite passes on 3.10/3.11 on *Linux* CI rather than macOS; and that the smoke job's tracker run succeeds on a runner with no RAPL. If 3.10 or 3.11 fails on Linux in a way it doesn't here, this becomes a fix-the-code task — `fail-fast: false` is what makes that legible. If five interpreters per PR proves too slow, moving 3.10/3.11 to push-and-nightly is the escape hatch; I did not pre-build it.

## Still open

Deciding the `requires-python` floor before any extras split lands, and `test-package.yml:43` installing `dash`/`fire` by hand instead of via the `[carbonboard]` extra, which lets packaging metadata drift from what CI actually installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
