### PR TITLE
feat(cli): add `codecarbon badge` command

### DIFF
--- a/codecarbon/badge.py
+++ b/codecarbon/badge.py
@@ -1,10 +1,9 @@
 """
 Generate a README badge from an existing ``emissions.csv``.
 
-Everything here is local: read the CSV written by ``FileOutput``, render a flat
-SVG badge and a `shields.io endpoint
-<https://shields.io/badges/endpoint-badge>`_ JSON file. No network call, no
-hosted service, no account.
+Everything here is local: read the CSV written by ``FileOutput`` and render a
+`shields.io endpoint <https://shields.io/badges/endpoint-badge>`_ JSON file.
+No network call, no hosted service, no account.
 """
 
 import csv
@@ -19,27 +18,6 @@ BADGE_STEM = "codecarbon-badge"
 # The badge is deliberately colour-neutral by default. CodeCarbon numbers are
 # often estimates, and a green badge on a large model would be greenwashing:
 # no gram threshold is meaningful across arbitrary workloads.
-
-_SVG_TEMPLATE = """<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="20" role="img" aria-label="{label}: {message}">
-  <title>{label}: {message}</title>
-  <linearGradient id="s" x2="0" y2="100%">
-    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
-    <stop offset="1" stop-opacity=".1"/>
-  </linearGradient>
-  <clipPath id="r"><rect width="{width}" height="20" rx="3" fill="#fff"/></clipPath>
-  <g clip-path="url(#r)">
-    <rect width="{label_width}" height="20" fill="#555"/>
-    <rect x="{label_width}" width="{message_width}" height="20" fill="{color}"/>
-    <rect width="{width}" height="20" fill="url(#s)"/>
-  </g>
-  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
-    <text x="{label_x}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
-    <text x="{label_x}" y="14">{label}</text>
-    <text x="{message_x}" y="15" fill="#010101" fill-opacity=".3">{message}</text>
-    <text x="{message_x}" y="14">{message}</text>
-  </g>
-</svg>
-"""
 
 
 def load_runs(emissions_file, project: Optional[str] = None) -> List[Dict]:
@@ -61,12 +39,31 @@ def load_runs(emissions_file, project: Optional[str] = None) -> List[Dict]:
     return rows
 
 
+def last_row_per_run(rows: List[Dict]) -> List[Dict]:
+    """
+    Keep one row per run: the last one.
+
+    CodeCarbon appends one row per flush, all sharing a ``run_id``, and every
+    row holds the *cumulative* totals since the start of that run --
+    ``FileOutput.out()`` discards the delta it is handed and writes the running
+    total. Summing raw rows would therefore double-count. Files without a
+    ``run_id`` column (older CSVs) are treated as one run per row.
+    """
+    if not rows or "run_id" not in rows[0]:
+        return rows
+    by_run: dict[str, dict] = {}
+    for row in rows:
+        by_run[row.get("run_id")] = row
+    return list(by_run.values())
+
+
 def summarise(rows: List[Dict], select: str = "last") -> Dict[str, float]:
     """
     Reduce the rows to the emissions and energy of a single reported value.
     """
-    emissions = [float(row["emissions"]) for row in rows]
-    energy = [float(row["energy_consumed"]) for row in rows]
+    runs = last_row_per_run(rows)
+    emissions = [float(row["emissions"]) for row in runs]
+    energy = [float(row["energy_consumed"]) for row in runs]
     if select == "last":
         value = {"emissions": emissions[-1], "energy_consumed": energy[-1]}
     elif select == "mean":
@@ -78,7 +75,7 @@ def summarise(rows: List[Dict], select: str = "last") -> Dict[str, float]:
         value = {"emissions": sum(emissions), "energy_consumed": sum(energy)}
     else:
         raise ValueError(f"Unknown selection '{select}', expected last/mean/total")
-    value["runs"] = len(rows)
+    value["runs"] = len(runs)
     return value
 
 
@@ -97,33 +94,6 @@ def format_value(kilos: float, unit: str = "gCO2eq") -> str:
     return f"{scaled:.3g} {prefix}{unit}"
 
 
-def _text_width(text: str) -> int:
-    # ponytail: character count times an average advance; real font metrics
-    # would need a font dependency and would move the badge by a pixel or two.
-    return int(len(text) * 6.5) + 20
-
-
-def render_svg(label: str, message: str, color: str = DEFAULT_COLOR) -> str:
-    label_width = _text_width(label)
-    message_width = _text_width(message)
-    return _SVG_TEMPLATE.format(
-        label=_escape(label),
-        message=_escape(message),
-        color=color,
-        width=label_width + message_width,
-        label_width=label_width,
-        message_width=message_width,
-        label_x=label_width // 2,
-        message_x=label_width + message_width // 2,
-    )
-
-
-def _escape(text: str) -> str:
-    for char, entity in (("&", "&amp;"), ("<", "&lt;"), (">", "&gt;")):
-        text = text.replace(char, entity)
-    return text
-
-
 def render_endpoint_json(label: str, message: str, color: str = DEFAULT_COLOR) -> str:
     return json.dumps(
         {
@@ -136,13 +106,10 @@ def render_endpoint_json(label: str, message: str, color: str = DEFAULT_COLOR) -
     )
 
 
-def render_markdown(label: str, output_dir=".") -> str:
+def render_markdown(label: str) -> str:
     return (
-        f"![{label}]({Path(output_dir) / (BADGE_STEM + '.svg')})\n"
-        "\n"
-        "or, publishing the endpoint JSON at a public URL:\n"
-        "\n"
-        f"![{label}](https://img.shields.io/endpoint?url=<your-url>/{BADGE_STEM}.json)"
+        f"![{label}](https://img.shields.io/endpoint"
+        f"?url=<public-url-of>/{BADGE_STEM}.json)"
     )
 
 
@@ -170,10 +137,10 @@ def render(
     color: str = DEFAULT_COLOR,
 ) -> str:
     """
-    Return the SVG source of the badge for an emissions file.
+    Return the shields.io endpoint JSON of the badge for an emissions file.
     """
     summary = summarise(load_runs(emissions_file, project), select)
-    return render_svg(label, message_for(summary, select, metric), color)
+    return render_endpoint_json(label, message_for(summary, select, metric), color)
 
 
 def write(
@@ -184,22 +151,15 @@ def write(
     label: str = DEFAULT_LABEL,
     color: str = DEFAULT_COLOR,
     output_dir=".",
-    formats=("svg", "json"),
-) -> List[Path]:
+) -> Path:
     """
-    Write the badge files and return the paths written.
+    Write the badge JSON file and return its path.
     """
-    summary = summarise(load_runs(emissions_file, project), select)
-    message = message_for(summary, select, metric)
     directory = Path(output_dir)
     directory.mkdir(parents=True, exist_ok=True)
-    written = []
-    if "svg" in formats:
-        path = directory / f"{BADGE_STEM}.svg"
-        path.write_text(render_svg(label, message, color), encoding="utf-8")
-        written.append(path)
-    if "json" in formats:
-        path = directory / f"{BADGE_STEM}.json"
-        path.write_text(render_endpoint_json(label, message, color), encoding="utf-8")
-        written.append(path)
-    return written
+    path = directory / f"{BADGE_STEM}.json"
+    path.write_text(
+        render(emissions_file, project, select, metric, label, color),
+        encoding="utf-8",
+    )
+    return path

--- a/codecarbon/badge.py
+++ b/codecarbon/badge.py
@@ -1,0 +1,205 @@
+"""
+Generate a README badge from an existing ``emissions.csv``.
+
+Everything here is local: read the CSV written by ``FileOutput``, render a flat
+SVG badge and a `shields.io endpoint
+<https://shields.io/badges/endpoint-badge>`_ JSON file. No network call, no
+hosted service, no account.
+"""
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DEFAULT_LABEL = "carbon"
+DEFAULT_COLOR = "#9f9f9f"
+BADGE_STEM = "codecarbon-badge"
+
+# The badge is deliberately colour-neutral by default. CodeCarbon numbers are
+# often estimates, and a green badge on a large model would be greenwashing:
+# no gram threshold is meaningful across arbitrary workloads.
+
+_SVG_TEMPLATE = """<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="20" role="img" aria-label="{label}: {message}">
+  <title>{label}: {message}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="{width}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="{label_width}" height="20" fill="#555"/>
+    <rect x="{label_width}" width="{message_width}" height="20" fill="{color}"/>
+    <rect width="{width}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="{label_x}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
+    <text x="{label_x}" y="14">{label}</text>
+    <text x="{message_x}" y="15" fill="#010101" fill-opacity=".3">{message}</text>
+    <text x="{message_x}" y="14">{message}</text>
+  </g>
+</svg>
+"""
+
+
+def load_runs(emissions_file, project: Optional[str] = None) -> List[Dict]:
+    """
+    Read the rows of an emissions.csv, optionally keeping a single project.
+    """
+    path = Path(emissions_file)
+    if not path.is_file():
+        raise FileNotFoundError(f"No emissions file at {path}")
+    with path.open(newline="", encoding="utf-8") as file:
+        rows = list(csv.DictReader(file))
+    if project is not None:
+        rows = [row for row in rows if row.get("project_name") == project]
+    if not rows:
+        raise ValueError(
+            f"No rows found in {path}"
+            + (f" for project '{project}'" if project else "")
+        )
+    return rows
+
+
+def summarise(rows: List[Dict], select: str = "last") -> Dict[str, float]:
+    """
+    Reduce the rows to the emissions and energy of a single reported value.
+    """
+    emissions = [float(row["emissions"]) for row in rows]
+    energy = [float(row["energy_consumed"]) for row in rows]
+    if select == "last":
+        value = {"emissions": emissions[-1], "energy_consumed": energy[-1]}
+    elif select == "mean":
+        value = {
+            "emissions": sum(emissions) / len(emissions),
+            "energy_consumed": sum(energy) / len(energy),
+        }
+    elif select == "total":
+        value = {"emissions": sum(emissions), "energy_consumed": sum(energy)}
+    else:
+        raise ValueError(f"Unknown selection '{select}', expected last/mean/total")
+    value["runs"] = len(rows)
+    return value
+
+
+def format_value(kilos: float, unit: str = "gCO2eq") -> str:
+    """
+    Format a value given in kg (or kWh) with a sensible scale, 3 significant
+    digits. ``unit`` is the gram-scale (or Wh-scale) unit name.
+    """
+    scaled, prefix = abs(kilos) * 1000, ""
+    if scaled < 1:
+        scaled, prefix = scaled * 1000, "m"
+    elif scaled >= 1_000_000:
+        scaled, prefix = scaled / 1_000_000, "M"
+    elif scaled >= 1000:
+        scaled, prefix = scaled / 1000, "k"
+    return f"{scaled:.3g} {prefix}{unit}"
+
+
+def _text_width(text: str) -> int:
+    # ponytail: character count times an average advance; real font metrics
+    # would need a font dependency and would move the badge by a pixel or two.
+    return int(len(text) * 6.5) + 20
+
+
+def render_svg(label: str, message: str, color: str = DEFAULT_COLOR) -> str:
+    label_width = _text_width(label)
+    message_width = _text_width(message)
+    return _SVG_TEMPLATE.format(
+        label=_escape(label),
+        message=_escape(message),
+        color=color,
+        width=label_width + message_width,
+        label_width=label_width,
+        message_width=message_width,
+        label_x=label_width // 2,
+        message_x=label_width + message_width // 2,
+    )
+
+
+def _escape(text: str) -> str:
+    for char, entity in (("&", "&amp;"), ("<", "&lt;"), (">", "&gt;")):
+        text = text.replace(char, entity)
+    return text
+
+
+def render_endpoint_json(label: str, message: str, color: str = DEFAULT_COLOR) -> str:
+    return json.dumps(
+        {
+            "schemaVersion": 1,
+            "label": label,
+            "message": message,
+            "color": color,
+        },
+        indent=2,
+    )
+
+
+def render_markdown(label: str, output_dir=".") -> str:
+    return (
+        f"![{label}]({Path(output_dir) / (BADGE_STEM + '.svg')})\n"
+        "\n"
+        "or, publishing the endpoint JSON at a public URL:\n"
+        "\n"
+        f"![{label}](https://img.shields.io/endpoint?url=<your-url>/{BADGE_STEM}.json)"
+    )
+
+
+def message_for(
+    summary: Dict[str, float], select: str = "last", metric: str = "emissions"
+) -> str:
+    """
+    Build the right-hand side of the badge from a summary.
+    """
+    suffix = {"last": "", "mean": "/run", "total": " total"}[select]
+    parts = []
+    if metric in ("emissions", "both"):
+        parts.append(format_value(summary["emissions"], "gCO2eq"))
+    if metric in ("energy", "both"):
+        parts.append(format_value(summary["energy_consumed"], "Wh"))
+    return " | ".join(parts) + suffix
+
+
+def render(
+    emissions_file="emissions.csv",
+    project: Optional[str] = None,
+    select: str = "last",
+    metric: str = "emissions",
+    label: str = DEFAULT_LABEL,
+    color: str = DEFAULT_COLOR,
+) -> str:
+    """
+    Return the SVG source of the badge for an emissions file.
+    """
+    summary = summarise(load_runs(emissions_file, project), select)
+    return render_svg(label, message_for(summary, select, metric), color)
+
+
+def write(
+    emissions_file="emissions.csv",
+    project: Optional[str] = None,
+    select: str = "last",
+    metric: str = "emissions",
+    label: str = DEFAULT_LABEL,
+    color: str = DEFAULT_COLOR,
+    output_dir=".",
+    formats=("svg", "json"),
+) -> List[Path]:
+    """
+    Write the badge files and return the paths written.
+    """
+    summary = summarise(load_runs(emissions_file, project), select)
+    message = message_for(summary, select, metric)
+    directory = Path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    written = []
+    if "svg" in formats:
+        path = directory / f"{BADGE_STEM}.svg"
+        path.write_text(render_svg(label, message, color), encoding="utf-8")
+        written.append(path)
+    if "json" in formats:
+        path = directory / f"{BADGE_STEM}.json"
+        path.write_text(render_endpoint_json(label, message, color), encoding="utf-8")
+        written.append(path)
+    return written

--- a/codecarbon/badge.py
+++ b/codecarbon/badge.py
@@ -7,17 +7,23 @@ No network call, no hosted service, no account.
 """
 
 import csv
+import enum
 import json
 from pathlib import Path
 from typing import Dict, List, Optional
 
-DEFAULT_LABEL = "carbon"
-DEFAULT_COLOR = "#9f9f9f"
 BADGE_STEM = "codecarbon-badge"
+LABEL = "carbon"
+# The badge is deliberately colour-neutral. CodeCarbon numbers are often
+# estimates, and a green badge on a large model would be greenwashing: no gram
+# threshold is meaningful across arbitrary workloads.
+COLOR = "#9f9f9f"
 
-# The badge is deliberately colour-neutral by default. CodeCarbon numbers are
-# often estimates, and a green badge on a large model would be greenwashing:
-# no gram threshold is meaningful across arbitrary workloads.
+
+class Select(str, enum.Enum):
+    last = "last"
+    mean = "mean"
+    total = "total"
 
 
 def load_runs(emissions_file, project: Optional[str] = None) -> List[Dict]:
@@ -39,42 +45,47 @@ def load_runs(emissions_file, project: Optional[str] = None) -> List[Dict]:
     return rows
 
 
+def _timestamp(row: Dict) -> str:
+    return row.get("timestamp") or ""
+
+
 def last_row_per_run(rows: List[Dict]) -> List[Dict]:
     """
-    Keep one row per run: the last one.
+    Keep the latest row of each run, ordered by timestamp.
 
     CodeCarbon appends one row per flush, all sharing a ``run_id``, and every
     row holds the *cumulative* totals since the start of that run --
     ``FileOutput.out()`` discards the delta it is handed and writes the running
-    total. Summing raw rows would therefore double-count. Files without a
-    ``run_id`` column (older CSVs) are treated as one run per row.
+    total. Summing raw rows would therefore double-count.
+
+    Rows are sorted by timestamp first: with ``allow_multiple_runs`` two
+    trackers interleave their flushes into one file, so file order does not
+    tell you which run finished last. Rows without a usable ``run_id`` (older
+    CSVs, blank values) each count as their own run.
     """
-    if not rows or "run_id" not in rows[0]:
-        return rows
-    by_run: dict[str, dict] = {}
-    for row in rows:
-        by_run[row.get("run_id")] = row
-    return list(by_run.values())
+    by_run: Dict[str, Dict] = {}
+    for index, row in enumerate(sorted(rows, key=_timestamp)):
+        by_run[row.get("run_id") or f"__norun{index}"] = row
+    return sorted(by_run.values(), key=_timestamp)
 
 
-def summarise(rows: List[Dict], select: str = "last") -> Dict[str, float]:
+def summarise(rows: List[Dict], select: Select = Select.last) -> Dict[str, float]:
     """
     Reduce the rows to the emissions and energy of a single reported value.
     """
     runs = last_row_per_run(rows)
     emissions = [float(row["emissions"]) for row in runs]
     energy = [float(row["energy_consumed"]) for row in runs]
-    if select == "last":
+    select = Select(select)
+    if select is Select.last:
         value = {"emissions": emissions[-1], "energy_consumed": energy[-1]}
-    elif select == "mean":
+    elif select is Select.mean:
         value = {
             "emissions": sum(emissions) / len(emissions),
             "energy_consumed": sum(energy) / len(energy),
         }
-    elif select == "total":
-        value = {"emissions": sum(emissions), "energy_consumed": sum(energy)}
     else:
-        raise ValueError(f"Unknown selection '{select}', expected last/mean/total")
+        value = {"emissions": sum(emissions), "energy_consumed": sum(energy)}
     value["runs"] = len(runs)
     return value
 
@@ -84,73 +95,44 @@ def format_value(kilos: float, unit: str = "gCO2eq") -> str:
     Format a value given in kg (or kWh) with a sensible scale, 3 significant
     digits. ``unit`` is the gram-scale (or Wh-scale) unit name.
     """
-    scaled, prefix = abs(kilos) * 1000, ""
-    if scaled < 1:
+    scaled, prefix = kilos * 1000, ""
+    magnitude = abs(scaled)
+    if magnitude < 1:
         scaled, prefix = scaled * 1000, "m"
-    elif scaled >= 1_000_000:
+    elif magnitude >= 1_000_000:
         scaled, prefix = scaled / 1_000_000, "M"
-    elif scaled >= 1000:
+    elif magnitude >= 1000:
         scaled, prefix = scaled / 1000, "k"
     return f"{scaled:.3g} {prefix}{unit}"
 
 
-def render_endpoint_json(label: str, message: str, color: str = DEFAULT_COLOR) -> str:
+def message_for(summary: Dict[str, float], select: Select = Select.last) -> str:
+    """
+    Build the right-hand side of the badge from a summary.
+    """
+    suffix = {Select.last: "", Select.mean: "/run", Select.total: " total"}[
+        Select(select)
+    ]
+    return format_value(summary["emissions"], "gCO2eq") + suffix
+
+
+def render(summary: Dict[str, float], select: Select = Select.last) -> str:
+    """
+    Return the shields.io endpoint JSON of the badge for a summary.
+    """
     return json.dumps(
         {
             "schemaVersion": 1,
-            "label": label,
-            "message": message,
-            "color": color,
+            "label": LABEL,
+            "message": message_for(summary, select),
+            "color": COLOR,
         },
         indent=2,
     )
 
 
-def render_markdown(label: str) -> str:
-    return (
-        f"![{label}](https://img.shields.io/endpoint"
-        f"?url=<public-url-of>/{BADGE_STEM}.json)"
-    )
-
-
-def message_for(
-    summary: Dict[str, float], select: str = "last", metric: str = "emissions"
-) -> str:
-    """
-    Build the right-hand side of the badge from a summary.
-    """
-    suffix = {"last": "", "mean": "/run", "total": " total"}[select]
-    parts = []
-    if metric in ("emissions", "both"):
-        parts.append(format_value(summary["emissions"], "gCO2eq"))
-    if metric in ("energy", "both"):
-        parts.append(format_value(summary["energy_consumed"], "Wh"))
-    return " | ".join(parts) + suffix
-
-
-def render(
-    emissions_file="emissions.csv",
-    project: Optional[str] = None,
-    select: str = "last",
-    metric: str = "emissions",
-    label: str = DEFAULT_LABEL,
-    color: str = DEFAULT_COLOR,
-) -> str:
-    """
-    Return the shields.io endpoint JSON of the badge for an emissions file.
-    """
-    summary = summarise(load_runs(emissions_file, project), select)
-    return render_endpoint_json(label, message_for(summary, select, metric), color)
-
-
 def write(
-    emissions_file="emissions.csv",
-    project: Optional[str] = None,
-    select: str = "last",
-    metric: str = "emissions",
-    label: str = DEFAULT_LABEL,
-    color: str = DEFAULT_COLOR,
-    output_dir=".",
+    summary: Dict[str, float], select: Select = Select.last, output_dir="."
 ) -> Path:
     """
     Write the badge JSON file and return its path.
@@ -158,8 +140,5 @@ def write(
     directory = Path(output_dir)
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / f"{BADGE_STEM}.json"
-    path.write_text(
-        render(emissions_file, project, select, metric, label, color),
-        encoding="utf-8",
-    )
+    path.write_text(render(summary, select), encoding="utf-8")
     return path

--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -501,20 +501,11 @@ def badge_command(
     project: Optional[str] = typer.Option(
         None, "--project", help="Only use rows of this project."
     ),
-    select: str = typer.Option(
-        "last", "--select", help="Which run(s) to report: last, mean or total."
-    ),
-    metric: str = typer.Option(
-        "emissions", "--metric", help="What to show: emissions, energy or both."
+    select: badge.Select = typer.Option(
+        badge.Select.last, "--select", help="Which run(s) to report."
     ),
     output_dir: Path = typer.Option(
         Path("."), "--output-dir", help="Where to write the badge file."
-    ),
-    label: str = typer.Option(
-        badge.DEFAULT_LABEL, "--label", help="Left-hand badge text."
-    ),
-    color: str = typer.Option(
-        badge.DEFAULT_COLOR, "--color", help="Badge colour, neutral grey by default."
     ),
 ):
     """
@@ -525,15 +516,7 @@ def badge_command(
     """
     try:
         summary = badge.summarise(badge.load_runs(file, project), select)
-        path = badge.write(
-            emissions_file=file,
-            project=project,
-            select=select,
-            metric=metric,
-            label=label,
-            color=color,
-            output_dir=output_dir,
-        )
+        path = badge.write(summary, select, output_dir)
     except (FileNotFoundError, ValueError, KeyError) as error:
         print(f"[bold red]{escape(str(error))}[/]")
         raise typer.Exit(1)
@@ -543,12 +526,17 @@ def badge_command(
         + (f" (project={project})" if project else "")
     )
     print(
-        f"{select}: {badge.format_value(summary['emissions'], 'gCO2eq')}, "
+        f"{select.value}: {badge.format_value(summary['emissions'], 'gCO2eq')}, "
         f"{badge.format_value(summary['energy_consumed'], 'Wh')}"
     )
     print(f"Wrote {path}")
     print("\nPublish that file at a public URL and paste into your README:\n")
-    print(escape(badge.render_markdown(label)))
+    print(
+        escape(
+            f"![{badge.LABEL}](https://img.shields.io/endpoint"
+            f"?url=<public-url-of>/{badge.BADGE_STEM}.json)"
+        )
+    )
 
 
 def questionary_prompt(prompt, list_options, default):

--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -508,7 +508,7 @@ def badge_command(
         "emissions", "--metric", help="What to show: emissions, energy or both."
     ),
     output_dir: Path = typer.Option(
-        Path("."), "--output-dir", help="Where to write the badge files."
+        Path("."), "--output-dir", help="Where to write the badge file."
     ),
     label: str = typer.Option(
         badge.DEFAULT_LABEL, "--label", help="Left-hand badge text."
@@ -516,20 +516,16 @@ def badge_command(
     color: str = typer.Option(
         badge.DEFAULT_COLOR, "--color", help="Badge colour, neutral grey by default."
     ),
-    output_format: str = typer.Option(
-        "all", "--format", help="Files to write: svg, json or all."
-    ),
 ):
     """
     Generate a badge for your README from an existing emissions file.
 
-    Nothing leaves your machine : the badge is rendered locally from the CSV.
+    Nothing leaves your machine : the shields.io endpoint JSON is written
+    locally from the CSV.
     """
-    formats = ("svg", "json") if output_format == "all" else (output_format,)
     try:
-        rows = badge.load_runs(file, project)
-        summary = badge.summarise(rows, select)
-        paths = badge.write(
+        summary = badge.summarise(badge.load_runs(file, project), select)
+        path = badge.write(
             emissions_file=file,
             project=project,
             select=select,
@@ -537,24 +533,22 @@ def badge_command(
             label=label,
             color=color,
             output_dir=output_dir,
-            formats=formats,
         )
     except (FileNotFoundError, ValueError, KeyError) as error:
         print(f"[bold red]{escape(str(error))}[/]")
         raise typer.Exit(1)
 
     print(
-        f"Read {summary['runs']} row(s) from {file}"
+        f"Read {summary['runs']} run(s) from {file}"
         + (f" (project={project})" if project else "")
     )
     print(
         f"{select}: {badge.format_value(summary['emissions'], 'gCO2eq')}, "
         f"{badge.format_value(summary['energy_consumed'], 'Wh')}"
     )
-    for path in paths:
-        print(f"Wrote {path}")
-    print("\nPaste into your README:\n")
-    print(escape(badge.render_markdown(label, output_dir)))
+    print(f"Wrote {path}")
+    print("\nPublish that file at a public URL and paste into your README:\n")
+    print(escape(badge.render_markdown(label)))
 
 
 def questionary_prompt(prompt, list_options, default):

--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -7,10 +7,11 @@ from typing import Optional
 
 import typer
 from rich import print
+from rich.markup import escape
 from rich.prompt import Confirm
 from typing_extensions import Annotated
 
-from codecarbon import __app_name__, __version__
+from codecarbon import __app_name__, __version__, badge
 from codecarbon.cli.cli_utils import (
     create_new_config_file,
     get_api_endpoint,
@@ -490,6 +491,70 @@ def detect():
             f" BUT only tracking these GPU ids : {hardware_info['gpu_ids']}"
         )
     print(f"- GPU model: {gpu_model_str}")
+
+
+@codecarbon.command("badge", short_help="Generate a README badge from emissions.csv.")
+def badge_command(
+    file: Path = typer.Option(
+        Path("./emissions.csv"), "--file", help="Emissions file to read."
+    ),
+    project: Optional[str] = typer.Option(
+        None, "--project", help="Only use rows of this project."
+    ),
+    select: str = typer.Option(
+        "last", "--select", help="Which run(s) to report: last, mean or total."
+    ),
+    metric: str = typer.Option(
+        "emissions", "--metric", help="What to show: emissions, energy or both."
+    ),
+    output_dir: Path = typer.Option(
+        Path("."), "--output-dir", help="Where to write the badge files."
+    ),
+    label: str = typer.Option(
+        badge.DEFAULT_LABEL, "--label", help="Left-hand badge text."
+    ),
+    color: str = typer.Option(
+        badge.DEFAULT_COLOR, "--color", help="Badge colour, neutral grey by default."
+    ),
+    output_format: str = typer.Option(
+        "all", "--format", help="Files to write: svg, json or all."
+    ),
+):
+    """
+    Generate a badge for your README from an existing emissions file.
+
+    Nothing leaves your machine : the badge is rendered locally from the CSV.
+    """
+    formats = ("svg", "json") if output_format == "all" else (output_format,)
+    try:
+        rows = badge.load_runs(file, project)
+        summary = badge.summarise(rows, select)
+        paths = badge.write(
+            emissions_file=file,
+            project=project,
+            select=select,
+            metric=metric,
+            label=label,
+            color=color,
+            output_dir=output_dir,
+            formats=formats,
+        )
+    except (FileNotFoundError, ValueError, KeyError) as error:
+        print(f"[bold red]{escape(str(error))}[/]")
+        raise typer.Exit(1)
+
+    print(
+        f"Read {summary['runs']} row(s) from {file}"
+        + (f" (project={project})" if project else "")
+    )
+    print(
+        f"{select}: {badge.format_value(summary['emissions'], 'gCO2eq')}, "
+        f"{badge.format_value(summary['energy_consumed'], 'Wh')}"
+    )
+    for path in paths:
+        print(f"Wrote {path}")
+    print("\nPaste into your README:\n")
+    print(escape(badge.render_markdown(label, output_dir)))
 
 
 def questionary_prompt(prompt, list_options, default):

--- a/docs/how-to/visualize.md
+++ b/docs/how-to/visualize.md
@@ -105,3 +105,8 @@ The app also provides a visualization of regional carbon intensity of electricit
 - [Configure CodeCarbon](configuration.md) for additional tracking options
 - [Integrate with experiment tracking tools](comet.md) like Comet for seamless workflow integration
 - [Join our Discord](https://discord.gg/GS9js2XkJR) to share your results and discuss emissions tracking with the community
+
+## Generate a README badge
+
+To turn a run into a badge you can commit next to your CI badges, see
+[`codecarbon badge`](../reference/cli.md#codecarbon-badge).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -124,32 +124,18 @@ run, so the badge uses the last row of each `run_id`: `last` is the latest run,
 | `--file` | path | ./emissions.csv | Emissions file to read |
 | `--project` | string | - | Only use rows of this project |
 | `--select` | choice | last | Which run(s) to report: `last`, `mean` or `total` |
-| `--metric` | choice | emissions | What to show: `emissions`, `energy` or `both` |
 | `--output-dir` | path | . | Where to write the badge file |
-| `--label` | string | carbon | Left-hand badge text |
-| `--color` | string | grey | Badge colour |
 
 **Examples:**
 ```bash
 # Badge for the last run
 codecarbon badge
 
-# Average over every run of one project, showing energy too
-codecarbon badge --project my-training --select mean --metric both
+# Average over every run of one project
+codecarbon badge --project my-training --select mean
 
 # Write into the docs assets folder
 codecarbon badge --output-dir docs/assets
 ```
 
-The badge is colour-neutral by default, and reports exactly what the CSV contains.
-Keep in mind that CodeCarbon values are estimates: CPU power may come from a TDP
-model and carbon intensity is often a country average, so a badge is a useful
-order-of-magnitude signal rather than an audited figure. If you want a colour, pass
-`--color` explicitly.
-
-Regenerate the badge in CI after a benchmark job, publish `codecarbon-badge.json`
-at a public URL and point shields.io at it:
-
-```markdown
-![carbon](https://img.shields.io/endpoint?url=https://example.org/codecarbon-badge.json)
-```
+Values are estimates — see [methodology](../explanation/methodology.md).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -98,3 +98,55 @@ codecarbon detect
 ```
 
 Displays detected RAM, CPU, GPU, and other hardware information that CodeCarbon uses to estimate energy consumption. Useful for verifying that CodeCarbon can see all your hardware.
+
+### `codecarbon badge`
+
+Generate a README badge from an existing `emissions.csv`.
+
+**Usage:**
+```bash
+codecarbon badge [OPTIONS]
+```
+
+Reads the emissions file, writes `codecarbon-badge.svg` and `codecarbon-badge.json`
+(a [shields.io endpoint](https://shields.io/badges/endpoint-badge) file), and prints
+a markdown snippet to paste into your README. Everything happens locally: no network
+call, no account, no data leaves your machine.
+
+**Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--file` | path | ./emissions.csv | Emissions file to read |
+| `--project` | string | - | Only use rows of this project |
+| `--select` | choice | last | Which run(s) to report: `last`, `mean` or `total` |
+| `--metric` | choice | emissions | What to show: `emissions`, `energy` or `both` |
+| `--output-dir` | path | . | Where to write the badge files |
+| `--label` | string | carbon | Left-hand badge text |
+| `--color` | string | grey | Badge colour |
+| `--format` | choice | all | Files to write: `svg`, `json` or `all` |
+
+**Examples:**
+```bash
+# Badge for the last run
+codecarbon badge
+
+# Average over every run of one project, showing energy too
+codecarbon badge --project my-training --select mean --metric both
+
+# Write into the docs assets folder
+codecarbon badge --output-dir docs/assets
+```
+
+The badge is colour-neutral by default, and reports exactly what the CSV contains.
+Keep in mind that CodeCarbon values are estimates: CPU power may come from a TDP
+model and carbon intensity is often a country average, so a badge is a useful
+order-of-magnitude signal rather than an audited figure. If you want a colour, pass
+`--color` explicitly.
+
+You can regenerate the badge in CI after a benchmark job and commit the SVG, or
+publish `codecarbon-badge.json` at a public URL and point shields.io at it:
+
+```markdown
+![carbon](https://img.shields.io/endpoint?url=https://example.org/codecarbon-badge.json)
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -108,10 +108,14 @@ Generate a README badge from an existing `emissions.csv`.
 codecarbon badge [OPTIONS]
 ```
 
-Reads the emissions file, writes `codecarbon-badge.svg` and `codecarbon-badge.json`
-(a [shields.io endpoint](https://shields.io/badges/endpoint-badge) file), and prints
-a markdown snippet to paste into your README. Everything happens locally: no network
+Reads the emissions file, writes `codecarbon-badge.json` (a
+[shields.io endpoint](https://shields.io/badges/endpoint-badge) file) and prints a
+markdown snippet to paste into your README. Everything happens locally: no network
 call, no account, no data leaves your machine.
+
+CodeCarbon writes one CSV row per flush, each holding the cumulative total of its
+run, so the badge uses the last row of each `run_id`: `last` is the latest run,
+`total` the sum over runs, `mean` the average per run.
 
 **Options:**
 
@@ -121,10 +125,9 @@ call, no account, no data leaves your machine.
 | `--project` | string | - | Only use rows of this project |
 | `--select` | choice | last | Which run(s) to report: `last`, `mean` or `total` |
 | `--metric` | choice | emissions | What to show: `emissions`, `energy` or `both` |
-| `--output-dir` | path | . | Where to write the badge files |
+| `--output-dir` | path | . | Where to write the badge file |
 | `--label` | string | carbon | Left-hand badge text |
 | `--color` | string | grey | Badge colour |
-| `--format` | choice | all | Files to write: `svg`, `json` or `all` |
 
 **Examples:**
 ```bash
@@ -144,8 +147,8 @@ model and carbon intensity is often a country average, so a badge is a useful
 order-of-magnitude signal rather than an audited figure. If you want a colour, pass
 `--color` explicitly.
 
-You can regenerate the badge in CI after a benchmark job and commit the SVG, or
-publish `codecarbon-badge.json` at a public URL and point shields.io at it:
+Regenerate the badge in CI after a benchmark job, publish `codecarbon-badge.json`
+at a public URL and point shields.io at it:
 
 ```markdown
 ![carbon](https://img.shields.io/endpoint?url=https://example.org/codecarbon-badge.json)

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -1,0 +1,122 @@
+import json
+import xml.etree.ElementTree as ET
+
+import pytest
+from typer.testing import CliRunner
+
+from codecarbon import badge
+from codecarbon.cli.main import codecarbon as cli_app
+
+CSV_CONTENT = """timestamp,project_name,emissions,energy_consumed
+2024-01-01T00:00:00,alpha,0.001,0.010
+2024-01-02T00:00:00,beta,0.500,1.000
+2024-01-03T00:00:00,alpha,0.003,0.020
+"""
+
+
+@pytest.fixture
+def emissions_file(tmp_path):
+    path = tmp_path / "emissions.csv"
+    path.write_text(CSV_CONTENT, encoding="utf-8")
+    return path
+
+
+def test_load_runs_filters_project(emissions_file):
+    assert len(badge.load_runs(emissions_file)) == 3
+    assert len(badge.load_runs(emissions_file, project="alpha")) == 2
+
+
+def test_load_runs_errors_cleanly(tmp_path, emissions_file):
+    with pytest.raises(FileNotFoundError):
+        badge.load_runs(tmp_path / "nope.csv")
+    with pytest.raises(ValueError):
+        badge.load_runs(emissions_file, project="gamma")
+
+
+def test_select_last_mean_total(emissions_file):
+    rows = badge.load_runs(emissions_file, project="alpha")
+    assert badge.summarise(rows, "last")["emissions"] == pytest.approx(0.003)
+    assert badge.summarise(rows, "mean")["emissions"] == pytest.approx(0.002)
+    assert badge.summarise(rows, "total")["emissions"] == pytest.approx(0.004)
+    assert badge.summarise(rows, "total")["energy_consumed"] == pytest.approx(0.030)
+    assert badge.summarise(rows, "last")["runs"] == 2
+    with pytest.raises(ValueError):
+        badge.summarise(rows, "median")
+
+
+@pytest.mark.parametrize(
+    ["value", "expected"],
+    [
+        (0.0000004, "0.4 mgCO2eq"),
+        (0.004, "4 gCO2eq"),
+        (0.5, "500 gCO2eq"),
+        (12.0, "12 kgCO2eq"),
+        (12000.0, "12 MgCO2eq"),
+    ],
+)
+def test_format_value_units(value, expected):
+    assert badge.format_value(value) == expected
+
+
+def test_message_for_metrics():
+    summary = {"emissions": 0.0124, "energy_consumed": 0.031}
+    assert badge.message_for(summary, "mean") == "12.4 gCO2eq/run"
+    assert badge.message_for(summary, "total", "both") == "12.4 gCO2eq | 31 Wh total"
+
+
+def test_render_svg_is_wellformed():
+    svg = badge.render_svg("carbon", "12.4 gCO2eq/run")
+    root = ET.fromstring(svg)
+    texts = [element.text for element in root.iter("{http://www.w3.org/2000/svg}text")]
+    assert "12.4 gCO2eq/run" in texts
+    assert "carbon" in texts
+
+
+def test_render_svg_escapes():
+    assert "<script>" not in badge.render_svg("a<script>", "b & c")
+
+
+def test_endpoint_json_schema():
+    payload = json.loads(badge.render_endpoint_json("carbon", "12.4 gCO2eq"))
+    assert payload == {
+        "schemaVersion": 1,
+        "label": "carbon",
+        "message": "12.4 gCO2eq",
+        "color": badge.DEFAULT_COLOR,
+    }
+
+
+def test_write_creates_both_files(emissions_file, tmp_path):
+    paths = badge.write(emissions_file, output_dir=tmp_path / "assets")
+    assert [path.name for path in paths] == [
+        "codecarbon-badge.svg",
+        "codecarbon-badge.json",
+    ]
+    assert all(path.is_file() for path in paths)
+
+
+def test_cli_badge_writes_files(emissions_file, tmp_path):
+    result = CliRunner().invoke(
+        cli_app,
+        [
+            "badge",
+            "--file",
+            str(emissions_file),
+            "--project",
+            "alpha",
+            "--select",
+            "mean",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "codecarbon-badge.svg").is_file()
+    assert (tmp_path / "codecarbon-badge.json").is_file()
+
+
+def test_cli_badge_missing_file(tmp_path):
+    result = CliRunner().invoke(
+        cli_app, ["badge", "--file", str(tmp_path / "nope.csv")]
+    )
+    assert result.exit_code == 1

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -67,10 +67,10 @@ def test_format_value_units(value, expected):
     assert badge.format_value(value) == expected
 
 
-def test_message_for_metrics():
+def test_message_for_select_suffix():
     summary = {"emissions": 0.0124, "energy_consumed": 0.031}
     assert badge.message_for(summary, "mean") == "12.4 gCO2eq/run"
-    assert badge.message_for(summary, "total", "both") == "12.4 gCO2eq | 31 Wh total"
+    assert badge.message_for(summary, "total") == "12.4 gCO2eq total"
 
 
 def test_cumulative_rows_are_not_double_counted(tmp_path):
@@ -84,23 +84,19 @@ def test_cumulative_rows_are_not_double_counted(tmp_path):
     assert badge.summarise(rows, "last")["runs"] == 2
 
 
-def test_endpoint_json_quotes_are_escaped():
-    payload = json.loads(badge.render_endpoint_json('a "quoted" label', "b & c"))
-    assert payload["label"] == 'a "quoted" label'
-
-
 def test_endpoint_json_schema():
-    payload = json.loads(badge.render_endpoint_json("carbon", "12.4 gCO2eq"))
+    payload = json.loads(badge.render({"emissions": 0.0124, "energy_consumed": 0.031}))
     assert payload == {
         "schemaVersion": 1,
-        "label": "carbon",
+        "label": badge.LABEL,
         "message": "12.4 gCO2eq",
-        "color": badge.DEFAULT_COLOR,
+        "color": badge.COLOR,
     }
 
 
 def test_write_creates_endpoint_file(emissions_file, tmp_path):
-    path = badge.write(emissions_file, output_dir=tmp_path / "assets")
+    summary = badge.summarise(badge.load_runs(emissions_file))
+    path = badge.write(summary, output_dir=tmp_path / "assets")
     assert path.name == "codecarbon-badge.json"
     assert json.loads(path.read_text())["schemaVersion"] == 1
 
@@ -129,3 +125,46 @@ def test_cli_badge_missing_file(tmp_path):
         cli_app, ["badge", "--file", str(tmp_path / "nope.csv")]
     )
     assert result.exit_code == 1
+
+
+# Two trackers with allow_multiple_runs flushing into the same file: run-b is
+# seen first but run-a is the one that finished last.
+INTERLEAVED_CSV = """timestamp,project_name,run_id,emissions,energy_consumed
+2024-01-01T00:00:00,alpha,run-b,0.001,0.010
+2024-01-01T00:00:30,alpha,run-a,0.002,0.020
+2024-01-01T00:01:00,alpha,run-b,0.003,0.030
+2024-01-01T00:01:30,alpha,run-a,0.004,0.040
+"""
+
+BLANK_RUN_ID_CSV = """timestamp,project_name,run_id,emissions,energy_consumed
+2024-01-01T00:00:00,alpha,,0.001,0.010
+2024-01-02T00:00:00,alpha,,0.002,0.020
+"""
+
+
+def test_interleaved_runs_pick_the_latest_by_timestamp(tmp_path):
+    path = tmp_path / "emissions.csv"
+    path.write_text(INTERLEAVED_CSV, encoding="utf-8")
+    rows = badge.load_runs(path)
+    assert badge.summarise(rows, "last")["emissions"] == pytest.approx(0.004)
+    assert badge.summarise(rows, "last")["runs"] == 2
+    assert badge.summarise(rows, "total")["emissions"] == pytest.approx(0.007)
+
+
+def test_blank_run_ids_are_separate_runs(tmp_path):
+    path = tmp_path / "emissions.csv"
+    path.write_text(BLANK_RUN_ID_CSV, encoding="utf-8")
+    rows = badge.load_runs(path)
+    assert badge.summarise(rows, "total")["emissions"] == pytest.approx(0.003)
+    assert badge.summarise(rows, "last")["runs"] == 2
+
+
+def test_format_value_keeps_the_sign():
+    assert badge.format_value(-0.004) == "-4 gCO2eq"
+
+
+def test_cli_rejects_unknown_select(emissions_file):
+    result = CliRunner().invoke(
+        cli_app, ["badge", "--file", str(emissions_file), "--select", "median"]
+    )
+    assert result.exit_code != 0

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -1,5 +1,4 @@
 import json
-import xml.etree.ElementTree as ET
 
 import pytest
 from typer.testing import CliRunner
@@ -7,10 +6,20 @@ from typer.testing import CliRunner
 from codecarbon import badge
 from codecarbon.cli.main import codecarbon as cli_app
 
-CSV_CONTENT = """timestamp,project_name,emissions,energy_consumed
-2024-01-01T00:00:00,alpha,0.001,0.010
-2024-01-02T00:00:00,beta,0.500,1.000
-2024-01-03T00:00:00,alpha,0.003,0.020
+CSV_CONTENT = """timestamp,project_name,run_id,emissions,energy_consumed
+2024-01-01T00:00:00,alpha,run-1,0.001,0.010
+2024-01-02T00:00:00,beta,run-2,0.500,1.000
+2024-01-03T00:00:00,alpha,run-3,0.003,0.020
+"""
+
+# Two runs, flushed several times each. Every row holds the cumulative total of
+# its run, so only the last row of each run counts.
+MULTI_FLUSH_CSV = """timestamp,project_name,run_id,emissions,energy_consumed
+2024-01-01T00:00:00,alpha,run-1,0.001,0.010
+2024-01-01T00:01:00,alpha,run-1,0.002,0.020
+2024-01-01T00:02:00,alpha,run-1,0.004,0.040
+2024-01-02T00:00:00,alpha,run-2,0.005,0.050
+2024-01-02T00:01:00,alpha,run-2,0.006,0.060
 """
 
 
@@ -64,16 +73,20 @@ def test_message_for_metrics():
     assert badge.message_for(summary, "total", "both") == "12.4 gCO2eq | 31 Wh total"
 
 
-def test_render_svg_is_wellformed():
-    svg = badge.render_svg("carbon", "12.4 gCO2eq/run")
-    root = ET.fromstring(svg)
-    texts = [element.text for element in root.iter("{http://www.w3.org/2000/svg}text")]
-    assert "12.4 gCO2eq/run" in texts
-    assert "carbon" in texts
+def test_cumulative_rows_are_not_double_counted(tmp_path):
+    path = tmp_path / "emissions.csv"
+    path.write_text(MULTI_FLUSH_CSV, encoding="utf-8")
+    rows = badge.load_runs(path)
+    assert badge.summarise(rows, "last")["emissions"] == pytest.approx(0.006)
+    assert badge.summarise(rows, "total")["emissions"] == pytest.approx(0.010)
+    assert badge.summarise(rows, "mean")["emissions"] == pytest.approx(0.005)
+    assert badge.summarise(rows, "total")["energy_consumed"] == pytest.approx(0.100)
+    assert badge.summarise(rows, "last")["runs"] == 2
 
 
-def test_render_svg_escapes():
-    assert "<script>" not in badge.render_svg("a<script>", "b & c")
+def test_endpoint_json_quotes_are_escaped():
+    payload = json.loads(badge.render_endpoint_json('a "quoted" label', "b & c"))
+    assert payload["label"] == 'a "quoted" label'
 
 
 def test_endpoint_json_schema():
@@ -86,13 +99,10 @@ def test_endpoint_json_schema():
     }
 
 
-def test_write_creates_both_files(emissions_file, tmp_path):
-    paths = badge.write(emissions_file, output_dir=tmp_path / "assets")
-    assert [path.name for path in paths] == [
-        "codecarbon-badge.svg",
-        "codecarbon-badge.json",
-    ]
-    assert all(path.is_file() for path in paths)
+def test_write_creates_endpoint_file(emissions_file, tmp_path):
+    path = badge.write(emissions_file, output_dir=tmp_path / "assets")
+    assert path.name == "codecarbon-badge.json"
+    assert json.loads(path.read_text())["schemaVersion"] == 1
 
 
 def test_cli_badge_writes_files(emissions_file, tmp_path):
@@ -111,7 +121,6 @@ def test_cli_badge_writes_files(emissions_file, tmp_path):
         ],
     )
     assert result.exit_code == 0, result.output
-    assert (tmp_path / "codecarbon-badge.svg").is_file()
     assert (tmp_path / "codecarbon-badge.json").is_file()
 
 


### PR DESCRIPTION
Implements #1349.

## What it adds

A `codecarbon badge` command that turns an existing `emissions.csv` into a README badge. Strictly local: it reads the CSV, writes one JSON file, and prints a snippet. No network call, no hosted service, no account, no new dependency (stdlib `csv` and `json` only).

## User-facing surface

```
codecarbon badge [--file PATH] [--project TEXT] [--select last|mean|total] [--output-dir PATH]
```

It writes `codecarbon-badge.json`, the [shields.io endpoint](https://shields.io/badges/endpoint-badge) schema, then prints the markdown to paste into a README once that file is published at a public URL. shields.io renders the image; CodeCarbon does not reimplement badge drawing.

The logic lives in `codecarbon/badge.py` (`load_runs`, `last_row_per_run`, `summarise`, `format_value`, `message_for`, `render`, `write`), usable directly from Python. The CLI command sits next to `detect` in `codecarbon/cli/main.py`. No tracker or output-method changes.

**One row per flush, not per run.** CodeCarbon appends a row on every flush and each row holds the *cumulative* totals of its run (`FileOutput.out()` discards the delta it is handed). The badge therefore groups rows by `run_id` and keeps the last row of each run, so `total` is the sum over runs, `mean` the average per run, and `runs` a run count.

Rows are ordered by `timestamp`, not by file order: `allow_multiple_runs` defaults to `True`, so two trackers can interleave their flushes into a single `emissions.csv` and the run that appears first is not necessarily the run that finished last. Rows with a blank or missing `run_id` (older CSVs) each count as their own run rather than collapsing into one.

**Colour-neutral, no knobs.** No `--label`, `--color` or `--metric`. CodeCarbon numbers are frequently estimates (TDP-modelled CPU power, country-average intensity) and no fixed gram threshold means anything across arbitrary workloads, so an automatic green badge would be greenwashing; the badge is grey and says grams. Anyone who wants different text or colour is already editing a JSON file they self-host. `--select` is an `enum.Enum`, so typer validates it and `--help` lists the choices.

## Verification

`tests/test_badge.py`, 18 tests, no network, `tmp_path` for outputs: project filtering, the three aggregations against hand-computed values, a multi-flush CSV proving cumulative rows are not double-counted, an interleaved-`run_id` CSV proving `last` follows the timestamp rather than file order, blank `run_id`s counting separately, signed formatting, unit formatting from mg to Mg, endpoint JSON schema, clean errors on a missing file and an empty project selection, and three `typer.testing.CliRunner` runs against the real command including the rejection of an invalid `--select`.

```
uv run pytest tests/test_badge.py -q   # 18 passed
```

`black` is clean on the touched files; the remaining `ruff` notes are pre-existing repo-wide style patterns (`Optional[...]`, `typer.Option` defaults) that the surrounding code already uses.

## Deliberately left out

- **Local SVG rendering.** An earlier revision shipped a hand-rolled shields-style SVG template plus a character-advance font-metrics guess for text width. That is a shields.io reimplementation the maintainers would own forever. Deleted; the endpoint JSON is the feature, and `json.dumps` escapes correctly for free.
- Colour thresholds and per-badge cosmetics (see above).
- The four `badge_*` config keys from the proposal. Flags only for now.
- A badge output method firing on every tracker stop. The CSV is the source of truth, regenerate on demand.
- Any hosted endpoint or ingestion service, badge history/trend graphs, and a GitHub Action.

Docs: a `codecarbon badge` section in `docs/reference/cli.md` and a cross-link from `docs/how-to/visualize.md`.

Closes #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
