### PR TITLE
feat: record token counts on tasks for energy-per-token reporting

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -819,6 +819,15 @@ class BaseEmissionsTracker(ABC):
             return
         if response is not None:
             extracted_input, extracted_output = extract_token_counts(response)
+            if not extracted_input and not extracted_output:
+                # Most common cause: a streamed OpenAI chunk, whose `usage` is
+                # None unless the request passed
+                # stream_options={"include_usage": True}.
+                logger.debug(
+                    "record_tokens : No token count found on the given response, "
+                    "recording 0 tokens. For a streamed response, ask your client "
+                    'for usage data (OpenAI: stream_options={"include_usage": True}).'
+                )
             input_tokens += extracted_input
             output_tokens += extracted_output
         task.record_tokens(

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -27,7 +27,7 @@ from codecarbon.external.hardware import CPU, GPU, AppleSiliconChip
 from codecarbon.external.logger import logger, set_logger_format, set_logger_level
 from codecarbon.external.ram import RAM
 from codecarbon.external.scheduler import PeriodicScheduler
-from codecarbon.external.task import Task
+from codecarbon.external.task import Task, extract_token_counts
 from codecarbon.input import DataSource
 from codecarbon.lock import Lock
 from codecarbon.output_methods.base_output import BaseOutput, OutputMethod
@@ -792,6 +792,41 @@ class BaseEmissionsTracker(ABC):
         )
         self._active_task = task_name
 
+    def record_tokens(
+        self,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        n_requests: int = 1,
+        response=None,
+        task_name: str = None,
+    ) -> None:
+        """
+        Record the token counts of one LLM request on a task, so that the task row
+        carries energy and emissions per token and per request.
+
+        :param input_tokens: Number of prompt tokens of the request.
+        :param output_tokens: Number of generated tokens of the request.
+        :param n_requests: Number of requests these counts stand for, default 1.
+        :param response: Optional response object of an OpenAI compatible client,
+                         Ollama or vLLM, from which the token counts are read.
+        :param task_name: Task to record on, default the currently active task.
+        :return: None
+        """
+        task_name = task_name if task_name else self._active_task
+        task = self._tasks.get(task_name)
+        if task is None:
+            logger.warning("record_tokens : No active task to record tokens on.")
+            return
+        if response is not None:
+            extracted_input, extracted_output = extract_token_counts(response)
+            input_tokens += extracted_input
+            output_tokens += extracted_output
+        task.record_tokens(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            n_requests=n_requests,
+        )
+
     def stop_task(self, task_name: str = None) -> EmissionsData:
         """
         Stop tracking a dedicated execution task. Delta energy is computed by task, to isolate its contribution to total
@@ -1447,6 +1482,14 @@ class TaskEmissionsTracker:
     with TaskEmissionsTracker(task_name="Grid search", tracker=tracker):
         grid = GridSearchCV(estimator=model, param_grid=param_grid)
     ```
+
+    For LLM inference, token counts of each request can be recorded on the task:
+    ```py
+    with TaskEmissionsTracker(task_name="llama3.1:8b", tracker=tracker) as task:
+        for prompt in prompts:
+            response = client.chat.completions.create(...)
+            task.record_tokens(response=response)
+    ```
     """
 
     def __init__(self, task_name, tracker: EmissionsTracker = None):
@@ -1461,6 +1504,24 @@ class TaskEmissionsTracker:
     def __enter__(self):
         self.tracker.start_task(self.task_name)
         return self
+
+    def record_tokens(
+        self,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        n_requests: int = 1,
+        response=None,
+    ) -> None:
+        """
+        Record the token counts of one LLM request on the task under measure.
+        See `BaseEmissionsTracker.record_tokens`.
+        """
+        self.tracker.record_tokens(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            n_requests=n_requests,
+            response=response,
+        )
 
     def __exit__(self, exc_type, exc_value, tb) -> None:
         self.tracker.stop_task()

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -27,7 +27,7 @@ from codecarbon.external.hardware import CPU, GPU, AppleSiliconChip
 from codecarbon.external.logger import logger, set_logger_format, set_logger_level
 from codecarbon.external.ram import RAM
 from codecarbon.external.scheduler import PeriodicScheduler
-from codecarbon.external.task import Task, extract_token_counts
+from codecarbon.external.task import Task
 from codecarbon.input import DataSource
 from codecarbon.lock import Lock
 from codecarbon.output_methods.base_output import BaseOutput, OutputMethod
@@ -797,7 +797,6 @@ class BaseEmissionsTracker(ABC):
         input_tokens: int = 0,
         output_tokens: int = 0,
         n_requests: int = 1,
-        response=None,
         task_name: str = None,
     ) -> None:
         """
@@ -807,8 +806,6 @@ class BaseEmissionsTracker(ABC):
         :param input_tokens: Number of prompt tokens of the request.
         :param output_tokens: Number of generated tokens of the request.
         :param n_requests: Number of requests these counts stand for, default 1.
-        :param response: Optional response object of an OpenAI compatible client,
-                         Ollama or vLLM, from which the token counts are read.
         :param task_name: Task to record on, default the currently active task.
         :return: None
         """
@@ -817,19 +814,6 @@ class BaseEmissionsTracker(ABC):
         if task is None:
             logger.warning("record_tokens : No active task to record tokens on.")
             return
-        if response is not None:
-            extracted_input, extracted_output = extract_token_counts(response)
-            if not extracted_input and not extracted_output:
-                # Most common cause: a streamed OpenAI chunk, whose `usage` is
-                # None unless the request passed
-                # stream_options={"include_usage": True}.
-                logger.debug(
-                    "record_tokens : No token count found on the given response, "
-                    "recording 0 tokens. For a streamed response, ask your client "
-                    'for usage data (OpenAI: stream_options={"include_usage": True}).'
-                )
-            input_tokens += extracted_input
-            output_tokens += extracted_output
         task.record_tokens(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -1497,7 +1481,10 @@ class TaskEmissionsTracker:
     with TaskEmissionsTracker(task_name="llama3.1:8b", tracker=tracker) as task:
         for prompt in prompts:
             response = client.chat.completions.create(...)
-            task.record_tokens(response=response)
+            task.record_tokens(
+                input_tokens=response.usage.prompt_tokens,
+                output_tokens=response.usage.completion_tokens,
+            )
     ```
     """
 
@@ -1519,7 +1506,6 @@ class TaskEmissionsTracker:
         input_tokens: int = 0,
         output_tokens: int = 0,
         n_requests: int = 1,
-        response=None,
     ) -> None:
         """
         Record the token counts of one LLM request on the task under measure.
@@ -1529,7 +1515,6 @@ class TaskEmissionsTracker:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             n_requests=n_requests,
-            response=response,
         )
 
     def __exit__(self, exc_type, exc_value, tb) -> None:

--- a/codecarbon/external/task.py
+++ b/codecarbon/external/task.py
@@ -4,55 +4,6 @@ from uuid import uuid4
 from codecarbon.output_methods.emissions_data import EmissionsData, TaskEmissionsData
 
 
-def _get(response, *names):
-    """
-    Read the first available attribute or mapping key from ``response``.
-    Returns None if none of ``names`` is present.
-    """
-    for name in names:
-        if isinstance(response, dict):
-            value = response.get(name)
-        else:
-            value = getattr(response, name, None)
-        if value is not None:
-            return value
-    return None
-
-
-def extract_token_counts(response):
-    """
-    Best effort extraction of (input_tokens, output_tokens) from the response of
-    an LLM serving stack. Everything is duck-typed, so codecarbon does not import
-    any inference library:
-
-    - OpenAI compatible clients : ``usage.prompt_tokens`` / ``usage.completion_tokens``
-    - Ollama : ``prompt_eval_count`` / ``eval_count``
-    - vLLM ``RequestOutput`` : ``prompt_token_ids`` / ``outputs[].token_ids``
-
-    Counts that cannot be found are reported as 0.
-    """
-    usage = _get(response, "usage")
-    if usage is not None:
-        return (
-            _get(usage, "prompt_tokens", "input_tokens") or 0,
-            _get(usage, "completion_tokens", "output_tokens") or 0,
-        )
-
-    eval_count = _get(response, "eval_count")
-    if eval_count is not None:
-        return _get(response, "prompt_eval_count") or 0, eval_count
-
-    prompt_token_ids = _get(response, "prompt_token_ids")
-    if prompt_token_ids is not None:
-        outputs = _get(response, "outputs") or []
-        return (
-            len(prompt_token_ids),
-            sum(len(getattr(completion, "token_ids", ())) for completion in outputs),
-        )
-
-    return 0, 0
-
-
 class Task:
     """
     A task, used to segregate electrical consumption when executing a treatment.

--- a/codecarbon/external/task.py
+++ b/codecarbon/external/task.py
@@ -4,6 +4,55 @@ from uuid import uuid4
 from codecarbon.output_methods.emissions_data import EmissionsData, TaskEmissionsData
 
 
+def _get(response, *names):
+    """
+    Read the first available attribute or mapping key from ``response``.
+    Returns None if none of ``names`` is present.
+    """
+    for name in names:
+        if isinstance(response, dict):
+            value = response.get(name)
+        else:
+            value = getattr(response, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def extract_token_counts(response):
+    """
+    Best effort extraction of (input_tokens, output_tokens) from the response of
+    an LLM serving stack. Everything is duck-typed, so codecarbon does not import
+    any inference library:
+
+    - OpenAI compatible clients : ``usage.prompt_tokens`` / ``usage.completion_tokens``
+    - Ollama : ``prompt_eval_count`` / ``eval_count``
+    - vLLM ``RequestOutput`` : ``prompt_token_ids`` / ``outputs[].token_ids``
+
+    Counts that cannot be found are reported as 0.
+    """
+    usage = _get(response, "usage")
+    if usage is not None:
+        return (
+            _get(usage, "prompt_tokens", "input_tokens") or 0,
+            _get(usage, "completion_tokens", "output_tokens") or 0,
+        )
+
+    eval_count = _get(response, "eval_count")
+    if eval_count is not None:
+        return _get(response, "prompt_eval_count") or 0, eval_count
+
+    prompt_token_ids = _get(response, "prompt_token_ids")
+    if prompt_token_ids is not None:
+        outputs = _get(response, "outputs") or []
+        return (
+            len(prompt_token_ids),
+            sum(len(getattr(completion, "token_ids", ())) for completion in outputs),
+        )
+
+    return 0, 0
+
+
 class Task:
     """
     A task, used to segregate electrical consumption when executing a treatment.
@@ -17,6 +66,19 @@ class Task:
         self.task_name: str = task_name
         self.start_time = time.perf_counter()
         self.is_active = True
+        self.input_tokens: int = 0
+        self.output_tokens: int = 0
+        self.n_requests: int = 0
+
+    def record_tokens(
+        self, input_tokens: int = 0, output_tokens: int = 0, n_requests: int = 1
+    ) -> None:
+        """
+        Accumulate token counters for this task.
+        """
+        self.input_tokens += input_tokens
+        self.output_tokens += output_tokens
+        self.n_requests += n_requests
 
     def out(self):
         return TaskEmissionsData(
@@ -52,4 +114,7 @@ class Task:
             ram_total_size=self.emissions_data.ram_total_size,
             tracking_mode=self.emissions_data.tracking_mode,
             on_cloud=self.emissions_data.on_cloud,
+            input_tokens=self.input_tokens,
+            output_tokens=self.output_tokens,
+            n_requests=self.n_requests,
         )

--- a/codecarbon/output_methods/emissions_data.py
+++ b/codecarbon/output_methods/emissions_data.py
@@ -114,19 +114,9 @@ class TaskEmissionsData:
     output_tokens: int = 0
     n_requests: int = 0
 
-    @property
-    def energy_per_output_token(self) -> float:
-        """Energy in kWh per output token, 0.0 if no output token was recorded."""
-        if not self.output_tokens:
-            return 0.0
-        return self.energy_consumed / self.output_tokens
-
-    @property
-    def emissions_per_request(self) -> float:
-        """Emissions in kgCO2eq per request, 0.0 if no request was recorded."""
-        if not self.n_requests:
-            return 0.0
-        return self.emissions / self.n_requests
+    # Energy per token and emissions per request are deliberately not exposed:
+    # `values` is built from `__dict__`, so a property reaches no output, and
+    # both are one division away from the columns above.
 
     @property
     def values(self) -> OrderedDict:

--- a/codecarbon/output_methods/emissions_data.py
+++ b/codecarbon/output_methods/emissions_data.py
@@ -110,6 +110,23 @@ class TaskEmissionsData:
     ram_utilization_percent: float = 0.0
     ram_used_gb: float = 0.0
     on_cloud: str = "N"
+    input_tokens: int = 0
+    output_tokens: int = 0
+    n_requests: int = 0
+
+    @property
+    def energy_per_output_token(self) -> float:
+        """Energy in kWh per output token, 0.0 if no output token was recorded."""
+        if not self.output_tokens:
+            return 0.0
+        return self.energy_consumed / self.output_tokens
+
+    @property
+    def emissions_per_request(self) -> float:
+        """Emissions in kgCO2eq per request, 0.0 if no request was recorded."""
+        if not self.n_requests:
+            return 0.0
+        return self.emissions / self.n_requests
 
     @property
     def values(self) -> OrderedDict:

--- a/docs/reference/output.md
+++ b/docs/reference/output.md
@@ -65,6 +65,17 @@ The package has an in-built logger that logs data into a CSV file named `emissio
 | ram_utilization_percent | Average RAM utilization during tracking period (%) |
 | ram_used_gb | Average RAM used during tracking period (GB) |
 
+Task rows, written to `emissions_<experiment_name>_<run_id>.csv`, carry three extra
+columns, filled in by `record_tokens()` (see
+[LLM inference](../tutorials/python-api.md#llm-inference-energy-per-token)) and
+left at `0` otherwise:
+
+| Field | Description |
+|-------|-------------|
+| input_tokens | Total prompt tokens recorded on the task |
+| output_tokens | Total generated tokens recorded on the task |
+| n_requests | Number of requests recorded on the task |
+
 !!! note
     Developers can enhance the Output interface by implementing a custom class that extends `BaseOutput` at `codecarbon/output.py`. For example, to log into a database.
 

--- a/docs/tutorials/python-api.md
+++ b/docs/tutorials/python-api.md
@@ -44,7 +44,7 @@ finally:
 
 The task manager tracks each sub-task independently. Tasks are not written to disk by default (to reduce overhead), so retrieve results from the `stop_task()` return value.
 
-**Advanced: LLM inference, energy per token**
+#### LLM inference: energy per token
 
 Energy per run is not comparable between models, because it depends on how many
 prompts you happened to send. Energy per output token is. If the task you are

--- a/docs/tutorials/python-api.md
+++ b/docs/tutorials/python-api.md
@@ -44,6 +44,49 @@ finally:
 
 The task manager tracks each sub-task independently. Tasks are not written to disk by default (to reduce overhead), so retrieve results from the `stop_task()` return value.
 
+**Advanced: LLM inference, energy per token**
+
+Energy per run is not comparable between models, because it depends on how many
+prompts you happened to send. Energy per output token is. If the task you are
+measuring is LLM inference, record the token counts of each request with
+`record_tokens()` and CodeCarbon will report them alongside the energy:
+
+``` python-skip
+from codecarbon import EmissionsTracker
+from codecarbon.emissions_tracker import TaskEmissionsTracker
+
+tracker = EmissionsTracker(project_name="llama3.1-8b-bench")
+
+with TaskEmissionsTracker(task_name="llama3.1:8b", tracker=tracker) as task:
+    for prompt in prompts:
+        response = client.chat.completions.create(model="llama3.1:8b", messages=prompt)
+        task.record_tokens(response=response)
+
+tracker.stop()
+```
+
+`record_tokens(response=...)` reads the counts the serving stack already returns.
+It understands OpenAI-compatible `usage` payloads, Ollama's `prompt_eval_count` /
+`eval_count`, and vLLM `RequestOutput` objects. Everything is read by duck typing,
+so CodeCarbon does not import any inference library. If your client is not one of
+these, pass the numbers yourself:
+
+``` python-skip
+task.record_tokens(input_tokens=128, output_tokens=256)
+```
+
+Counts accumulate over the life of the task, and the resulting `TaskEmissionsData`
+exposes `input_tokens`, `output_tokens` and `n_requests`, plus two derived values:
+`energy_per_output_token` (kWh per output token) and `emissions_per_request`
+(kgCO₂eq per request).
+
+!!! warning
+    Measure enough requests for the task to last several `measure_power_secs`
+    windows. A per-token figure derived from a task shorter than one measurement
+    window is mostly noise. Under continuous batching, requests overlap and
+    per-request attribution is not physically meaningful, although the aggregate
+    per-token figure remains valid.
+
 ### Context Manager
 
 Now that you've seen the explicit object approach, let's look at the more idiomatic **context manager** pattern. This is the recommended way for most use cases.

--- a/docs/tutorials/python-api.md
+++ b/docs/tutorials/python-api.md
@@ -76,9 +76,9 @@ task.record_tokens(input_tokens=128, output_tokens=256)
 ```
 
 Counts accumulate over the life of the task, and the resulting `TaskEmissionsData`
-exposes `input_tokens`, `output_tokens` and `n_requests`, plus two derived values:
-`energy_per_output_token` (kWh per output token) and `emissions_per_request`
-(kgCO₂eq per request).
+exposes `input_tokens`, `output_tokens` and `n_requests` — written to the task CSV
+alongside `energy_consumed` and `emissions`, so energy per output token and
+emissions per request are one division away.
 
 !!! warning
     Measure enough requests for the task to last several `measure_power_secs`

--- a/docs/tutorials/python-api.md
+++ b/docs/tutorials/python-api.md
@@ -60,20 +60,18 @@ tracker = EmissionsTracker(project_name="llama3.1-8b-bench")
 with TaskEmissionsTracker(task_name="llama3.1:8b", tracker=tracker) as task:
     for prompt in prompts:
         response = client.chat.completions.create(model="llama3.1:8b", messages=prompt)
-        task.record_tokens(response=response)
+        task.record_tokens(
+            input_tokens=response.usage.prompt_tokens,
+            output_tokens=response.usage.completion_tokens,
+        )
 
 tracker.stop()
 ```
 
-`record_tokens(response=...)` reads the counts the serving stack already returns.
-It understands OpenAI-compatible `usage` payloads, Ollama's `prompt_eval_count` /
-`eval_count`, and vLLM `RequestOutput` objects. Everything is read by duck typing,
-so CodeCarbon does not import any inference library. If your client is not one of
-these, pass the numbers yourself:
-
-``` python-skip
-task.record_tokens(input_tokens=128, output_tokens=256)
-```
+The counts come from wherever your serving stack reports them — `usage` for
+OpenAI-compatible clients, `prompt_eval_count` / `eval_count` for Ollama, and so
+on. CodeCarbon does not inspect the response object, so it imports no inference
+library and nothing breaks when a vendor changes its payload.
 
 Counts accumulate over the life of the task, and the resulting `TaskEmissionsData`
 exposes `input_tokens`, `output_tokens` and `n_requests` — written to the task CSV

--- a/docs/tutorials/python-api.md
+++ b/docs/tutorials/python-api.md
@@ -46,10 +46,7 @@ The task manager tracks each sub-task independently. Tasks are not written to di
 
 #### LLM inference: energy per token
 
-Energy per run is not comparable between models, because it depends on how many
-prompts you happened to send. Energy per output token is. If the task you are
-measuring is LLM inference, record the token counts of each request with
-`record_tokens()` and CodeCarbon will report them alongside the energy:
+Record the token counts of each request with `record_tokens()`:
 
 ``` python-skip
 from codecarbon import EmissionsTracker
@@ -68,10 +65,9 @@ with TaskEmissionsTracker(task_name="llama3.1:8b", tracker=tracker) as task:
 tracker.stop()
 ```
 
-The counts come from wherever your serving stack reports them — `usage` for
+The counts come from wherever your serving stack reports them: `usage` for
 OpenAI-compatible clients, `prompt_eval_count` / `eval_count` for Ollama, and so
-on. CodeCarbon does not inspect the response object, so it imports no inference
-library and nothing breaks when a vendor changes its payload.
+on.
 
 Counts accumulate over the life of the task, and the resulting `TaskEmissionsData`
 exposes `input_tokens`, `output_tokens` and `n_requests` — written to the task CSV

--- a/tests/test_token_tracking.py
+++ b/tests/test_token_tracking.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import unittest
+from unittest import mock
 
 from pandas import read_csv
 
@@ -50,27 +51,6 @@ class TestExtractTokenCounts(unittest.TestCase):
         self.assertEqual((0, 0), extract_token_counts({"text": "hello"}))
 
 
-class TestTaskEmissionsDataProperties(unittest.TestCase):
-    def _task_data(self, **kwargs):
-        tracker = EmissionsTracker(save_to_file=False, allow_multiple_runs=True)
-        tracker.start_task("properties")
-        tracker.record_tokens(**kwargs)
-        tracker.stop_task()
-        task = tracker._tasks["properties"].out()
-        tracker.stop()
-        return task
-
-    def test_zero_counters_do_not_raise(self):
-        task = self._task_data(n_requests=0)
-        self.assertEqual(0.0, task.energy_per_output_token)
-        self.assertEqual(0.0, task.emissions_per_request)
-
-    def test_derived_values(self):
-        task = self._task_data(output_tokens=100, n_requests=4)
-        self.assertAlmostEqual(task.energy_consumed / 100, task.energy_per_output_token)
-        self.assertAlmostEqual(task.emissions / 4, task.emissions_per_request)
-
-
 class TestTokenTracking(unittest.TestCase):
     def setUp(self) -> None:
         os.makedirs(OUTPUT_DIR, exist_ok=True)
@@ -90,11 +70,32 @@ class TestTokenTracking(unittest.TestCase):
         self.assertEqual(52, data.output_tokens)
         self.assertEqual(3, data.n_requests)
 
-    def test_record_tokens_without_active_task_is_ignored(self):
+    def test_record_tokens_without_active_task_warns_and_records_nothing(self):
         tracker = EmissionsTracker(save_to_file=False, allow_multiple_runs=True)
         tracker.start()
-        tracker.record_tokens(output_tokens=10)
+        with mock.patch("codecarbon.emissions_tracker.logger") as mock_logger:
+            tracker.record_tokens(output_tokens=10)
         tracker.stop()
+
+        self.assertEqual({}, tracker._tasks)
+        mock_logger.warning.assert_called_once()
+        self.assertIn("No active task", mock_logger.warning.call_args[0][0])
+
+    def test_response_without_usage_logs_a_debug_hint(self):
+        tracker = EmissionsTracker(save_to_file=False, allow_multiple_runs=True)
+        with TaskEmissionsTracker("inference", tracker=tracker) as task:
+            # A streamed OpenAI chunk carries no usage unless the caller asked
+            # for stream_options={"include_usage": True}.
+            with mock.patch("codecarbon.emissions_tracker.logger") as mock_logger:
+                task.record_tokens(response={"choices": [], "usage": None})
+        data = tracker._tasks["inference"].out()
+        tracker.stop()
+
+        self.assertEqual(
+            (0, 0, 1), (data.input_tokens, data.output_tokens, data.n_requests)
+        )
+        mock_logger.debug.assert_called_once()
+        self.assertIn("include_usage", mock_logger.debug.call_args[0][0])
 
     def test_token_counts_are_written_to_the_task_csv(self):
         tracker = EmissionsTracker(

--- a/tests/test_token_tracking.py
+++ b/tests/test_token_tracking.py
@@ -7,48 +7,8 @@ from pandas import read_csv
 
 from codecarbon import EmissionsTracker
 from codecarbon.emissions_tracker import TaskEmissionsTracker
-from codecarbon.external.task import extract_token_counts
 
 OUTPUT_DIR = "test_token_data"
-
-
-class OpenAIUsage:
-    prompt_tokens = 12
-    completion_tokens = 30
-
-
-class OpenAIResponse:
-    usage = OpenAIUsage()
-
-
-class VLLMCompletion:
-    def __init__(self, n):
-        self.token_ids = list(range(n))
-
-
-class VLLMRequestOutput:
-    def __init__(self):
-        self.prompt_token_ids = list(range(7))
-        self.outputs = [VLLMCompletion(4), VLLMCompletion(6)]
-
-
-class TestExtractTokenCounts(unittest.TestCase):
-    def test_openai_object(self):
-        self.assertEqual((12, 30), extract_token_counts(OpenAIResponse()))
-
-    def test_openai_dict(self):
-        response = {"usage": {"prompt_tokens": 3, "completion_tokens": 8}}
-        self.assertEqual((3, 8), extract_token_counts(response))
-
-    def test_ollama_dict(self):
-        response = {"prompt_eval_count": 5, "eval_count": 42, "response": "hi"}
-        self.assertEqual((5, 42), extract_token_counts(response))
-
-    def test_vllm_request_output(self):
-        self.assertEqual((7, 10), extract_token_counts(VLLMRequestOutput()))
-
-    def test_unknown_response_is_zero(self):
-        self.assertEqual((0, 0), extract_token_counts({"text": "hello"}))
 
 
 class TestTokenTracking(unittest.TestCase):
@@ -62,8 +22,8 @@ class TestTokenTracking(unittest.TestCase):
         tracker = EmissionsTracker(save_to_file=False, allow_multiple_runs=True)
         with TaskEmissionsTracker("inference", tracker=tracker) as task:
             task.record_tokens(input_tokens=10, output_tokens=20)
-            task.record_tokens(response=OpenAIResponse())
-            task.record_tokens(response={"prompt_eval_count": 1, "eval_count": 2})
+            task.record_tokens(input_tokens=12, output_tokens=30)
+            task.record_tokens(input_tokens=1, output_tokens=2)
         data = tracker._tasks["inference"].out()
         tracker.stop()
         self.assertEqual(23, data.input_tokens)
@@ -80,22 +40,6 @@ class TestTokenTracking(unittest.TestCase):
         self.assertEqual({}, tracker._tasks)
         mock_logger.warning.assert_called_once()
         self.assertIn("No active task", mock_logger.warning.call_args[0][0])
-
-    def test_response_without_usage_logs_a_debug_hint(self):
-        tracker = EmissionsTracker(save_to_file=False, allow_multiple_runs=True)
-        with TaskEmissionsTracker("inference", tracker=tracker) as task:
-            # A streamed OpenAI chunk carries no usage unless the caller asked
-            # for stream_options={"include_usage": True}.
-            with mock.patch("codecarbon.emissions_tracker.logger") as mock_logger:
-                task.record_tokens(response={"choices": [], "usage": None})
-        data = tracker._tasks["inference"].out()
-        tracker.stop()
-
-        self.assertEqual(
-            (0, 0, 1), (data.input_tokens, data.output_tokens, data.n_requests)
-        )
-        mock_logger.debug.assert_called_once()
-        self.assertIn("include_usage", mock_logger.debug.call_args[0][0])
 
     def test_token_counts_are_written_to_the_task_csv(self):
         tracker = EmissionsTracker(

--- a/tests/test_token_tracking.py
+++ b/tests/test_token_tracking.py
@@ -1,0 +1,114 @@
+import os
+import shutil
+import unittest
+
+from pandas import read_csv
+
+from codecarbon import EmissionsTracker
+from codecarbon.emissions_tracker import TaskEmissionsTracker
+from codecarbon.external.task import extract_token_counts
+
+OUTPUT_DIR = "test_token_data"
+
+
+class OpenAIUsage:
+    prompt_tokens = 12
+    completion_tokens = 30
+
+
+class OpenAIResponse:
+    usage = OpenAIUsage()
+
+
+class VLLMCompletion:
+    def __init__(self, n):
+        self.token_ids = list(range(n))
+
+
+class VLLMRequestOutput:
+    def __init__(self):
+        self.prompt_token_ids = list(range(7))
+        self.outputs = [VLLMCompletion(4), VLLMCompletion(6)]
+
+
+class TestExtractTokenCounts(unittest.TestCase):
+    def test_openai_object(self):
+        self.assertEqual((12, 30), extract_token_counts(OpenAIResponse()))
+
+    def test_openai_dict(self):
+        response = {"usage": {"prompt_tokens": 3, "completion_tokens": 8}}
+        self.assertEqual((3, 8), extract_token_counts(response))
+
+    def test_ollama_dict(self):
+        response = {"prompt_eval_count": 5, "eval_count": 42, "response": "hi"}
+        self.assertEqual((5, 42), extract_token_counts(response))
+
+    def test_vllm_request_output(self):
+        self.assertEqual((7, 10), extract_token_counts(VLLMRequestOutput()))
+
+    def test_unknown_response_is_zero(self):
+        self.assertEqual((0, 0), extract_token_counts({"text": "hello"}))
+
+
+class TestTaskEmissionsDataProperties(unittest.TestCase):
+    def _task_data(self, **kwargs):
+        tracker = EmissionsTracker(save_to_file=False, allow_multiple_runs=True)
+        tracker.start_task("properties")
+        tracker.record_tokens(**kwargs)
+        tracker.stop_task()
+        task = tracker._tasks["properties"].out()
+        tracker.stop()
+        return task
+
+    def test_zero_counters_do_not_raise(self):
+        task = self._task_data(n_requests=0)
+        self.assertEqual(0.0, task.energy_per_output_token)
+        self.assertEqual(0.0, task.emissions_per_request)
+
+    def test_derived_values(self):
+        task = self._task_data(output_tokens=100, n_requests=4)
+        self.assertAlmostEqual(task.energy_consumed / 100, task.energy_per_output_token)
+        self.assertAlmostEqual(task.emissions / 4, task.emissions_per_request)
+
+
+class TestTokenTracking(unittest.TestCase):
+    def setUp(self) -> None:
+        os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(OUTPUT_DIR, ignore_errors=True)
+
+    def test_record_tokens_accumulates_over_a_task(self):
+        tracker = EmissionsTracker(save_to_file=False, allow_multiple_runs=True)
+        with TaskEmissionsTracker("inference", tracker=tracker) as task:
+            task.record_tokens(input_tokens=10, output_tokens=20)
+            task.record_tokens(response=OpenAIResponse())
+            task.record_tokens(response={"prompt_eval_count": 1, "eval_count": 2})
+        data = tracker._tasks["inference"].out()
+        tracker.stop()
+        self.assertEqual(23, data.input_tokens)
+        self.assertEqual(52, data.output_tokens)
+        self.assertEqual(3, data.n_requests)
+
+    def test_record_tokens_without_active_task_is_ignored(self):
+        tracker = EmissionsTracker(save_to_file=False, allow_multiple_runs=True)
+        tracker.start()
+        tracker.record_tokens(output_tokens=10)
+        tracker.stop()
+
+    def test_token_counts_are_written_to_the_task_csv(self):
+        tracker = EmissionsTracker(
+            output_dir=OUTPUT_DIR,
+            experiment_name="tokens",
+            allow_multiple_runs=True,
+        )
+        with TaskEmissionsTracker("inference", tracker=tracker) as task:
+            task.record_tokens(input_tokens=4, output_tokens=16)
+        tracker.stop()
+
+        task_file = [f for f in os.listdir(OUTPUT_DIR) if f.startswith("emissions_")]
+        df = read_csv(os.path.join(OUTPUT_DIR, task_file[0]))
+        row = df[df.task_name == "inference"].iloc[0]
+        self.assertEqual(4, row.input_tokens)
+        self.assertEqual(16, row.output_tokens)
+        self.assertEqual(1, row.n_requests)


### PR DESCRIPTION
## What this adds

Energy per run is not a comparable number for an LLM: it depends entirely on how many prompts happened to be sent. Energy per output token is. CodeCarbon already measures the power draw over a task; the only missing ingredient was the token counter, which only the caller knows.

This PR lets the caller hand that counter over, and carries it through the existing task machinery to the output handlers.

## User-facing surface

Three new fields on `TaskEmissionsData`, all defaulting to `0`: `input_tokens`, `output_tokens`, `n_requests`. They are plain stored counters. **No derived properties are exposed** — an earlier version of this description claimed `energy_per_output_token` and `emissions_per_request` were added, and that was wrong. `TaskEmissionsData.values` is built from `__dict__`, so a property reaches no output method, and both figures are one division away from the columns above. See the comment at `codecarbon/output_methods/emissions_data.py:115-117`.

One recording entry point, on the tracker and mirrored on `TaskEmissionsTracker`:

```python
with TaskEmissionsTracker(task_name="llama3.1:8b", tracker=tracker) as task:
    for prompt in prompts:
        response = client.chat.completions.create(...)
        task.record_tokens(
            input_tokens=response.usage.prompt_tokens,
            output_tokens=response.usage.completion_tokens,
        )
```

That is the whole API. CodeCarbon does not inspect the response object: the caller reads its own client's usage fields, which it already knows how to do, and no inference library is imported or added as a dependency. (A `response=` argument that duck-typed OpenAI / Ollama / vLLM payloads was in an earlier revision and has been removed — vendor response shapes drift, and each drift would land here as a silent zero.)

Counts accumulate over the life of one task; recording with no active task logs a warning and is otherwise a no-op.

The three fields flow through `Task.out()` and appear as three extra columns in the per-task CSV. Note that the task CSV is rewritten in full on each run (`FileOutput.task_out` writes a fresh dataframe to a per-run-id path), so there is no header-migration concern for existing files.

## Verification

`tests/test_token_tracking.py`: accumulation across several `record_tokens` calls in one task, recording with no active task, and an end-to-end check that the columns land in the task CSV with the right values. `tests/test_tracking_inference.py` and `test_docs_examples.py` still pass.

```
uv run pytest tests/test_token_tracking.py tests/test_tracking_inference.py tests/test_docs_examples.py -q
15 passed
```

`ruff format` / `ruff check` are clean on the touched files (the repo-wide `task lint` / `task format` were not run — they currently churn ~120 unrelated files).

## Deliberately left out

- No response-object introspection for any serving stack.
- No derived per-token / per-request properties; the raw counters and the existing energy columns are enough to compute them.
- No prefill/decode split — attributing those needs sub-second sampling the current scheduler cannot deliver.
- No per-request task granularity. A single request is typically far shorter than `measure_power_secs`, so per-request tasks would be dominated by measurement noise.
- Token counts stay task-level and do not propagate to run-level `EmissionsData`, since a run may mix inference with other work.
- Continuous batching makes per-request attribution physically meaningless; that is documented as a limitation rather than papered over.

Docs updated: an "LLM inference, energy per token" section in `docs/tutorials/python-api.md` and the three task columns in `docs/reference/output.md`.

Closes #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)
