### PR TITLE
feat: carbon-aware `codecarbon wait` (forecast + greenest-window selection)

### DIFF
--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -480,6 +480,12 @@ def wait(
         str,
         typer.Option(help="Maximum delay before the job must start."),
     ] = "12h",
+    finish_by: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Latest acceptable finish time, e.g. '8h'. Overrides --deadline."
+        ),
+    ] = None,
     threshold: Annotated[
         Optional[float],
         typer.Option(help="gCO2e/kWh at or below which we start immediately."),
@@ -509,6 +515,7 @@ def wait(
         ctx,
         duration=duration,
         deadline=deadline,
+        finish_by=finish_by,
         threshold=threshold,
         dry_run=dry_run,
         log_level=log_level,

--- a/codecarbon/cli/main.py
+++ b/codecarbon/cli/main.py
@@ -465,6 +465,57 @@ def monitor(
         raise e
 
 
+@codecarbon.command(
+    "wait",
+    short_help="Wait for a low-carbon window, then run a command.",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def wait(
+    ctx: typer.Context,
+    duration: Annotated[
+        str,
+        typer.Option(help="Expected job length, e.g. '90m', '2h', '1h30m'."),
+    ] = "1h",
+    deadline: Annotated[
+        str,
+        typer.Option(help="Maximum delay before the job must start."),
+    ] = "12h",
+    threshold: Annotated[
+        Optional[float],
+        typer.Option(help="gCO2e/kWh at or below which we start immediately."),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(help="Print the recommendation and exit without waiting."),
+    ] = False,
+    measure_power_secs: Annotated[
+        int,
+        typer.Option(help="Interval between two measures."),
+    ] = 10,
+    log_level: Annotated[
+        str,
+        typer.Option(help="Log level (critical, error, warning, info, debug)"),
+    ] = "error",
+):
+    """Wait for the greenest window in the carbon intensity forecast, then run
+    a command under measurement.
+
+    Requires an Electricity Maps API token; without one, the command runs
+    immediately rather than blocking.
+    """
+    from codecarbon.cli.wait import wait_for_green_window
+
+    return wait_for_green_window(
+        ctx,
+        duration=duration,
+        deadline=deadline,
+        threshold=threshold,
+        dry_run=dry_run,
+        log_level=log_level,
+        measure_power_secs=measure_power_secs,
+    )
+
+
 @codecarbon.command("detect", short_help="Detect hardware and print information.")
 def detect():
     """

--- a/codecarbon/cli/monitor.py
+++ b/codecarbon/cli/monitor.py
@@ -55,7 +55,7 @@ def run_and_monitor(
 
     # Get the command from remaining args (strip nested subcommand / `--` leftovers)
     command = list(getattr(ctx, "args", None) or [])
-    while command and command[0] in ("monitor", "--"):
+    while command and command[0] in ("monitor", "wait", "--"):
         command.pop(0)
 
     if not command:

--- a/codecarbon/cli/wait.py
+++ b/codecarbon/cli/wait.py
@@ -169,10 +169,4 @@ def wait_for_green_window(
             print("\n⚠️  Wait aborted, the command was not run.", file=sys.stderr)
             raise typer.Exit(130)
 
-    # Strip our own subcommand name -- only in first position, so a user
-    # command that legitimately contains the word "wait" survives intact.
-    args = list(getattr(ctx, "args", []))
-    if args and args[0] == "wait":
-        args = args[1:]
-    ctx.args = args
     run_and_monitor(ctx, log_level=log_level, **tracker_args)

--- a/codecarbon/cli/wait.py
+++ b/codecarbon/cli/wait.py
@@ -71,7 +71,7 @@ def wait_for_green_window(
         codecarbon wait --deadline 12h --duration 2h -- python train.py
     """
     from codecarbon.cli.monitor import run_and_monitor
-    from codecarbon.core.config import get_hierarchical_config
+    from codecarbon.core.electricitymaps_api import resolve_token
     from codecarbon.external.logger import set_logger_level
 
     set_logger_level(log_level)
@@ -83,10 +83,7 @@ def wait_for_green_window(
         print(f"ERROR: {e}", file=sys.stderr)
         raise typer.Exit(1)
 
-    config = get_hierarchical_config()
-    token = config.get("electricitymaps_api_token") or config.get(
-        "co2_signal_api_token"
-    )
+    token = resolve_token()
 
     window = find_green_window(job_duration, max_delay, token)
     delay_seconds = 0.0

--- a/codecarbon/cli/wait.py
+++ b/codecarbon/cli/wait.py
@@ -1,0 +1,135 @@
+"""CodeCarbon CLI - Wait Command"""
+
+import re
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import typer
+from rich import print
+
+_DURATION_RE = re.compile(r"^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
+
+
+def parse_duration(value: str) -> timedelta:
+    """Parse "90m", "2h", "1h30m" or a plain number of seconds."""
+    value = value.strip().lower()
+    if value.isdigit():
+        return timedelta(seconds=int(value))
+    match = _DURATION_RE.match(value)
+    if not match or not any(match.groups()):
+        raise ValueError(f"Invalid duration: {value!r}. Use e.g. '90m', '2h', '1h30m'.")
+    hours, minutes, seconds = (int(g or 0) for g in match.groups())
+    return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+
+
+def find_green_window(
+    duration: timedelta,
+    deadline: timedelta,
+    token: Optional[str],
+):
+    """Return (start, intensity, now_intensity) or None when we should run now."""
+    from codecarbon.core.intensity_forecast import best_window, get_forecast
+    from codecarbon.external.geography import GeoMetadata
+    from codecarbon.input import DataSource
+
+    geo = GeoMetadata.from_geo_js(DataSource().geo_js_url)
+    forecast = get_forecast(geo, token=token, horizon_hours=_ceil_hours(deadline))
+    if forecast is None:
+        return None
+
+    now = datetime.now(timezone.utc)
+    start, intensity = best_window(forecast, duration, deadline=now + deadline)
+    return start, intensity, forecast.points[0].g_co2e_per_kwh
+
+
+def _ceil_hours(delta: timedelta) -> int:
+    return max(1, -(-int(delta.total_seconds()) // 3600))
+
+
+def wait_for_green_window(
+    ctx: typer.Context,
+    duration: str = "1h",
+    deadline: str = "12h",
+    threshold: Optional[float] = None,
+    dry_run: bool = False,
+    log_level: str = "error",
+    **tracker_args,
+):
+    """Wait for the greenest window in the forecast, then run a command.
+
+    This is a sleep, not a scheduler: it does not fork, daemonise or persist.
+    For deferral that must survive a reboot, use cron, systemd or Airflow.
+
+    Examples:
+
+        # Print the recommendation and exit
+        codecarbon wait --dry-run --deadline 24h --duration 90m
+
+        # Block until the greenest window, then run under measurement
+        codecarbon wait --deadline 12h --duration 2h -- python train.py
+    """
+    from codecarbon.cli.monitor import run_and_monitor
+    from codecarbon.core.config import get_hierarchical_config
+    from codecarbon.external.logger import set_logger_level
+
+    set_logger_level(log_level)
+
+    try:
+        job_duration = parse_duration(duration)
+        max_delay = parse_duration(deadline)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        raise typer.Exit(1)
+
+    config = get_hierarchical_config()
+    token = config.get("electricitymaps_api_token") or config.get(
+        "co2_signal_api_token"
+    )
+
+    window = find_green_window(job_duration, max_delay, token)
+    delay_seconds = 0.0
+    if window is None:
+        print("🌱 CodeCarbon: no forecast available, running now.")
+    else:
+        start, intensity, now_intensity = window
+        delay_seconds = max(0.0, (start - datetime.now(timezone.utc)).total_seconds())
+        if threshold is not None and now_intensity <= threshold:
+            print(
+                f"🌱 CodeCarbon: current intensity {now_intensity:.0f} gCO2e/kWh is "
+                f"at or below the {threshold:.0f} threshold, running now."
+            )
+            delay_seconds = 0.0
+        elif delay_seconds <= 0:
+            print(
+                f"🌱 CodeCarbon: now is already the greenest window "
+                f"({now_intensity:.0f} gCO2e/kWh)."
+            )
+        else:
+            saving = (
+                100 * (now_intensity - intensity) / now_intensity
+                if now_intensity
+                else 0
+            )
+            print(
+                f"🌱 Best start: {start:%Y-%m-%d %H:%M} UTC  "
+                f"({intensity:.0f} gCO2e/kWh, now: {now_intensity:.0f})  "
+                f"-> saves ~{saving:.0f}%"
+            )
+
+    if dry_run:
+        raise typer.Exit(0)
+
+    if delay_seconds > 0:
+        print(
+            f"   Waiting {delay_seconds / 3600:.1f}h before starting. Ctrl-C to run now."
+        )
+        try:
+            time.sleep(delay_seconds)
+        except KeyboardInterrupt:
+            print("\n⚠️  Wait interrupted, starting now.", file=sys.stderr)
+
+    # Strip our own subcommand name so `run_and_monitor` sees only the command.
+    ctx.args = [arg for arg in getattr(ctx, "args", []) if arg != "wait"]
+    run_and_monitor(ctx, log_level=log_level, **tracker_args)

--- a/codecarbon/cli/wait.py
+++ b/codecarbon/cli/wait.py
@@ -34,11 +34,29 @@ def find_green_window(
     forecast sees it. Asking the /latest endpoint for a live value instead
     would be a second HTTP call for a number only used to print a percentage.
     """
+    import pycountry
+
+    from codecarbon.core.config import get_hierarchical_config
     from codecarbon.core.intensity_forecast import best_window, get_forecast
     from codecarbon.external.geography import GeoMetadata
     from codecarbon.input import DataSource
 
-    geo = GeoMetadata.from_geo_js(DataSource().geo_js_url)
+    # The tracker honours a configured country, so the forecast must too:
+    # geolocating by IP would silently forecast the wrong grid.
+    config = get_hierarchical_config()
+    configured = config.get("country_iso_code")
+    country = (
+        pycountry.countries.get(alpha_3=configured.upper()) if configured else None
+    )
+    if country:
+        geo = GeoMetadata(
+            country_iso_code=country.alpha_3,
+            country_name=country.name,
+            region=config.get("region"),
+            country_2letter_iso_code=country.alpha_2,
+        )
+    else:
+        geo = GeoMetadata.from_geo_js(DataSource().geo_js_url)
     # A window may start as late as the deadline, so the forecast must cover
     # the deadline plus one job length.
     forecast = get_forecast(

--- a/codecarbon/cli/wait.py
+++ b/codecarbon/cli/wait.py
@@ -4,10 +4,11 @@ import re
 import sys
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Optional
 
 import typer
 from rich import print
+
+from codecarbon.external.logger import logger
 
 _DURATION_RE = re.compile(r"^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
 
@@ -27,21 +28,33 @@ def parse_duration(value: str) -> timedelta:
 def find_green_window(
     duration: timedelta,
     deadline: timedelta,
-    token: Optional[str],
+    token: str | None,
 ):
     """Return (start, intensity, now_intensity) or None when we should run now."""
+    from codecarbon.core import electricitymaps_api
     from codecarbon.core.intensity_forecast import best_window, get_forecast
     from codecarbon.external.geography import GeoMetadata
     from codecarbon.input import DataSource
 
     geo = GeoMetadata.from_geo_js(DataSource().geo_js_url)
-    forecast = get_forecast(geo, token=token, horizon_hours=_ceil_hours(deadline))
+    # A window may start as late as the deadline, so the forecast must cover
+    # the deadline plus one job length.
+    forecast = get_forecast(
+        geo, token=token, horizon_hours=_ceil_hours(deadline + duration)
+    )
     if forecast is None:
         return None
 
+    try:
+        now_intensity = electricitymaps_api.get_carbon_intensity(geo, token or "")
+    except Exception as e:
+        # The forecast's first point is a stand-in, not the live value.
+        logger.debug(f"wait: current intensity unavailable ({e}), using the forecast.")
+        now_intensity = forecast.points[0].g_co2e_per_kwh
+
     now = datetime.now(timezone.utc)
     start, intensity = best_window(forecast, duration, deadline=now + deadline)
-    return start, intensity, forecast.points[0].g_co2e_per_kwh
+    return start, intensity, now_intensity
 
 
 def _ceil_hours(delta: timedelta) -> int:
@@ -52,7 +65,7 @@ def wait_for_green_window(
     ctx: typer.Context,
     duration: str = "1h",
     deadline: str = "12h",
-    threshold: Optional[float] = None,
+    threshold: float | None = None,
     dry_run: bool = False,
     log_level: str = "error",
     **tracker_args,
@@ -127,6 +140,10 @@ def wait_for_green_window(
         except KeyboardInterrupt:
             print("\n⚠️  Wait interrupted, starting now.", file=sys.stderr)
 
-    # Strip our own subcommand name so `run_and_monitor` sees only the command.
-    ctx.args = [arg for arg in getattr(ctx, "args", []) if arg != "wait"]
+    # Strip our own subcommand name -- only in first position, so a user
+    # command that legitimately contains the word "wait" survives intact.
+    args = list(getattr(ctx, "args", []))
+    if args and args[0] == "wait":
+        args = args[1:]
+    ctx.args = args
     run_and_monitor(ctx, log_level=log_level, **tracker_args)

--- a/codecarbon/cli/wait.py
+++ b/codecarbon/cli/wait.py
@@ -8,8 +8,6 @@ from datetime import datetime, timedelta, timezone
 import typer
 from rich import print
 
-from codecarbon.external.logger import logger
-
 _DURATION_RE = re.compile(r"^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
 
 
@@ -30,8 +28,12 @@ def find_green_window(
     deadline: timedelta,
     token: str | None,
 ):
-    """Return (start, intensity, now_intensity) or None when we should run now."""
-    from codecarbon.core import electricitymaps_api
+    """Return (start, intensity, now_intensity) or None when we should run now.
+
+    `now_intensity` is the first forecast point, i.e. the current period as the
+    forecast sees it. Asking the /latest endpoint for a live value instead
+    would be a second HTTP call for a number only used to print a percentage.
+    """
     from codecarbon.core.intensity_forecast import best_window, get_forecast
     from codecarbon.external.geography import GeoMetadata
     from codecarbon.input import DataSource
@@ -45,13 +47,7 @@ def find_green_window(
     if forecast is None:
         return None
 
-    try:
-        now_intensity = electricitymaps_api.get_carbon_intensity(geo, token or "")
-    except Exception as e:
-        # The forecast's first point is a stand-in, not the live value.
-        logger.debug(f"wait: current intensity unavailable ({e}), using the forecast.")
-        now_intensity = forecast.points[0].g_co2e_per_kwh
-
+    now_intensity = forecast.points[0].g_co2e_per_kwh
     now = datetime.now(timezone.utc)
     start, intensity = best_window(forecast, duration, deadline=now + deadline)
     return start, intensity, now_intensity
@@ -65,6 +61,7 @@ def wait_for_green_window(
     ctx: typer.Context,
     duration: str = "1h",
     deadline: str = "12h",
+    finish_by: str | None = None,
     threshold: float | None = None,
     dry_run: bool = False,
     log_level: str = "error",
@@ -82,6 +79,9 @@ def wait_for_green_window(
 
         # Block until the greenest window, then run under measurement
         codecarbon wait --deadline 12h --duration 2h -- python train.py
+
+        # Bound the finish time instead of the start
+        codecarbon wait --finish-by 8h --duration 2h -- python train.py
     """
     from codecarbon.cli.monitor import run_and_monitor
     from codecarbon.core.electricitymaps_api import resolve_token
@@ -91,7 +91,16 @@ def wait_for_green_window(
 
     try:
         job_duration = parse_duration(duration)
-        max_delay = parse_duration(deadline)
+        # --deadline bounds the start, --finish-by bounds the end; the search
+        # only ever needs the latest acceptable start.
+        if finish_by is not None:
+            max_delay = parse_duration(finish_by) - job_duration
+            if max_delay < timedelta(0):
+                raise ValueError(
+                    f"--finish-by {finish_by} is sooner than --duration {duration}."
+                )
+        else:
+            max_delay = parse_duration(deadline)
     except ValueError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         raise typer.Exit(1)

--- a/codecarbon/cli/wait.py
+++ b/codecarbon/cli/wait.py
@@ -142,12 +142,14 @@ def wait_for_green_window(
 
     if delay_seconds > 0:
         print(
-            f"   Waiting {delay_seconds / 3600:.1f}h before starting. Ctrl-C to run now."
+            f"   Waiting {delay_seconds / 3600:.1f}h before starting. "
+            "Ctrl-C to abort."
         )
         try:
             time.sleep(delay_seconds)
         except KeyboardInterrupt:
-            print("\n⚠️  Wait interrupted, starting now.", file=sys.stderr)
+            print("\n⚠️  Wait aborted, the command was not run.", file=sys.stderr)
+            raise typer.Exit(130)
 
     # Strip our own subcommand name -- only in first position, so a user
     # command that legitimately contains the word "wait" survives intact.

--- a/codecarbon/core/electricitymaps_api.py
+++ b/codecarbon/core/electricitymaps_api.py
@@ -9,6 +9,7 @@ from codecarbon.external.geography import GeoMetadata
 from codecarbon.external.logger import logger
 
 URL: str = "https://api.electricitymaps.com/v3/carbon-intensity/latest"
+FORECAST_URL: str = "https://api.electricitymaps.com/v3/carbon-intensity/forecast"
 ELECTRICITYMAPS_API_TIMEOUT: int = 30
 
 # Grid carbon intensity is published hourly at best, while emissions are computed

--- a/codecarbon/core/intensity_forecast.py
+++ b/codecarbon/core/intensity_forecast.py
@@ -10,20 +10,15 @@ API backs off once for the whole process instead of once per caller. The
 forecast response itself is not cached: it is fetched once per `codecarbon
 wait` invocation, and its useful lifetime is nothing like the current
 intensity's short TTL.
-
-Once pluggable intensity providers land (see issue #1356), `get_forecast`
-should become an optional `forecast()` method on the provider protocol.
 """
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 
-from codecarbon.core.electricitymaps_api import location_params, request
+from codecarbon.core.electricitymaps_api import FORECAST_URL, location_params, request
 from codecarbon.external.geography import GeoMetadata
 from codecarbon.external.logger import logger
-
-FORECAST_URL: str = "https://api.electricitymaps.com/v3/carbon-intensity/forecast"
 
 
 @dataclass(frozen=True)
@@ -36,8 +31,6 @@ class IntensityPoint:
 class Forecast:
     zone: str
     points: List[IntensityPoint]  # ordered, typically hourly
-    source: str
-    fetched_at: datetime
 
 
 def _parse_datetime(value: str) -> datetime:
@@ -85,8 +78,6 @@ def get_forecast(
         return Forecast(
             zone=data.get("zone", ""),
             points=points,
-            source="electricitymaps",
-            fetched_at=datetime.now(timezone.utc),
         )
     except Exception as e:
         logger.error(

--- a/codecarbon/core/intensity_forecast.py
+++ b/codecarbon/core/intensity_forecast.py
@@ -1,0 +1,148 @@
+"""Carbon intensity forecasts and greenest-window selection.
+
+The only provider able to serve a forecast today is Electricity Maps, and only
+for users holding a token for it. When no provider can answer, `get_forecast`
+returns ``None`` and every caller must degrade to "run now" -- a job is never
+blocked on a missing credential.
+
+Once pluggable intensity providers land (see issue #1356), `get_forecast`
+should become an optional `forecast()` method on the provider protocol rather
+than a second HTTP client.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from codecarbon.core.electricitymaps_api import ELECTRICITYMAPS_API_TIMEOUT
+from codecarbon.external.geography import GeoMetadata
+from codecarbon.external.logger import logger
+
+FORECAST_URL: str = "https://api.electricitymaps.com/v3/carbon-intensity/forecast"
+
+
+@dataclass(frozen=True)
+class IntensityPoint:
+    at: datetime  # timezone-aware, UTC
+    g_co2e_per_kwh: float
+
+
+@dataclass(frozen=True)
+class Forecast:
+    zone: str
+    points: List[IntensityPoint]  # ordered, typically hourly
+    source: str
+    fetched_at: datetime
+
+
+def _location_params(geo: GeoMetadata) -> Dict[str, Any]:
+    """Build the Electricity Maps location query, as `get_emissions` does."""
+    if geo.latitude:
+        return {"lat": geo.latitude, "lon": geo.longitude}
+    return {"countryCode": geo.country_2letter_iso_code}
+
+
+def _parse_datetime(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def get_forecast(
+    geo: GeoMetadata,
+    *,
+    token: Optional[str] = None,
+    horizon_hours: int = 48,
+) -> Optional[Forecast]:
+    """Return an intensity forecast, or None when no provider can supply one.
+
+    Never raises: a forecast is an optimisation, not a requirement.
+    """
+    if not token:
+        logger.warning(
+            "No Electricity Maps API token configured, cannot fetch a carbon "
+            "intensity forecast."
+        )
+        return None
+
+    try:
+        resp = requests.get(
+            FORECAST_URL,
+            params=_location_params(geo),
+            headers={"auth-token": token},
+            timeout=ELECTRICITYMAPS_API_TIMEOUT,
+        )
+        if resp.status_code != 200:
+            body = resp.json()
+            raise ValueError(body.get("error") or body.get("message") or resp.text)
+
+        data = resp.json()
+        horizon_end = datetime.now(timezone.utc) + timedelta(hours=horizon_hours)
+        points = [
+            IntensityPoint(
+                at=_parse_datetime(entry["datetime"]),
+                g_co2e_per_kwh=float(entry["carbonIntensity"]),
+            )
+            for entry in data["forecast"]
+            if entry.get("carbonIntensity") is not None
+        ]
+        points = sorted(
+            (point for point in points if point.at <= horizon_end),
+            key=lambda point: point.at,
+        )
+        if not points:
+            raise ValueError("No usable forecast points in response")
+
+        return Forecast(
+            zone=data.get("zone", ""),
+            points=points,
+            source="electricitymaps",
+            fetched_at=datetime.now(timezone.utc),
+        )
+    except Exception as e:
+        logger.error(
+            f"intensity_forecast.get_forecast: {e} >>> Falling back to running now."
+        )
+        return None
+
+
+def best_window(
+    forecast: Forecast,
+    duration: timedelta,
+    deadline: Optional[datetime] = None,
+) -> Tuple[datetime, float]:
+    """Start time minimising mean intensity over `duration`, and that mean.
+
+    Only windows that both start at or after the first forecast point and
+    finish before `deadline` are considered. Returns the earliest point and its
+    intensity when no complete window fits, so "just run it" is the default.
+    """
+    points = forecast.points
+    fallback = (points[0].at, points[0].g_co2e_per_kwh)
+
+    # The forecast covers up to one step past its last point.
+    step = points[1].at - points[0].at if len(points) > 1 else duration
+    covered_until = points[-1].at + step
+
+    best: Optional[Tuple[datetime, float]] = None
+    for start_index, start in enumerate(points):
+        window_end = start.at + duration
+        if window_end > covered_until:
+            break
+        if deadline is not None and window_end > deadline:
+            break
+        # ponytail: linear rescan per start, fine for hourly points over a few
+        # days; use a running sum if horizons ever grow by orders of magnitude.
+        covered = [
+            point.g_co2e_per_kwh
+            for point in points[start_index:]
+            if point.at < window_end
+        ]
+        mean = sum(covered) / len(covered)
+        if best is None or mean < best[1]:
+            best = (start.at, mean)
+
+    return best or fallback

--- a/codecarbon/core/intensity_forecast.py
+++ b/codecarbon/core/intensity_forecast.py
@@ -111,8 +111,13 @@ def best_window(
     points = forecast.points
     fallback = (points[0].at, points[0].g_co2e_per_kwh)
 
-    # The forecast covers up to one step past its last point.
-    step = points[1].at - points[0].at if len(points) > 1 else duration
+    # The forecast covers up to one step past its last point. Gaps are not
+    # guaranteed uniform, so the smallest one is the safe assumption.
+    step = (
+        min(b.at - a.at for a, b in zip(points, points[1:]))
+        if len(points) > 1
+        else duration
+    )
     covered_until = points[-1].at + step
 
     best: Optional[Tuple[datetime, float]] = None
@@ -124,12 +129,18 @@ def best_window(
             break
         # ponytail: linear rescan per start, fine for hourly points over a few
         # days; use a running sum if horizons ever grow by orders of magnitude.
-        covered = [
-            point.g_co2e_per_kwh
-            for point in points[start_index:]
-            if point.at < window_end
+        # Each point holds until the next one, so weight it by how much of its
+        # period falls inside the window: an hourly point half-covered by the
+        # window's end must not count as a full hour.
+        covered = [point for point in points[start_index:] if point.at < window_end]
+        ends = [point.at for point in covered[1:]] + [window_end]
+        weights = [
+            (min(end, window_end) - point.at).total_seconds()
+            for point, end in zip(covered, ends)
         ]
-        mean = sum(covered) / len(covered)
+        mean = sum(
+            point.g_co2e_per_kwh * weight for point, weight in zip(covered, weights)
+        ) / sum(weights)
         if best is None or mean < best[1]:
             best = (start.at, mean)
 

--- a/codecarbon/core/intensity_forecast.py
+++ b/codecarbon/core/intensity_forecast.py
@@ -5,18 +5,25 @@ for users holding a token for it. When no provider can answer, `get_forecast`
 returns ``None`` and every caller must degrade to "run now" -- a job is never
 blocked on a missing credential.
 
+HTTP goes through `codecarbon.core.electricitymaps_api.request`, so a failing
+API backs off once for the whole process instead of once per caller. The
+forecast response itself is not cached: it is fetched once per `codecarbon
+wait` invocation, and its useful lifetime is nothing like the current
+intensity's five-minute TTL.
+
 Once pluggable intensity providers land (see issue #1356), `get_forecast`
-should become an optional `forecast()` method on the provider protocol rather
-than a second HTTP client.
+should become an optional `forecast()` method on the provider protocol.
 """
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
-import requests
-
-from codecarbon.core.electricitymaps_api import ELECTRICITYMAPS_API_TIMEOUT
+from codecarbon.core.electricitymaps_api import (
+    clear_cooldown,
+    location_params,
+    request,
+)
 from codecarbon.external.geography import GeoMetadata
 from codecarbon.external.logger import logger
 
@@ -35,13 +42,6 @@ class Forecast:
     points: List[IntensityPoint]  # ordered, typically hourly
     source: str
     fetched_at: datetime
-
-
-def _location_params(geo: GeoMetadata) -> Dict[str, Any]:
-    """Build the Electricity Maps location query, as `get_emissions` does."""
-    if geo.latitude:
-        return {"lat": geo.latitude, "lon": geo.longitude}
-    return {"countryCode": geo.country_2letter_iso_code}
 
 
 def _parse_datetime(value: str) -> datetime:
@@ -69,17 +69,7 @@ def get_forecast(
         return None
 
     try:
-        resp = requests.get(
-            FORECAST_URL,
-            params=_location_params(geo),
-            headers={"auth-token": token},
-            timeout=ELECTRICITYMAPS_API_TIMEOUT,
-        )
-        if resp.status_code != 200:
-            body = resp.json()
-            raise ValueError(body.get("error") or body.get("message") or resp.text)
-
-        data = resp.json()
+        data = request(FORECAST_URL, location_params(geo), token)
         horizon_end = datetime.now(timezone.utc) + timedelta(hours=horizon_hours)
         points = [
             IntensityPoint(
@@ -96,6 +86,7 @@ def get_forecast(
         if not points:
             raise ValueError("No usable forecast points in response")
 
+        clear_cooldown()
         return Forecast(
             zone=data.get("zone", ""),
             points=points,

--- a/codecarbon/core/intensity_forecast.py
+++ b/codecarbon/core/intensity_forecast.py
@@ -90,7 +90,8 @@ def get_forecast(
         )
     except Exception as e:
         logger.error(
-            f"intensity_forecast.get_forecast: {e} >>> Falling back to running now."
+            f"intensity_forecast.get_forecast: {type(e).__name__}: {e} "
+            ">>> Falling back to running now."
         )
         return None
 

--- a/codecarbon/core/intensity_forecast.py
+++ b/codecarbon/core/intensity_forecast.py
@@ -107,9 +107,11 @@ def best_window(
 ) -> Tuple[datetime, float]:
     """Start time minimising mean intensity over `duration`, and that mean.
 
-    Only windows that both start at or after the first forecast point and
-    finish before `deadline` are considered. Returns the earliest point and its
-    intensity when no complete window fits, so "just run it" is the default.
+    `deadline` is the latest acceptable *start* time -- the job may run past
+    it. Only windows starting at or after the first forecast point, at or
+    before `deadline`, and fully covered by the forecast are considered.
+    Returns the earliest point and its intensity when no complete window fits,
+    so "just run it" is the default.
     """
     points = forecast.points
     fallback = (points[0].at, points[0].g_co2e_per_kwh)
@@ -123,7 +125,7 @@ def best_window(
         window_end = start.at + duration
         if window_end > covered_until:
             break
-        if deadline is not None and window_end > deadline:
+        if deadline is not None and start.at > deadline:
             break
         # ponytail: linear rescan per start, fine for hourly points over a few
         # days; use a running sum if horizons ever grow by orders of magnitude.

--- a/codecarbon/core/intensity_forecast.py
+++ b/codecarbon/core/intensity_forecast.py
@@ -9,7 +9,7 @@ HTTP goes through `codecarbon.core.electricitymaps_api.request`, so a failing
 API backs off once for the whole process instead of once per caller. The
 forecast response itself is not cached: it is fetched once per `codecarbon
 wait` invocation, and its useful lifetime is nothing like the current
-intensity's five-minute TTL.
+intensity's short TTL.
 
 Once pluggable intensity providers land (see issue #1356), `get_forecast`
 should become an optional `forecast()` method on the provider protocol.
@@ -19,11 +19,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 
-from codecarbon.core.electricitymaps_api import (
-    clear_cooldown,
-    location_params,
-    request,
-)
+from codecarbon.core.electricitymaps_api import location_params, request
 from codecarbon.external.geography import GeoMetadata
 from codecarbon.external.logger import logger
 
@@ -86,7 +82,6 @@ def get_forecast(
         if not points:
             raise ValueError("No usable forecast points in response")
 
-        clear_cooldown()
         return Forecast(
             zone=data.get("zone", ""),
             points=points,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -88,6 +88,70 @@ codecarbon monitor -- node app.js --port 8080
 
 Same options as `codecarbon monitor` apply (see above).
 
+### `codecarbon wait -- <command>`
+
+Wait for the greenest window in the carbon intensity forecast, then run a command under measurement.
+
+**Usage:**
+```bash
+codecarbon wait [OPTIONS] -- <your_command>
+```
+
+CodeCarbon fetches an hourly carbon intensity forecast for your location from
+[Electricity Maps](https://api.electricitymaps.com), picks the start time that minimises the
+average intensity over the expected job length, sleeps until then, and finally hands the command
+to `codecarbon monitor` — so measurement, CSV output and exit-code propagation are identical.
+
+This is a sleep, not a scheduler: the process stays in the foreground and does not fork, daemonise
+or persist across a reboot. For deferral that must survive a reboot, use cron, systemd or Airflow.
+Pressing `Ctrl+C` during the wait does not abort — it starts the job immediately. The emissions
+tracker only starts after the sleep, so a waiting process holds no lock.
+
+**Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--duration` | string | 1h | Expected job length, e.g. `90m`, `2h`, `1h30m`, or a plain number of seconds |
+| `--deadline` | string | 12h | Maximum delay before the job must start |
+| `--threshold` | float | - | gCO2e/kWh at or below which the job starts immediately, without waiting |
+| `--dry-run` | flag | false | Print the recommendation and exit without waiting or running |
+| `--measure-power-secs` | int | 10 | Interval between two measures |
+| `--log-level` | choice | error | Log level: critical, error, warning, info, debug |
+
+**Examples:**
+```bash
+# Print the recommendation and exit
+codecarbon wait --dry-run --deadline 24h --duration 90m
+
+# Block until the greenest window, then run under measurement
+codecarbon wait --deadline 12h --duration 2h -- python train.py
+
+# Start straight away if the grid is already below 100 gCO2e/kWh
+codecarbon wait --threshold 100 --deadline 6h -- bash benchmark.sh
+```
+
+The dry run prints the chosen window, for example:
+
+```console
+$ codecarbon wait --dry-run --deadline 24h --duration 90m
+🌱 Best start: 2026-08-13 03:00 UTC  (112 gCO2e/kWh, now: 341)  -> saves ~67%
+```
+
+**Requirements:**
+
+A forecast is only available with an `electricitymaps_api_token` (the `co2_signal_api_token` key
+is also accepted) — see [Electricity Maps API Token](../how-to/configuration.md#electricity-maps-api-token).
+The location is detected automatically from your IP address; there is no offline or
+`--country-iso-code` option for this command.
+
+**When no forecast is available:**
+
+A forecast is an optimisation, never a requirement — the job is never blocked on a missing
+credential. If no token is configured, or the API returns an error, a malformed payload or an
+empty forecast, CodeCarbon prints `no forecast available, running now.` and starts the command
+straight away. The same applies when no complete window fits before the deadline, or when the
+forecast says now is already the greenest moment.
+
 ### `codecarbon detect`
 
 Detect and print hardware information.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -112,7 +112,7 @@ tracker only starts after the sleep, so a waiting process holds no lock.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--duration` | string | 1h | Expected job length, e.g. `90m`, `2h`, `1h30m`, or a plain number of seconds |
-| `--deadline` | string | 12h | Maximum delay before the job must start |
+| `--deadline` | string | 12h | Maximum delay before the job must start; the job itself may finish after it |
 | `--threshold` | float | - | gCO2e/kWh at or below which the job starts immediately, without waiting |
 | `--dry-run` | flag | false | Print the recommendation and exit without waiting or running |
 | `--measure-power-secs` | int | 10 | Interval between two measures |
@@ -149,8 +149,11 @@ The location is detected automatically from your IP address; there is no offline
 A forecast is an optimisation, never a requirement — the job is never blocked on a missing
 credential. If no token is configured, or the API returns an error, a malformed payload or an
 empty forecast, CodeCarbon prints `no forecast available, running now.` and starts the command
-straight away. The same applies when no complete window fits before the deadline, or when the
-forecast says now is already the greenest moment.
+straight away. The same applies when the forecast covers no complete window, or when it says now is already
+the greenest moment.
+
+`--deadline` bounds the *start* time, not the end: `--deadline 12h --duration 2h` considers every
+start in the next 12 hours, so the job may still be running 14 hours from now.
 
 ### `codecarbon detect`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -144,8 +144,8 @@ $ codecarbon wait --dry-run --deadline 24h --duration 90m
 
 A forecast is only available with an `electricitymaps_api_token` (the `co2_signal_api_token` key
 is also accepted), see [Electricity Maps API Token](../how-to/configuration.md#electricity-maps-api-token).
-The location is detected automatically from your IP address; there is no offline or
-`--country-iso-code` option for this command.
+The location comes from `country_iso_code` in your configuration when it is set, and is otherwise
+detected from your IP address.
 
 If no token is configured, or the API returns an error, a malformed payload or an
 empty forecast, CodeCarbon prints `no forecast available, running now.` and starts the command

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -113,6 +113,7 @@ tracker only starts after the sleep, so a waiting process holds no lock.
 |--------|------|---------|-------------|
 | `--duration` | string | 1h | Expected job length, e.g. `90m`, `2h`, `1h30m`, or a plain number of seconds |
 | `--deadline` | string | 12h | Maximum delay before the job must start; the job itself may finish after it |
+| `--finish-by` | string | - | Latest acceptable *finish* time. Overrides `--deadline` with `--finish-by` minus `--duration` |
 | `--threshold` | float | - | gCO2e/kWh at or below which the job starts immediately, without waiting |
 | `--dry-run` | flag | false | Print the recommendation and exit without waiting or running |
 | `--measure-power-secs` | int | 10 | Interval between two measures |
@@ -128,6 +129,9 @@ codecarbon wait --deadline 12h --duration 2h -- python train.py
 
 # Start straight away if the grid is already below 100 gCO2e/kWh
 codecarbon wait --threshold 100 --deadline 6h -- bash benchmark.sh
+
+# The job must be finished within 8 hours, and takes about 2
+codecarbon wait --finish-by 8h --duration 2h -- python train.py
 ```
 
 The dry run prints the chosen window, for example:
@@ -153,7 +157,12 @@ straight away. The same applies when the forecast covers no complete window, or 
 the greenest moment.
 
 `--deadline` bounds the *start* time, not the end: `--deadline 12h --duration 2h` considers every
-start in the next 12 hours, so the job may still be running 14 hours from now.
+start in the next 12 hours, so the job may still be running 14 hours from now. When you mean "this
+must be **done** by then", use `--finish-by` instead: `--finish-by 12h --duration 2h` searches
+starts in the next 10 hours. Passing a `--finish-by` shorter than `--duration` is an error.
+
+The `now:` figure in the output is the first point of the forecast, i.e. the current period as the
+forecast sees it, not a separate reading of the live grid — `wait` makes exactly one API call.
 
 ### `codecarbon detect`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -102,9 +102,9 @@ CodeCarbon fetches an hourly carbon intensity forecast for your location from
 average intensity over the expected job length, sleeps until then, and finally hands the command
 to `codecarbon monitor`, so measurement, CSV output and exit-code propagation are identical.
 
-The process stays in the foreground for the whole wait. Pressing `Ctrl+C` during the wait does not
-abort: it starts the job immediately. The emissions tracker only starts after the sleep, so a
-waiting process holds no lock.
+The process stays in the foreground for the whole wait. Pressing `Ctrl+C` during the wait aborts:
+the command is not run and the exit code is 130. The emissions tracker only starts after the
+sleep, so a waiting process holds no lock.
 
 **Options:**
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -100,12 +100,11 @@ codecarbon wait [OPTIONS] -- <your_command>
 CodeCarbon fetches an hourly carbon intensity forecast for your location from
 [Electricity Maps](https://api.electricitymaps.com), picks the start time that minimises the
 average intensity over the expected job length, sleeps until then, and finally hands the command
-to `codecarbon monitor` — so measurement, CSV output and exit-code propagation are identical.
+to `codecarbon monitor`, so measurement, CSV output and exit-code propagation are identical.
 
-This is a sleep, not a scheduler: the process stays in the foreground and does not fork, daemonise
-or persist across a reboot. For deferral that must survive a reboot, use cron, systemd or Airflow.
-Pressing `Ctrl+C` during the wait does not abort — it starts the job immediately. The emissions
-tracker only starts after the sleep, so a waiting process holds no lock.
+The process stays in the foreground for the whole wait. Pressing `Ctrl+C` during the wait does not
+abort: it starts the job immediately. The emissions tracker only starts after the sleep, so a
+waiting process holds no lock.
 
 **Options:**
 
@@ -144,14 +143,11 @@ $ codecarbon wait --dry-run --deadline 24h --duration 90m
 **Requirements:**
 
 A forecast is only available with an `electricitymaps_api_token` (the `co2_signal_api_token` key
-is also accepted) — see [Electricity Maps API Token](../how-to/configuration.md#electricity-maps-api-token).
+is also accepted), see [Electricity Maps API Token](../how-to/configuration.md#electricity-maps-api-token).
 The location is detected automatically from your IP address; there is no offline or
 `--country-iso-code` option for this command.
 
-**When no forecast is available:**
-
-A forecast is an optimisation, never a requirement — the job is never blocked on a missing
-credential. If no token is configured, or the API returns an error, a malformed payload or an
+If no token is configured, or the API returns an error, a malformed payload or an
 empty forecast, CodeCarbon prints `no forecast available, running now.` and starts the command
 straight away. The same applies when the forecast covers no complete window, or when it says now is already
 the greenest moment.
@@ -162,7 +158,7 @@ must be **done** by then", use `--finish-by` instead: `--finish-by 12h --duratio
 starts in the next 10 hours. Passing a `--finish-by` shorter than `--duration` is an error.
 
 The `now:` figure in the output is the first point of the forecast, i.e. the current period as the
-forecast sees it, not a separate reading of the live grid — `wait` makes exactly one API call.
+forecast sees it, not a separate reading of the live grid: `wait` makes exactly one API call.
 
 ### `codecarbon detect`
 

--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -134,6 +134,7 @@ You've now learned how to track emissions from the command line. Next steps:
 - **Track in Python**: Use the [Python API tutorial](python-api.md) for fine-grained tracking within your code.
 - **Send to Dashboard**: Learn how to [send data to the CodeCarbon dashboard](../how-to/cloud-api.md).
 - **Configure Details**: See the [configuration guide](../how-to/configuration.md) for advanced options like proxy setup.
+- **Run When the Grid Is Green**: Defer a job to the cleanest hours with [`codecarbon wait`](../reference/cli.md#codecarbon-wait-command).
 
 ## See Also
 

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -53,7 +53,7 @@ def test_run_and_monitor_strips_nested_monitor_prefix(monkeypatch):
 
     with pytest.raises(typer.Exit) as exc_info:
         monitor_module.run_and_monitor(
-            SimpleNamespace(args=["monitor", "--", "echo", "hi"])
+            SimpleNamespace(args=["wait", "monitor", "--", "echo", "hi"])
         )
 
     assert exc_info.value.exit_code == 0

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -33,15 +33,11 @@ def no_network(monkeypatch):
     )
 
 
-def _patch_forecast(monkeypatch, values, now_intensity=None):
+def _patch_forecast(monkeypatch, values):
     now = datetime.now(timezone.utc)
     monkeypatch.setattr(
         "codecarbon.core.intensity_forecast.get_forecast",
         lambda geo, **kwargs: _forecast(values, now),
-    )
-    monkeypatch.setattr(
-        "codecarbon.core.electricitymaps_api.get_carbon_intensity",
-        lambda geo, token="": values[0] if now_intensity is None else now_intensity,
     )
 
 
@@ -130,11 +126,14 @@ def test_threshold_short_circuits_the_wait(monkeypatch, capsys, no_network):
     assert "running now" in capsys.readouterr().out
 
 
-def test_threshold_uses_the_live_intensity_not_the_forecast(
-    monkeypatch, capsys, no_network
-):
-    # The first forecast point is above the threshold, the live grid is below.
-    _patch_forecast(monkeypatch, [300, 300, 100, 100], now_intensity=120)
+def test_no_second_call_for_the_current_intensity(monkeypatch, capsys, no_network):
+    # The first forecast point is the "now" value: fetching /latest as well
+    # would be a second HTTP call just to print a percentage.
+    _patch_forecast(monkeypatch, [120, 300, 50, 50])
+    monkeypatch.setattr(
+        "codecarbon.core.electricitymaps_api.get_carbon_intensity",
+        lambda *a, **k: pytest.fail("second live call"),
+    )
     monkeypatch.setattr(wait_module.time, "sleep", lambda s: pytest.fail("slept"))
     monkeypatch.setattr(
         "codecarbon.cli.monitor.run_and_monitor", lambda ctx, **kwargs: None
@@ -145,6 +144,31 @@ def test_threshold_uses_the_live_intensity_not_the_forecast(
     )
 
     assert "running now" in capsys.readouterr().out
+
+
+def test_finish_by_bounds_the_end_not_the_start(monkeypatch, no_network):
+    # Trough at +4h, but the job must be done by +3h, so only a start at or
+    # before +2h is acceptable: the cheapest of those is +1h.
+    _patch_forecast(monkeypatch, [300, 100, 200, 200, 10, 10])
+    slept = []
+    monkeypatch.setattr(wait_module.time, "sleep", lambda s: slept.append(s))
+    monkeypatch.setattr(
+        "codecarbon.cli.monitor.run_and_monitor", lambda ctx, **kwargs: None
+    )
+
+    wait_module.wait_for_green_window(
+        SimpleNamespace(args=[]), duration="1h", finish_by="3h"
+    )
+
+    assert len(slept) == 1
+    assert 3600 - 60 < slept[0] <= 3600
+
+
+def test_finish_by_shorter_than_duration_is_rejected(monkeypatch, capsys, no_network):
+    with pytest.raises(typer.Exit):
+        wait_module.wait_for_green_window(
+            SimpleNamespace(args=[]), duration="4h", finish_by="1h"
+        )
 
 
 def test_only_the_leading_subcommand_name_is_stripped(monkeypatch, no_network):

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -229,3 +229,25 @@ def test_keyboard_interrupt_during_wait_aborts(monkeypatch, no_network):
 
     assert exc_info.value.exit_code == 130
     assert called == {}
+
+
+def test_configured_country_is_preferred_over_geolocation(monkeypatch):
+    monkeypatch.setattr(
+        "codecarbon.external.geography.GeoMetadata.from_geo_js",
+        classmethod(lambda cls, url: pytest.fail("geolocated despite a config")),
+    )
+    monkeypatch.setattr(
+        "codecarbon.core.config.get_hierarchical_config",
+        lambda: {"country_iso_code": "fra", "region": "ile-de-france"},
+    )
+    seen = {}
+    monkeypatch.setattr(
+        "codecarbon.core.intensity_forecast.get_forecast",
+        lambda geo, **kwargs: seen.update(geo=geo),
+    )
+
+    wait_module.find_green_window(timedelta(hours=1), timedelta(hours=2), "tok")
+
+    assert seen["geo"].country_iso_code == "FRA"
+    assert seen["geo"].country_2letter_iso_code == "FR"
+    assert seen["geo"].region == "ile-de-france"

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -15,8 +15,6 @@ def _forecast(values, start):
             IntensityPoint(at=start + timedelta(hours=i), g_co2e_per_kwh=v)
             for i, v in enumerate(values)
         ],
-        source="test",
-        fetched_at=start,
     )
 
 
@@ -103,7 +101,7 @@ def test_no_forecast_runs_now(monkeypatch, capsys, no_network):
     )
 
     assert slept == []
-    assert called["args"] == ["--", "python", "train.py"]
+    assert called["args"] == ["wait", "--", "python", "train.py"]
     assert "no forecast available" in capsys.readouterr().out
 
 
@@ -171,7 +169,8 @@ def test_finish_by_shorter_than_duration_is_rejected(monkeypatch, capsys, no_net
         )
 
 
-def test_only_the_leading_subcommand_name_is_stripped(monkeypatch, no_network):
+def test_the_context_args_reach_the_monitor_untouched(monkeypatch, no_network):
+    # run_and_monitor strips its own subcommand prefixes, so wait must not.
     _patch_forecast(monkeypatch, [100, 300, 300])
     called = {}
     monkeypatch.setattr(
@@ -183,7 +182,7 @@ def test_only_the_leading_subcommand_name_is_stripped(monkeypatch, no_network):
         SimpleNamespace(args=["wait", "--", "make", "wait"]), duration="1h"
     )
 
-    assert called["args"] == ["--", "make", "wait"]
+    assert called["args"] == ["wait", "--", "make", "wait"]
 
 
 def test_sleeps_until_the_green_window_then_delegates(monkeypatch, no_network):
@@ -205,7 +204,7 @@ def test_sleeps_until_the_green_window_then_delegates(monkeypatch, no_network):
 
     assert len(slept) == 1
     assert 2 * 3600 - 60 < slept[0] <= 2 * 3600
-    assert called["args"] == ["python", "train.py"]
+    assert called["args"] == ["wait", "python", "train.py"]
     assert called["measure_power_secs"] == 15
 
 

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -209,7 +209,7 @@ def test_sleeps_until_the_green_window_then_delegates(monkeypatch, no_network):
     assert called["measure_power_secs"] == 15
 
 
-def test_keyboard_interrupt_during_wait_runs_immediately(monkeypatch, no_network):
+def test_keyboard_interrupt_during_wait_aborts(monkeypatch, no_network):
     _patch_forecast(monkeypatch, [300, 300, 100, 100, 300])
 
     def _interrupt(seconds):
@@ -222,8 +222,10 @@ def test_keyboard_interrupt_during_wait_runs_immediately(monkeypatch, no_network
         lambda ctx, **kwargs: called.setdefault("ran", True),
     )
 
-    wait_module.wait_for_green_window(
-        SimpleNamespace(args=["python", "train.py"]), duration="2h", deadline="6h"
-    )
+    with pytest.raises(typer.Exit) as exc_info:
+        wait_module.wait_for_green_window(
+            SimpleNamespace(args=["python", "train.py"]), duration="2h", deadline="6h"
+        )
 
-    assert called["ran"] is True
+    assert exc_info.value.exit_code == 130
+    assert called == {}

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -1,0 +1,169 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+import typer
+
+from codecarbon.cli import wait as wait_module
+from codecarbon.core.intensity_forecast import Forecast, IntensityPoint
+
+
+def _forecast(values, start):
+    return Forecast(
+        zone="FR",
+        points=[
+            IntensityPoint(at=start + timedelta(hours=i), g_co2e_per_kwh=v)
+            for i, v in enumerate(values)
+        ],
+        source="test",
+        fetched_at=start,
+    )
+
+
+@pytest.fixture
+def no_network(monkeypatch):
+    """Never let the wait command reach geolocation or the intensity API."""
+    monkeypatch.setattr(
+        "codecarbon.external.geography.GeoMetadata.from_geo_js",
+        classmethod(lambda cls, url: SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        "codecarbon.core.config.get_hierarchical_config",
+        lambda: {"electricitymaps_api_token": "tok"},
+    )
+
+
+def _patch_forecast(monkeypatch, values):
+    now = datetime.now(timezone.utc)
+    monkeypatch.setattr(
+        "codecarbon.core.intensity_forecast.get_forecast",
+        lambda geo, **kwargs: _forecast(values, now),
+    )
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("90m", timedelta(minutes=90)),
+        ("2h", timedelta(hours=2)),
+        ("1h30m", timedelta(hours=1, minutes=30)),
+        ("45s", timedelta(seconds=45)),
+        ("3600", timedelta(hours=1)),
+    ],
+)
+def test_parse_duration(value, expected):
+    assert wait_module.parse_duration(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "soon", "2 hours", "h", "-1h"])
+def test_parse_duration_rejects_garbage(value):
+    with pytest.raises(ValueError):
+        wait_module.parse_duration(value)
+
+
+def test_dry_run_prints_recommendation_and_exits(monkeypatch, capsys, no_network):
+    _patch_forecast(monkeypatch, [300, 300, 100, 100, 300])
+    slept = []
+    monkeypatch.setattr(wait_module.time, "sleep", lambda s: slept.append(s))
+
+    with pytest.raises(typer.Exit) as exc:
+        wait_module.wait_for_green_window(
+            SimpleNamespace(args=[]), duration="2h", deadline="6h", dry_run=True
+        )
+
+    assert exc.value.exit_code == 0
+    assert slept == []
+    out = capsys.readouterr().out
+    assert "Best start" in out
+    assert "saves ~67%" in out
+
+
+def test_invalid_duration_exits_with_error(monkeypatch, capsys, no_network):
+    with pytest.raises(typer.Exit) as exc:
+        wait_module.wait_for_green_window(
+            SimpleNamespace(args=[]), duration="whenever", dry_run=True
+        )
+    assert exc.value.exit_code == 1
+
+
+def test_no_forecast_runs_now(monkeypatch, capsys, no_network):
+    monkeypatch.setattr(
+        "codecarbon.core.intensity_forecast.get_forecast", lambda geo, **kwargs: None
+    )
+    slept = []
+    monkeypatch.setattr(wait_module.time, "sleep", lambda s: slept.append(s))
+    called = {}
+    monkeypatch.setattr(
+        "codecarbon.cli.monitor.run_and_monitor",
+        lambda ctx, **kwargs: called.setdefault("args", list(ctx.args)),
+    )
+
+    wait_module.wait_for_green_window(
+        SimpleNamespace(args=["wait", "--", "python", "train.py"])
+    )
+
+    assert slept == []
+    assert called["args"] == ["--", "python", "train.py"]
+    assert "no forecast available" in capsys.readouterr().out
+
+
+def test_threshold_short_circuits_the_wait(monkeypatch, capsys, no_network):
+    _patch_forecast(monkeypatch, [120, 300, 50, 50])
+    slept = []
+    monkeypatch.setattr(wait_module.time, "sleep", lambda s: slept.append(s))
+    monkeypatch.setattr(
+        "codecarbon.cli.monitor.run_and_monitor", lambda ctx, **kwargs: None
+    )
+
+    wait_module.wait_for_green_window(
+        SimpleNamespace(args=["python", "train.py"]),
+        duration="1h",
+        deadline="6h",
+        threshold=150,
+    )
+
+    assert slept == []
+    assert "running now" in capsys.readouterr().out
+
+
+def test_sleeps_until_the_green_window_then_delegates(monkeypatch, no_network):
+    _patch_forecast(monkeypatch, [300, 300, 100, 100, 300])
+    slept = []
+    monkeypatch.setattr(wait_module.time, "sleep", lambda s: slept.append(s))
+    called = {}
+    monkeypatch.setattr(
+        "codecarbon.cli.monitor.run_and_monitor",
+        lambda ctx, **kwargs: called.update(kwargs, args=list(ctx.args)),
+    )
+
+    wait_module.wait_for_green_window(
+        SimpleNamespace(args=["wait", "python", "train.py"]),
+        duration="2h",
+        deadline="6h",
+        measure_power_secs=15,
+    )
+
+    assert len(slept) == 1
+    assert 2 * 3600 - 60 < slept[0] <= 2 * 3600
+    assert called["args"] == ["python", "train.py"]
+    assert called["measure_power_secs"] == 15
+
+
+def test_keyboard_interrupt_during_wait_runs_immediately(monkeypatch, no_network):
+    _patch_forecast(monkeypatch, [300, 300, 100, 100, 300])
+
+    def _interrupt(seconds):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(wait_module.time, "sleep", _interrupt)
+    called = {}
+    monkeypatch.setattr(
+        "codecarbon.cli.monitor.run_and_monitor",
+        lambda ctx, **kwargs: called.setdefault("ran", True),
+    )
+
+    wait_module.wait_for_green_window(
+        SimpleNamespace(args=["python", "train.py"]), duration="2h", deadline="6h"
+    )
+
+    assert called["ran"] is True

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -33,11 +33,15 @@ def no_network(monkeypatch):
     )
 
 
-def _patch_forecast(monkeypatch, values):
+def _patch_forecast(monkeypatch, values, now_intensity=None):
     now = datetime.now(timezone.utc)
     monkeypatch.setattr(
         "codecarbon.core.intensity_forecast.get_forecast",
         lambda geo, **kwargs: _forecast(values, now),
+    )
+    monkeypatch.setattr(
+        "codecarbon.core.electricitymaps_api.get_carbon_intensity",
+        lambda geo, token="": values[0] if now_intensity is None else now_intensity,
     )
 
 
@@ -124,6 +128,38 @@ def test_threshold_short_circuits_the_wait(monkeypatch, capsys, no_network):
 
     assert slept == []
     assert "running now" in capsys.readouterr().out
+
+
+def test_threshold_uses_the_live_intensity_not_the_forecast(
+    monkeypatch, capsys, no_network
+):
+    # The first forecast point is above the threshold, the live grid is below.
+    _patch_forecast(monkeypatch, [300, 300, 100, 100], now_intensity=120)
+    monkeypatch.setattr(wait_module.time, "sleep", lambda s: pytest.fail("slept"))
+    monkeypatch.setattr(
+        "codecarbon.cli.monitor.run_and_monitor", lambda ctx, **kwargs: None
+    )
+
+    wait_module.wait_for_green_window(
+        SimpleNamespace(args=[]), duration="1h", deadline="6h", threshold=150
+    )
+
+    assert "running now" in capsys.readouterr().out
+
+
+def test_only_the_leading_subcommand_name_is_stripped(monkeypatch, no_network):
+    _patch_forecast(monkeypatch, [100, 300, 300])
+    called = {}
+    monkeypatch.setattr(
+        "codecarbon.cli.monitor.run_and_monitor",
+        lambda ctx, **kwargs: called.setdefault("args", list(ctx.args)),
+    )
+
+    wait_module.wait_for_green_window(
+        SimpleNamespace(args=["wait", "--", "make", "wait"]), duration="1h"
+    )
+
+    assert called["args"] == ["--", "make", "wait"]
 
 
 def test_sleeps_until_the_green_window_then_delegates(monkeypatch, no_network):

--- a/tests/test_intensity_forecast.py
+++ b/tests/test_intensity_forecast.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import responses
 
-from codecarbon.core import electricitymaps_api, intensity_forecast
+from codecarbon.core import electricitymaps_api
 from codecarbon.core.intensity_forecast import (
     Forecast,
     IntensityPoint,
@@ -22,8 +22,6 @@ def _forecast(values):
             IntensityPoint(at=BASE + timedelta(hours=i), g_co2e_per_kwh=v)
             for i, v in enumerate(values)
         ],
-        source="test",
-        fetched_at=BASE,
     )
 
 
@@ -78,7 +76,7 @@ class TestGetForecast(unittest.TestCase):
         )
         responses.add(
             responses.GET,
-            intensity_forecast.FORECAST_URL,
+            electricitymaps_api.FORECAST_URL,
             json=_payload([100]),
             status=200,
         )
@@ -89,14 +87,13 @@ class TestGetForecast(unittest.TestCase):
     def test_parses_forecast(self):
         responses.add(
             responses.GET,
-            intensity_forecast.FORECAST_URL,
+            electricitymaps_api.FORECAST_URL,
             json=_payload([100, 200, 50]),
             status=200,
         )
         forecast = get_forecast(self._geo, token="tok")
         assert forecast is not None
         assert forecast.zone == "FR"
-        assert forecast.source == "electricitymaps"
         assert [p.g_co2e_per_kwh for p in forecast.points] == [100, 200, 50]
         assert all(p.at.tzinfo is not None for p in forecast.points)
         assert responses.calls[0].request.headers["auth-token"] == "tok"
@@ -106,7 +103,7 @@ class TestGetForecast(unittest.TestCase):
     def test_uses_lat_lon_when_available(self):
         responses.add(
             responses.GET,
-            intensity_forecast.FORECAST_URL,
+            electricitymaps_api.FORECAST_URL,
             json=_payload([100]),
             status=200,
         )
@@ -120,7 +117,7 @@ class TestGetForecast(unittest.TestCase):
         payload["forecast"][0]["datetime"] = "2999-01-01T03:00:00"
         responses.add(
             responses.GET,
-            intensity_forecast.FORECAST_URL,
+            electricitymaps_api.FORECAST_URL,
             json=payload,
             status=200,
         )
@@ -131,7 +128,7 @@ class TestGetForecast(unittest.TestCase):
     def test_horizon_truncates_points(self):
         responses.add(
             responses.GET,
-            intensity_forecast.FORECAST_URL,
+            electricitymaps_api.FORECAST_URL,
             json=_payload([100, 200, 300, 400]),
             status=200,
         )
@@ -142,7 +139,7 @@ class TestGetForecast(unittest.TestCase):
     def test_error_status_returns_none(self):
         responses.add(
             responses.GET,
-            intensity_forecast.FORECAST_URL,
+            electricitymaps_api.FORECAST_URL,
             json={"error": "no access"},
             status=403,
         )
@@ -152,7 +149,7 @@ class TestGetForecast(unittest.TestCase):
     def test_malformed_payload_returns_none(self):
         responses.add(
             responses.GET,
-            intensity_forecast.FORECAST_URL,
+            electricitymaps_api.FORECAST_URL,
             json={"unexpected": True},
             status=200,
         )
@@ -162,7 +159,7 @@ class TestGetForecast(unittest.TestCase):
     def test_empty_forecast_returns_none(self):
         responses.add(
             responses.GET,
-            intensity_forecast.FORECAST_URL,
+            electricitymaps_api.FORECAST_URL,
             json={"zone": "FR", "forecast": []},
             status=200,
         )
@@ -231,7 +228,7 @@ class TestBestWindow(unittest.TestCase):
             IntensityPoint(at=BASE + timedelta(hours=3), g_co2e_per_kwh=100),
             IntensityPoint(at=BASE + timedelta(hours=4), g_co2e_per_kwh=50),
         ]
-        forecast = Forecast(zone="FR", points=points, source="test", fetched_at=BASE)
+        forecast = Forecast(zone="FR", points=points)
         # The forecast covers one hour, not three, past its last point, so the
         # cheapest-looking window (starting at the last point) is not complete.
         start, _ = best_window(forecast, timedelta(hours=2))

--- a/tests/test_intensity_forecast.py
+++ b/tests/test_intensity_forecast.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import responses
 
-from codecarbon.core import intensity_forecast
+from codecarbon.core import electricitymaps_api, intensity_forecast
 from codecarbon.core.intensity_forecast import (
     Forecast,
     IntensityPoint,
@@ -45,6 +45,10 @@ def _payload(values, start=None):
 
 class TestGetForecast(unittest.TestCase):
     def setUp(self) -> None:
+        # The forecast shares the Electricity Maps failure cooldown with the
+        # current-intensity path, so a failing test must not starve the next.
+        electricitymaps_api.reset_cache()
+        self.addCleanup(electricitymaps_api.reset_cache)
         self._geo = GeoMetadata(
             country_iso_code="FRA",
             country_name="France",
@@ -62,6 +66,20 @@ class TestGetForecast(unittest.TestCase):
 
     def test_no_token_returns_none_without_calling_api(self):
         assert get_forecast(self._geo, token=None) is None
+
+    @responses.activate
+    def test_shared_cooldown_skips_the_request(self):
+        # A failure on the current-intensity path must back the forecast off
+        # too: no HTTP request, and still a None instead of a raise.
+        electricitymaps_api._start_cooldown()
+        responses.add(
+            responses.GET,
+            intensity_forecast.FORECAST_URL,
+            json=_payload([100]),
+            status=200,
+        )
+        assert get_forecast(self._geo, token="tok") is None
+        assert len(responses.calls) == 0
 
     @responses.activate
     def test_parses_forecast(self):

--- a/tests/test_intensity_forecast.py
+++ b/tests/test_intensity_forecast.py
@@ -217,3 +217,22 @@ class TestBestWindow(unittest.TestCase):
         start, mean = best_window(forecast, timedelta(hours=10))
         assert start == BASE
         assert mean == 300
+
+    def test_partial_last_hour_is_weighted_by_overlap(self):
+        # 90 minutes over hourly points: the second hour only counts for half.
+        forecast = _forecast([100, 300, 300])
+        start, mean = best_window(forecast, timedelta(minutes=90))
+        assert start == BASE
+        assert mean == (100 * 60 + 300 * 30) / 90
+
+    def test_irregular_gaps_do_not_stretch_the_coverage(self):
+        points = [
+            IntensityPoint(at=BASE, g_co2e_per_kwh=300),
+            IntensityPoint(at=BASE + timedelta(hours=3), g_co2e_per_kwh=100),
+            IntensityPoint(at=BASE + timedelta(hours=4), g_co2e_per_kwh=50),
+        ]
+        forecast = Forecast(zone="FR", points=points, source="test", fetched_at=BASE)
+        # The forecast covers one hour, not three, past its last point, so the
+        # cheapest-looking window (starting at the last point) is not complete.
+        start, _ = best_window(forecast, timedelta(hours=2))
+        assert start == BASE + timedelta(hours=3)

--- a/tests/test_intensity_forecast.py
+++ b/tests/test_intensity_forecast.py
@@ -183,18 +183,28 @@ class TestBestWindow(unittest.TestCase):
         start, _ = best_window(forecast, timedelta(hours=2))
         assert start == BASE + timedelta(hours=3)
 
-    def test_deadline_shorter_than_duration_falls_back_to_now(self):
+    def test_deadline_before_the_next_point_leaves_only_now(self):
         forecast = _forecast([300, 100, 100])
         start, mean = best_window(
             forecast, timedelta(hours=2), deadline=BASE + timedelta(minutes=30)
         )
         assert start == BASE
-        assert mean == 300
+        assert mean == 200
+
+    def test_deadline_caps_the_start_time_not_the_end(self):
+        # The deadline is the latest acceptable start: a window starting at it
+        # is allowed even though it finishes afterwards.
+        forecast = _forecast([300, 200, 50, 50])
+        start, mean = best_window(
+            forecast, timedelta(hours=2), deadline=BASE + timedelta(hours=2)
+        )
+        assert start == BASE + timedelta(hours=2)
+        assert mean == 50
 
     def test_deadline_restricts_the_search(self):
         forecast = _forecast([300, 200, 50, 50])
         start, _ = best_window(
-            forecast, timedelta(hours=1), deadline=BASE + timedelta(hours=2)
+            forecast, timedelta(hours=1), deadline=BASE + timedelta(hours=1)
         )
         assert start == BASE + timedelta(hours=1)
 

--- a/tests/test_intensity_forecast.py
+++ b/tests/test_intensity_forecast.py
@@ -1,0 +1,187 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+import responses
+
+from codecarbon.core import intensity_forecast
+from codecarbon.core.intensity_forecast import (
+    Forecast,
+    IntensityPoint,
+    best_window,
+    get_forecast,
+)
+from codecarbon.external.geography import GeoMetadata
+
+BASE = datetime(2026, 8, 13, 0, 0, tzinfo=timezone.utc)
+
+
+def _forecast(values):
+    return Forecast(
+        zone="FR",
+        points=[
+            IntensityPoint(at=BASE + timedelta(hours=i), g_co2e_per_kwh=v)
+            for i, v in enumerate(values)
+        ],
+        source="test",
+        fetched_at=BASE,
+    )
+
+
+def _payload(values, start=None):
+    start = start or datetime.now(timezone.utc)
+    return {
+        "zone": "FR",
+        "forecast": [
+            {
+                "datetime": (start + timedelta(hours=i))
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "carbonIntensity": v,
+            }
+            for i, v in enumerate(values)
+        ],
+    }
+
+
+class TestGetForecast(unittest.TestCase):
+    def setUp(self) -> None:
+        self._geo = GeoMetadata(
+            country_iso_code="FRA",
+            country_name="France",
+            region=None,
+            country_2letter_iso_code="FR",
+        )
+        self._geo_latlon = GeoMetadata(
+            country_iso_code="FRA",
+            country_name="France",
+            region=None,
+            country_2letter_iso_code="FR",
+            latitude=48.85,
+            longitude=2.35,
+        )
+
+    def test_no_token_returns_none_without_calling_api(self):
+        assert get_forecast(self._geo, token=None) is None
+
+    @responses.activate
+    def test_parses_forecast(self):
+        responses.add(
+            responses.GET,
+            intensity_forecast.FORECAST_URL,
+            json=_payload([100, 200, 50]),
+            status=200,
+        )
+        forecast = get_forecast(self._geo, token="tok")
+        assert forecast is not None
+        assert forecast.zone == "FR"
+        assert forecast.source == "electricitymaps"
+        assert [p.g_co2e_per_kwh for p in forecast.points] == [100, 200, 50]
+        assert all(p.at.tzinfo is not None for p in forecast.points)
+        assert responses.calls[0].request.headers["auth-token"] == "tok"
+        assert "countryCode=FR" in responses.calls[0].request.url
+
+    @responses.activate
+    def test_uses_lat_lon_when_available(self):
+        responses.add(
+            responses.GET,
+            intensity_forecast.FORECAST_URL,
+            json=_payload([100]),
+            status=200,
+        )
+        get_forecast(self._geo_latlon, token="tok")
+        url = responses.calls[0].request.url
+        assert "lat=48.85" in url and "lon=2.35" in url
+
+    @responses.activate
+    def test_naive_timestamps_are_treated_as_utc(self):
+        payload = _payload([100])
+        payload["forecast"][0]["datetime"] = "2999-01-01T03:00:00"
+        responses.add(
+            responses.GET,
+            intensity_forecast.FORECAST_URL,
+            json=payload,
+            status=200,
+        )
+        forecast = get_forecast(self._geo, token="tok", horizon_hours=24 * 365 * 1000)
+        assert forecast.points[0].at.tzinfo == timezone.utc
+
+    @responses.activate
+    def test_horizon_truncates_points(self):
+        responses.add(
+            responses.GET,
+            intensity_forecast.FORECAST_URL,
+            json=_payload([100, 200, 300, 400]),
+            status=200,
+        )
+        forecast = get_forecast(self._geo, token="tok", horizon_hours=2)
+        assert len(forecast.points) <= 3
+
+    @responses.activate
+    def test_error_status_returns_none(self):
+        responses.add(
+            responses.GET,
+            intensity_forecast.FORECAST_URL,
+            json={"error": "no access"},
+            status=403,
+        )
+        assert get_forecast(self._geo, token="tok") is None
+
+    @responses.activate
+    def test_malformed_payload_returns_none(self):
+        responses.add(
+            responses.GET,
+            intensity_forecast.FORECAST_URL,
+            json={"unexpected": True},
+            status=200,
+        )
+        assert get_forecast(self._geo, token="tok") is None
+
+    @responses.activate
+    def test_empty_forecast_returns_none(self):
+        responses.add(
+            responses.GET,
+            intensity_forecast.FORECAST_URL,
+            json={"zone": "FR", "forecast": []},
+            status=200,
+        )
+        assert get_forecast(self._geo, token="tok") is None
+
+
+class TestBestWindow(unittest.TestCase):
+    def test_picks_the_trough(self):
+        forecast = _forecast([300, 250, 100, 90, 280, 300])
+        start, mean = best_window(forecast, timedelta(hours=2))
+        assert start == BASE + timedelta(hours=2)
+        assert mean == 95
+
+    def test_flat_series_picks_now(self):
+        forecast = _forecast([200] * 5)
+        start, mean = best_window(forecast, timedelta(hours=2))
+        assert start == BASE
+        assert mean == 200
+
+    def test_decreasing_series_picks_last_complete_window(self):
+        forecast = _forecast([500, 400, 300, 200, 100])
+        start, _ = best_window(forecast, timedelta(hours=2))
+        assert start == BASE + timedelta(hours=3)
+
+    def test_deadline_shorter_than_duration_falls_back_to_now(self):
+        forecast = _forecast([300, 100, 100])
+        start, mean = best_window(
+            forecast, timedelta(hours=2), deadline=BASE + timedelta(minutes=30)
+        )
+        assert start == BASE
+        assert mean == 300
+
+    def test_deadline_restricts_the_search(self):
+        forecast = _forecast([300, 200, 50, 50])
+        start, _ = best_window(
+            forecast, timedelta(hours=1), deadline=BASE + timedelta(hours=2)
+        )
+        assert start == BASE + timedelta(hours=1)
+
+    def test_duration_longer_than_horizon_falls_back_to_now(self):
+        forecast = _forecast([300, 100])
+        start, mean = best_window(forecast, timedelta(hours=10))
+        assert start == BASE
+        assert mean == 300

--- a/tests/test_intensity_forecast.py
+++ b/tests/test_intensity_forecast.py
@@ -71,7 +71,11 @@ class TestGetForecast(unittest.TestCase):
     def test_shared_cooldown_skips_the_request(self):
         # A failure on the current-intensity path must back the forecast off
         # too: no HTTP request, and still a None instead of a raise.
-        electricitymaps_api._start_cooldown()
+        electricitymaps_api._start_cooldown(
+            electricitymaps_api._cache_key(
+                electricitymaps_api.location_params(self._geo), "tok"
+            )
+        )
         responses.add(
             responses.GET,
             intensity_forecast.FORECAST_URL,


### PR DESCRIPTION
A deliberately narrow first slice of carbon-aware scheduling (#1356).

> Stacks on #1358: `wait` reuses that PR's cached, backed-off Electricity Maps client instead of opening a second HTTP path. Review #1358 first; this PR targets `feat/intensity-providers` and its diff here is only the `wait` feature.

## What is in it

- `codecarbon/core/intensity_forecast.py` — `IntensityPoint` / `Forecast` dataclasses, `get_forecast()` against the Electricity Maps `/carbon-intensity/forecast` endpoint (going through #1358's shared `request()`, so a failing location backs off once for the whole process rather than once per caller), and `best_window()`, a pure sliding-mean window search with no I/O.
- `codecarbon/cli/wait.py` + a `wait` command in `codecarbon/cli/main.py`:

```console
# print the recommendation and exit
$ codecarbon wait --dry-run --deadline 24h --duration 90m
🌱 Best start: 2026-08-13 03:00 UTC  (112 gCO2e/kWh, now: 341)  -> saves ~67%

# block until the greenest window, then run under measurement
$ codecarbon wait --deadline 12h --duration 2h -- python train.py

# the job must be *finished* within 8 hours, and takes about 2
$ codecarbon wait --finish-by 8h --duration 2h -- python train.py
```

`--deadline` is the latest acceptable **start**, so `--deadline 12h --duration 2h` may leave the job running 14 hours from now. `--finish-by` is the complement most people actually mean: it bounds the end, and is implemented as `finish_by - duration` feeding the same search. A `--finish-by` shorter than `--duration` is rejected.

**One API call.** `wait` fetches the forecast and nothing else. The "now" figure printed, and the value `--threshold` compares against, is the first forecast point — the current period as the forecast sees it. An earlier revision also hit `/carbon-intensity/latest` for a live reading, which was a second network round trip in service of a percentage.

The blocking form delegates to the existing `run_and_monitor`, so measurement, CSV output and exit-code propagation are unchanged. The tracker only starts after the sleep, so a waiting process holds no lock. Ctrl-C during the wait starts the job immediately rather than aborting.

`get_forecast` never raises: no token, a non-200, a malformed payload or an empty forecast all return `None`, and every caller degrades to running now. A job is never blocked on a missing credential.

## What is deliberately not in it

- **The `@carbon_aware` decorator / `wait_for_green_window` context manager.** The CLI is the smaller surface and validates whether anyone wants the sleeping behaviour before we own a second one.
- **`deferred_seconds` / `avoided_emissions` on `EmissionsData`.** Worth having, but they should ship with a proven blocking path — two always-zero CSV columns are a schema change for no reader.
- **A static fallback diurnal profile** for users without a token. It would broaden reach a lot but risks systematically wrong advice: solar-heavy zones trough at midday, wind-heavy zones at night.
- **Mid-wait re-evaluation** as the forecast updates, and region shifting.

## What is blocked on the intensity-provider work

Electricity Maps is currently the only source that can serve a forecast, and only for users holding a paid token. That caps how much of the audience this feature can reach, and it is why this is a narrow slice rather than the full design in #1356.

`get_forecast` is written to be absorbed: once pluggable intensity providers land it should become an optional `forecast()` method on the provider protocol rather than a second HTTP client, and the HTTP lives in one place (#1358's `request()`) so that move is mechanical.

## Tests

`tests/test_intensity_forecast.py` (14) and `tests/cli/test_wait.py` (22), all passing, no network — HTTP is stubbed with `responses` as in `tests/test_electricitymaps_api.py`, and geolocation, config and `time.sleep` are monkeypatched in the CLI tests. Coverage includes payload parsing, lat/lon vs `countryCode` selection, naive-vs-aware timestamps, horizon truncation, every failure mode returning `None`, the shared cooldown skipping the request, the window search (trough, flat, monotonic, deadline shorter than duration, duration longer than horizon), `--finish-by` bounding the end and its rejection when shorter than `--duration`, the duration parser, the threshold short-circuit taking no second API call, and delegation to `run_and_monitor` with the residual command.

```
uv run pytest tests/cli/test_wait.py tests/test_intensity_forecast.py -q   # 36 passed
```

Docs: a `codecarbon wait` section in `docs/reference/cli.md` and a pointer from `docs/tutorials/cli.md`.

Refs #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)
