### PR TITLE
fix: send and store real sub-second emission durations

### DIFF
--- a/carbonserver/carbonserver/api/schemas.py
+++ b/carbonserver/carbonserver/api/schemas.py
@@ -56,7 +56,7 @@ class User(UserBase):
 class EmissionBase(BaseModel):
     timestamp: datetime
     run_id: UUID
-    duration: int = Field(
+    duration: float = Field(
         ..., gt=0, description="The duration must be greater than zero"
     )
     emissions_sum: Optional[float] = Field(
@@ -283,7 +283,7 @@ class ExperimentReport(ExperimentBase):
     gpu_energy: float
     ram_energy: float
     energy_consumed: float
-    duration: int
+    duration: float
     emissions_rate: float
     emissions_count: int
     cpu_utilization_percent: Optional[float] = None
@@ -396,7 +396,7 @@ class ProjectReport(ProjectBase):
     gpu_energy: float
     ram_energy: float
     energy_consumed: float
-    duration: int
+    duration: float
     emissions_rate: float
     emissions_count: int
     cpu_utilization_percent: Optional[float] = None
@@ -443,7 +443,7 @@ class OrganizationReport(OrganizationBase):
     gpu_energy: float
     ram_energy: float
     energy_consumed: float
-    duration: int
+    duration: float
     emissions_rate: float
     emissions_count: int
     cpu_utilization_percent: Optional[float] = None

--- a/carbonserver/tests/api/test_schema_compatibility.py
+++ b/carbonserver/tests/api/test_schema_compatibility.py
@@ -118,3 +118,27 @@ def test_client_create_payloads_validate_against_server_schemas(
     client_payload, server_schema
 ):
     server_schema.model_validate(dataclasses.asdict(client_payload))
+
+
+def test_millisecond_duration_survives_client_to_server():
+    """A single FastAPI request lasts milliseconds and must not be rounded away."""
+    payload = client_schemas.EmissionCreate(
+        timestamp="2021-04-04T08:43:00+02:00",
+        run_id="40088f1a-d28e-4980-8d80-bf5600056a14",
+        duration=0.0042,
+        emissions_sum=1544.54,
+        emissions_rate=1.548444,
+        cpu_power=0.3,
+        gpu_power=0.0,
+        ram_power=0.15,
+        cpu_energy=55.21874,
+        gpu_energy=0.0,
+        ram_energy=2.0,
+        energy_consumed=57.21874,
+    )
+
+    validated = server_schemas.EmissionCreate.model_validate(
+        dataclasses.asdict(payload)
+    )
+
+    assert validated.duration == 0.0042

--- a/codecarbon/core/api_client.py
+++ b/codecarbon/core/api_client.py
@@ -189,15 +189,16 @@ class ApiClient:  # (AsyncClient)
                     "ApiClient.add_emission still no run_id, aborting for this time !"
                 )
             return False
-        if carbon_emission["duration"] < 1:
+        if carbon_emission["duration"] <= 0:
+            # The server declares duration as gt=0, so this would 422.
             logger.warning(
-                "ApiClient : emissions not sent because of a duration smaller than 1."
+                "ApiClient : emissions not sent because the duration is not positive."
             )
             return False
         emission = EmissionCreate(
             timestamp=get_datetime_with_timezone(),
             run_id=self.run_id,
-            duration=int(carbon_emission["duration"]),
+            duration=carbon_emission["duration"],
             emissions_sum=carbon_emission["emissions"],
             emissions_rate=carbon_emission["emissions_rate"],
             cpu_power=carbon_emission["cpu_power"],

--- a/codecarbon/core/schemas.py
+++ b/codecarbon/core/schemas.py
@@ -12,7 +12,7 @@ from uuid import UUID
 class EmissionBase:
     timestamp: str
     run_id: str
-    duration: int
+    duration: float
     emissions_sum: float
     emissions_rate: float
     cpu_power: float

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -235,31 +235,65 @@ class TestApi(unittest.TestCase):
             )
         )
 
-    def test_add_emission_skips_short_duration(self):
-        api = ApiClient(
-            endpoint_url="http://test.com",
-            experiment_id="exp-1",
-            conf=conf,
-            create_run_automatically=False,
-        )
-        api.run_id = "run-1"
-
-        self.assertFalse(
-            api.add_emission(
-                {
-                    "duration": 0.5,
-                    "emissions": 1.0,
-                    "emissions_rate": 1.0,
-                    "cpu_power": 1.0,
-                    "gpu_power": 0.0,
-                    "ram_power": 0.5,
-                    "cpu_energy": 0.1,
-                    "gpu_energy": 0.0,
-                    "ram_energy": 0.1,
-                    "energy_consumed": 0.2,
-                }
+    def test_add_emission_sends_millisecond_duration_unchanged(self):
+        """A single FastAPI request lasts milliseconds: send it, do not round it."""
+        with requests_mock.Mocker() as m:
+            m.post("http://test.com/emissions", json={"id": "em-1"}, status_code=201)
+            api = ApiClient(
+                endpoint_url="http://test.com",
+                experiment_id="exp-1",
+                conf=conf,
+                create_run_automatically=False,
             )
-        )
+            api.run_id = "run-1"
+
+            self.assertTrue(
+                api.add_emission(
+                    {
+                        "duration": 0.0042,
+                        "emissions": 1.0,
+                        "emissions_rate": 1.0,
+                        "cpu_power": 1.0,
+                        "gpu_power": 0.0,
+                        "ram_power": 0.5,
+                        "cpu_energy": 0.1,
+                        "gpu_energy": 0.0,
+                        "ram_energy": 0.1,
+                        "energy_consumed": 0.2,
+                    }
+                )
+            )
+            self.assertEqual(m.last_request.json()["duration"], 0.0042)
+
+    def test_add_emission_skips_zero_duration(self):
+        """A zero-length flush would be a 422: the server requires duration > 0."""
+        with requests_mock.Mocker() as m:
+            m.post("http://test.com/emissions", json={"id": "em-1"}, status_code=201)
+            api = ApiClient(
+                endpoint_url="http://test.com",
+                experiment_id="exp-1",
+                conf=conf,
+                create_run_automatically=False,
+            )
+            api.run_id = "run-1"
+
+            self.assertFalse(
+                api.add_emission(
+                    {
+                        "duration": 0.0,
+                        "emissions": 0.0,
+                        "emissions_rate": 0.0,
+                        "cpu_power": 1.0,
+                        "gpu_power": 0.0,
+                        "ram_power": 0.5,
+                        "cpu_energy": 0.0,
+                        "gpu_energy": 0.0,
+                        "ram_energy": 0.0,
+                        "energy_consumed": 0.0,
+                    }
+                )
+            )
+            self.assertFalse(m.called)
 
     def test_add_emission_raises_on_unsuccessful_post(self):
         with requests_mock.Mocker() as m:


### PR DESCRIPTION
Extracted from #1203 (`feat/add-fastapi-middleware`), which bundled this with unrelated FastAPI middleware work. It stands alone and can be reviewed and merged independently; #1203 will be rebased to drop the duplicated hunks.

## What

- `duration` becomes `float` instead of `int` in `codecarbon/core/schemas.py` and `carbonserver/carbonserver/api/schemas.py` (`EmissionBase`).
- `ApiClient.add_emission` no longer refuses emissions shorter than one second, and no longer truncates the duration with `int(...)`. It does still skip a **non-positive** duration: the server declares `duration` as `Field(..., gt=0)`, so a zero-length flush would be a 422. Skipping rather than clamping, because clamping would invent a duration that was never measured.
- `ExperimentReport`, `ProjectReport` and `OrganizationReport` widen `duration` from `int` to `float`.

## Why

The DB column and the ORM were **always** `Column(Float)` (`carbonserver/carbonserver/api/infra/database/sql_models.py`) — only the pydantic models claimed `int`. So nothing about storage changes here; the schemas are simply being made honest about what the database already holds. On the client side the `< 1` guard silently dropped any measurement shorter than a second, which is every short-lived task.

The report widening is not cosmetic: those endpoints `SUM()` a Float column into a field declared `int`. Today every stored duration happens to be a whole number, so it validates by luck. The first sub-second duration in the database makes the sum non-integral and the response model raises a validation error — a latent 500 on the experiment/project/organization report endpoints. Widening the reports is therefore part of this fix, not a separate cleanup.

**No DB migration is needed.** The `emissions.duration` column is already `Column(Float)` in `carbonserver/carbonserver/api/infra/database/sql_models.py` — this PR only changes the pydantic layer, the storage type is unchanged.

## Tests

- `carbonserver/tests/api/test_schema_compatibility.py::test_millisecond_duration_survives_client_to_server` — a client payload with `duration=0.0042` validates against the server schema unchanged.
- `tests/test_api_call.py::TestApi::test_add_emission_sends_millisecond_duration_unchanged` — replaces `test_add_emission_skips_short_duration`; asserts the POST body carries `0.0042`.

- `tests/test_api_call.py::TestApi::test_add_emission_skips_zero_duration` — a `duration=0.0` flush is dropped client-side and never reaches the server's `gt=0` validator.

Both fail on `master` (`ValidationError`, and `emissions not sent because of a duration smaller than 1`) and pass with the fix.

`uv run pytest tests/ -q --ignore=tests/test_viz_data.py` → 626 passed, 21 skipped. carbonserver unit tests → 108 passed. `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
