### PR TITLE
fix: raise geolocation API timeout and retry the primary API once

### DIFF
--- a/codecarbon/external/geography.py
+++ b/codecarbon/external/geography.py
@@ -12,6 +12,9 @@ import requests
 from codecarbon.core.cloud import get_env_cloud_details
 from codecarbon.external.logger import logger
 
+GEO_API_TIMEOUT: float = 5
+GEO_API_RETRIES: int = 1
+
 
 @dataclass
 class CloudMetadata:
@@ -88,10 +91,29 @@ class GeoMetadata:
             self.region,
         )
 
+    @staticmethod
+    def _get_geo_json(url: str, retries: int = 0) -> Dict:
+        """
+        Query a geolocation API, retrying only when the network itself fails,
+        so a slow or busy connection does not send us straight to the fallback.
+        """
+        for attempt in range(retries + 1):
+            try:
+                return requests.get(url, timeout=GEO_API_TIMEOUT).json()
+            except (
+                requests.exceptions.Timeout,
+                requests.exceptions.ConnectionError,
+            ) as e:
+                if attempt == retries:
+                    raise
+                logger.debug(
+                    f"Could not reach {url}, retrying ({attempt + 1}/{retries}) - Exception : {e}"
+                )
+
     @classmethod
     def from_geo_js(cls, url: str) -> "GeoMetadata":
         try:
-            response: Dict = requests.get(url, timeout=0.5).json()
+            response: Dict = cls._get_geo_json(url, retries=GEO_API_RETRIES)
 
             region = response.get("region", "").lower()
             if not region:
@@ -114,7 +136,7 @@ class GeoMetadata:
         geo_url_backup = "https://ipinfo.io/json"
 
         try:
-            geo_response: Dict = requests.get(geo_url_backup, timeout=0.5).json()
+            geo_response: Dict = cls._get_geo_json(geo_url_backup)
 
             # extract latitude and longitude from loc (e.g., "loc": "37.4056,-122.0775")
             loc = geo_response.get("loc", "").split(",")
@@ -140,7 +162,7 @@ class GeoMetadata:
         except Exception as e:
             # If both API calls fail, default to Canada
             logger.warning(
-                f"Unable to access geographical location through fallback API. Using 'Canada' as the default value - Exception : {e} - url={geo_url_backup}"
+                f"Unable to access geographical location through fallback API. Defaulting to Canada, so emissions will be computed with the Canadian carbon intensity - Exception : {e} - url={geo_url_backup}"
             )
 
             return cls(

--- a/tests/test_emissions_tracker.py
+++ b/tests/test_emissions_tracker.py
@@ -17,7 +17,7 @@ from codecarbon.emissions_tracker import (
     OfflineEmissionsTracker,
     track_emissions,
 )
-from codecarbon.external.geography import CloudMetadata
+from codecarbon.external.geography import GEO_API_RETRIES, CloudMetadata
 from codecarbon.output import BoAmpsOutput, CodeCarbonAPIOutput, OutputMethod
 from tests.fake_modules import pynvml as fake_pynvml
 from tests.testdata import (
@@ -289,7 +289,8 @@ class TestCarbonTracker(unittest.TestCase):
         tracker.start()
         heavy_computation(run_time_secs=2)
         emissions = tracker.stop()
-        self.assertEqual(2, mocked_requests_get.call_count)
+        # The primary API is tried once more before the backup one is called.
+        self.assertEqual(GEO_API_RETRIES + 2, mocked_requests_get.call_count)
         self.assertIsInstance(emissions, float)
         self.assertAlmostEqual(1.1037980397280433e-05, emissions, places=2)
 

--- a/tests/test_geography.py
+++ b/tests/test_geography.py
@@ -1,9 +1,14 @@
 import unittest
 from unittest import mock
 
+import requests
 import responses
 
-from codecarbon.external.geography import CloudMetadata, GeoMetadata
+from codecarbon.external.geography import (
+    GEO_API_TIMEOUT,
+    CloudMetadata,
+    GeoMetadata,
+)
 from tests.testdata import (
     CLOUD_METADATA_AWS,
     CLOUD_METADATA_AZURE,
@@ -117,6 +122,44 @@ class TestGeoMetadata(unittest.TestCase):
         self.assertEqual("USA", geo.country_iso_code)
         self.assertEqual("United States", geo.country_name)
         self.assertEqual("illinois", geo.region)
+
+    @responses.activate
+    def test_geo_metadata_retries_primary_api_on_timeout(self):
+        responses.add(
+            responses.GET,
+            self.geo_js_url,
+            body=requests.exceptions.Timeout("Read timed out"),
+        )
+        responses.add(responses.GET, self.geo_js_url, json=GEO_METADATA_USA, status=200)
+        responses.add(
+            responses.GET,
+            "https://ipinfo.io/json",
+            json=GEO_METADATA_USA_BACKUP,
+            status=200,
+        )
+
+        geo = GeoMetadata.from_geo_js(self.geo_js_url)
+
+        self.assertEqual("USA", geo.country_iso_code)
+        self.assertEqual("illinois", geo.region)
+        # The primary API answered on the second try, so the backup is never called.
+        self.assertEqual(
+            [self.geo_js_url, self.geo_js_url],
+            [call.request.url for call in responses.calls],
+        )
+
+    def test_geo_metadata_uses_configured_timeout(self):
+        mocked_response = mock.Mock()
+        mocked_response.json.return_value = GEO_METADATA_USA
+
+        with mock.patch(
+            "codecarbon.external.geography.requests.get", return_value=mocked_response
+        ) as mocked_get:
+            geo = GeoMetadata.from_geo_js(self.geo_js_url)
+
+        self.assertEqual("USA", geo.country_iso_code)
+        self.assertGreater(GEO_API_TIMEOUT, 0.5)
+        mocked_get.assert_called_once_with(self.geo_js_url, timeout=GEO_API_TIMEOUT)
 
     @responses.activate
     def test_geo_metadata_CANADA(self):


### PR DESCRIPTION
## Description
The geolocation lookup used a hardcoded 0.5 second timeout for the primary API (get.geojs.io) and for the backup one (ipinfo.io). Half a second is a small budget for a network call, so a healthy API can miss it and codecarbon drops to the backup, or to the hardcoded Canada default when the backup is slow too.

The timeout now lives in a `GEO_API_TIMEOUT` constant set to 5 seconds, following the same pattern as `ELECTRICITYMAPS_API_TIMEOUT` in `codecarbon/core/electricitymaps_api.py`. The primary API also gets one retry, limited to timeouts and connection errors, so a reply that arrives but does not parse still goes to the backup like before. The Canada default is untouched, its warning now says plainly that emissions will be computed with the Canadian carbon intensity.

## Related Issue
Fixes #854

## Motivation and Context
The reporter started eight trackers in parallel and six of them logged "Unable to access geographical location through primary API". Sleeping up to 10 seconds between processes was the workaround. With half a second to answer, a handful of trackers hitting the same API at once is enough to miss the deadline, and the wrong country means the wrong carbon intensity for the whole run.

## How Has This Been Tested?
I ran the package suite on Windows with `CODECARBON_ALLOW_MULTIPLE_RUNS=True pytest -m "not integ_test" tests/`, and 614 of the 615 collected tests pass. The one failure, `test_task_energy_with_live_update_interference`, fails the same way on master on this machine: it mocks CPU and RAM but not the GPU, and this laptop has a real NVIDIA card whose energy lands in the total. Three test modules need optional dev packages I could not install here, so they were left out of the run.

I added two tests in `tests/test_geography.py` and checked that both fail before the change. One has the primary API time out on the first call and answer on the second, asserting the backup is never called. The other asserts the request goes out with the constant instead of 0.5. I also bumped the expected request count in `test_carbon_tracker_timeout`, which counted the calls made when both APIs time out. black and isort are clean on the changed files.

## Screenshots (if appropriate):
Not applicable.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure

Please refer to [docs/how-to/ai-policy.md](https://docs.codecarbon.io/latest/how-to/ai_policy/) for detailed guidelines on how to disclose AI usage in your PR. Accurately completing this section is mandatory.

- [ ] ðŸŸ¥ AI-vibecoded: You cannot explain the logic. Car analogy : the car drive by itself, you are outside it and just tell it where to go.
- [x] ðŸŸ  AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [ ] â­ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] â™»ï¸ No AI used. Car analogy : you drive the car.

An AI coding agent wrote this patch and this description under my direction, and I read every line, ran the tests myself and can explain the change.

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[docs/how-to/contributing.md](https://docs.codecarbon.io/latest/how-to/contributing/)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.