### PR TITLE
fix: apply the documented coordinate rounding to all outputs, not just the API

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -55,6 +55,14 @@ if TYPE_CHECKING:
 
 _sentinel = object()
 
+# One decimal place, so about 11.1 km at the equator.
+_COORDINATE_PRECISION = 1
+
+
+def _round_coordinate(value: Optional[float]) -> Optional[float]:
+    """Reduce the precision of a latitude or longitude for privacy."""
+    return value if value is None else round(value, _COORDINATE_PRECISION)
+
 
 class BaseEmissionsTracker(ABC):
     """
@@ -382,8 +390,11 @@ class BaseEmissionsTracker(ABC):
         self._geo = self._get_geo_metadata()
         cloud: CloudMetadata = self._get_cloud_metadata()
         if cloud.is_on_private_infra:
-            self._conf["longitude"] = self._geo.longitude
-            self._conf["latitude"] = self._geo.latitude
+            # Reduce precision for privacy, see docs/reference/output.md.
+            # self._geo keeps the full precision coordinates, they are needed
+            # for the Electricity Maps carbon intensity lookup.
+            self._conf["longitude"] = _round_coordinate(self._geo.longitude)
+            self._conf["latitude"] = _round_coordinate(self._geo.latitude)
 
     def __init__(
         self,

--- a/tests/test_emissions_tracker.py
+++ b/tests/test_emissions_tracker.py
@@ -1108,3 +1108,76 @@ class TestCarbonTracker(unittest.TestCase):
 
         # Verification: If it wasn't cumulative, it would be 3.0 kWh * 300 g/kWh = 0.9 kg
         self.assertLess(data3.emissions, 0.8)
+
+    @mock.patch("codecarbon.emissions_tracker.EmissionsTracker._get_geo_metadata")
+    @mock.patch("codecarbon.emissions_tracker.EmissionsTracker._get_cloud_metadata")
+    @mock.patch("codecarbon.core.electricitymaps_api.requests.get")
+    @mock.patch("codecarbon.core.resource_tracker.ResourceTracker")
+    @mock.patch(
+        "codecarbon.emissions_tracker.BaseEmissionsTracker.get_detected_hardware"
+    )
+    @mock.patch("codecarbon.emissions_tracker.PeriodicScheduler")
+    def test_coordinates_precision_is_reduced_in_emissions_data(
+        self,
+        mock_scheduler,
+        mock_get_hw,
+        mock_resource_tracker,
+        mock_get,
+        mock_cloud,
+        mock_geo,
+        mock_cli_setup,
+        mock_log_values,
+        mocked_get_cloud_metadata_class,
+        mocked_get_gpu_details,
+        mocked_get_gpu_utilization_list,
+        mocked_is_gpu_details_available,
+        mocked_is_nvidia_system,
+    ):
+        mock_geo.return_value = mock.MagicMock(
+            latitude=48.8566,
+            longitude=2.3522,
+            country_iso_code="FRA",
+            country_2letter_iso_code="FR",
+        )
+        mock_cloud.return_value = mock.MagicMock(
+            is_on_private_infra=True, provider=None, region=None
+        )
+        mock_get_hw.return_value = {
+            "ram_total_size": 16.0,
+            "cpu_count": 8,
+            "cpu_physical_count": 4,
+            "cpu_model": "Mock CPU",
+            "gpu_count": 0,
+            "gpu_model": "None",
+            "gpu_ids": None,
+        }
+        mock_get.return_value = mock.MagicMock(
+            status_code=200, json=lambda: {"carbonIntensity": 100}
+        )
+
+        tracker = EmissionsTracker(
+            electricitymaps_api_token="test-token",
+            save_to_file=False,
+            measure_power_secs=1,
+            allow_multiple_runs=True,
+        )
+
+        mock_cpu = mock.MagicMock()
+        from codecarbon.external.hardware import CPU
+
+        mock_cpu.__class__ = CPU
+        mock_cpu.measure_power_and_energy.return_value = (
+            Power.from_watts(100),
+            Energy.from_energy(kWh=1.0),
+        )
+        tracker._hardware = [mock_cpu]
+
+        tracker.start()
+        data = tracker._prepare_emissions_data()
+
+        # Every output method gets coordinates reduced to one decimal place.
+        self.assertEqual(data.latitude, 48.9)
+        self.assertEqual(data.longitude, 2.4)
+        # The carbon intensity lookup still uses the full precision coordinates.
+        self.assertEqual(tracker._geo.latitude, 48.8566)
+        self.assertEqual(tracker._geo.longitude, 2.3522)


### PR DESCRIPTION
## Description

The output reference says the `latitude` and `longitude` columns are written with reduced precision as a privacy measure. That was only true for the API. The rounding lived in `ApiClient.add_run`, and nothing rounded the values on the way to `emissions.csv` or any of the other output methods.

`_ensure_geo_metadata` copied the raw geolocation result into `self._conf`, and `_prepare_emissions_data` read those values straight back out. So the CSV got whatever precision the geolocation provider returned, which for a home connection can be a lot more precise than 11 km.

I moved the rounding to the one place the coordinates enter the config, so every output method now agrees. `self._geo` still holds the full precision values, because the Electricity Maps carbon intensity lookup reads `geo.latitude` and `geo.longitude` directly and would lose accuracy otherwise. I left the existing `round()` in `api_client.py` in place. It is now a second round that changes nothing on this path, but it still does real work for coordinates set by hand in a `.codecarbon.config` file, since those never go through `_ensure_geo_metadata`.

No documentation change is needed. The docs already describe the behaviour this makes true.

## Related Issue

Fixes #1376

## Motivation and Context

`emissions.csv` is the file people attach to papers and commit to repositories. The documentation told them the coordinates in it were already coarsened, and they were not. A documented privacy guarantee that does not hold is worse than no guarantee at all, so this takes option 1 from the issue and makes the code match what users were told.

The change is visible in the output. Coordinates in new CSV files will have one decimal place instead of four or more.

## How Has This Been Tested?

I added `test_coordinates_precision_is_reduced_in_emissions_data` to `tests/test_emissions_tracker.py`. It mocks the geolocation lookup with 48.8566 / 2.3522, calls `_prepare_emissions_data()`, and checks the result carries 48.9 / 2.4 while `tracker._geo` still holds the full precision values. I checked the test fails on the unpatched source and passes with the change.

I also ran the package suite locally with `CODECARBON_ALLOW_MULTIPLE_RUNS=True`. 620 passed, 3 failed. The three failures are `tests/cli/test_cli_main.py::test_monitor_run_and_monitor`, `tests/test_docs_examples.py::test_doc_python_blocks[scikit-learn.md]` and `test_task_energy_with_live_update_interference`. All three fail the same way on master with my changes stashed, so they are not caused by this PR. `black --check` is clean on both changed files.

## Screenshots (if appropriate):

Not applicable.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure

Please refer to [docs/how-to/ai-policy.md](https://docs.codecarbon.io/latest/how-to/ai_policy/) for detailed guidelines on how to disclose AI usage in your PR. Accurately completing this section is mandatory.

- [ ] ðŸŸ¥ AI-vibecoded: You cannot explain the logic. Car analogy : the car drive by itself, you are outside it and just tell it where to go.
- [x] ðŸŸ  AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [ ] â­ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] â™»ï¸ No AI used. Car analogy : you drive the car.

I used an AI coding tool to write the patch and this description, and I reviewed and ran everything myself before opening the PR.

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[docs/how-to/contributing.md](https://docs.codecarbon.io/latest/how-to/contributing/)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.