### PR TITLE
fix: avoid IndexError in carbonboard when no project is selected

### DIFF
--- a/codecarbon/viz/components.py
+++ b/codecarbon/viz/components.py
@@ -91,7 +91,8 @@ class Components:
                     dcc.Dropdown(
                         id="project_name",
                         options=[{"label": i, "value": i} for i in projects],
-                        value=projects[0],
+                        value=projects[0] if projects else None,
+                        clearable=False,
                     ),
                 ],
                 style={"display": "inline-block"},

--- a/codecarbon/viz/data.py
+++ b/codecarbon/viz/data.py
@@ -23,6 +23,24 @@ class Data:
 
     @staticmethod
     def get_project_summary(project_data: List[Dict]):
+        if not project_data:
+            # No run to summarise, e.g. when the project dropdown is cleared.
+            # Keep the same shape so the callbacks reading it still work.
+            return {
+                "last_run": {
+                    "timestamp": "",
+                    "duration": 0,
+                    "emissions": 0,
+                    "energy_consumed": 0,
+                },
+                "total": {"duration": 0, "emissions": 0, "energy_consumed": 0},
+                "country_name": "",
+                "country_iso_code": "",
+                "region": "",
+                "on_cloud": "N",
+                "cloud_provider": "",
+                "cloud_region": "",
+            }
         last_run = project_data[-1]
         project_summary = {
             "last_run": {

--- a/tests/test_viz_data.py
+++ b/tests/test_viz_data.py
@@ -30,6 +30,54 @@ def test_get_project_data(emissions_data: pd.DataFrame):
     pd.testing.assert_frame_equal(pd.DataFrame(project_data.data), emissions_data)
 
 
+def test_get_project_summary(emissions_data: pd.DataFrame):
+    viz_data = data.Data()
+    project_data = viz_data.get_project_data(emissions_data, project_name="codecarbon")
+    project_summary = viz_data.get_project_summary(project_data.data)
+    assert project_summary["last_run"]["timestamp"] == "2021-09-23T15:04:51"
+    assert project_summary["total"]["duration"] == pytest.approx(161.20380687713623)
+    assert project_summary["total"]["emissions"] == pytest.approx(0.0004490989249167)
+    assert project_summary["total"]["energy_consumed"] == pytest.approx(
+        0.00057442898176
+    )
+    assert project_summary["country_name"] == "Morocco"
+    assert project_summary["country_iso_code"] == "MAR"
+    assert project_summary["region"] == "casablanca-settat"
+    assert project_summary["on_cloud"] == "N"
+
+
+def test_get_project_summary_empty(emissions_data: pd.DataFrame):
+    """Selecting no project used to raise an IndexError, see #918."""
+    viz_data = data.Data()
+    project_data = viz_data.get_project_data(emissions_data, project_name=None)
+    assert project_data.data == []
+
+    project_summary = viz_data.get_project_summary(project_data.data)
+    assert project_summary == {
+        "last_run": {
+            "timestamp": "",
+            "duration": 0,
+            "emissions": 0,
+            "energy_consumed": 0,
+        },
+        "total": {"duration": 0, "emissions": 0, "energy_consumed": 0},
+        "country_name": "",
+        "country_iso_code": "",
+        "region": "",
+        "on_cloud": "N",
+        "cloud_provider": "",
+        "cloud_region": "",
+    }
+
+    # The callbacks read the same keys whether or not a project is selected.
+    populated_summary = viz_data.get_project_summary(
+        viz_data.get_project_data(emissions_data, project_name="codecarbon").data
+    )
+    assert project_summary.keys() == populated_summary.keys()
+    assert project_summary["last_run"].keys() == populated_summary["last_run"].keys()
+    assert project_summary["total"].keys() == populated_summary["total"].keys()
+
+
 def test_get_global_emissions_choropleth_data(
     global_energy_mix_data: Dict[str, Dict[str, Any]],
 ):


### PR DESCRIPTION
## Description

`Data.get_project_summary` read `project_data[-1]` without checking the list had anything in it. Clearing the project dropdown filters the dataframe down to zero rows, so the callback raised `IndexError: list index out of range` and the dashboard stopped updating.

It now returns a zeroed summary with the same keys when there is no run, so the nine callback outputs still unpack. I also set `clearable=False` on the project dropdown and guarded the default value, so an empty CSV does not crash on startup either. `carbonboard_on_api.py` calls the same two helpers and gets the fix as well.

To be clear about scope, this fixes only the IndexError. The asset 404s reported in the same issue were already fixed by #958.

## Related Issue

Fixes #918

## Motivation and Context

Clearing the dropdown is a normal thing to do in the UI, and one stray click left the board dead until restart. Guarding at the source keeps every caller safe instead of patching one callback.

## How Has This Been Tested?

Added `test_get_project_summary_empty` and a non-empty companion `test_get_project_summary` to `tests/test_viz_data.py`. The empty test fails with the reported IndexError before the change and passes after. `uv run pytest -vv tests/test_viz_data.py tests/test_viz_units.py` gives 10 passed. I also checked by hand that the downstream callbacks survive the zeroed summary: the equivalents render as zero, the regional choropleth falls back to its placeholder row, and the cloud barchart takes the `on_cloud == "N"` path.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure

- [ ] ðŸŸ¥ AI-vibecoded: You cannot explain the logic.
- [x] ðŸŸ  AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [ ] â­ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] â™»ï¸ No AI used. Car analogy : you drive the car.

This patch and its tests were written by an AI agent working from my instructions, and I reviewed the diff and the test run before opening the PR.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[docs/how-to/contributing.md](https://docs.codecarbon.io/latest/how-to/contributing/)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.