### PR TITLE
feat: warn when SLURM ranks double count a node

### DIFF
--- a/codecarbon/core/slurm.py
+++ b/codecarbon/core/slurm.py
@@ -1,0 +1,26 @@
+import os
+import re
+
+from codecarbon.external.logger import logger
+
+
+def warn_on_multi_rank_double_counting(tracking_mode: str) -> None:
+    """
+    Warn when several ranks share a node and each one measures the whole node.
+
+    In ``machine`` mode every rank reports the node's power, so the job's
+    reported footprint is silently multiplied by the number of ranks per node.
+    """
+    if tracking_mode != "machine":
+        return
+    # SLURM writes this as "4", or as "4(x2)" for a heterogeneous allocation.
+    ntasks_per_node = os.environ.get("SLURM_NTASKS_PER_NODE", "")
+    match = re.match(r"\d+", ntasks_per_node)
+    if match and int(match.group()) > 1:
+        logger.warning(
+            f"SLURM_NTASKS_PER_NODE is {ntasks_per_node} and tracking_mode is "
+            "'machine': every rank measures the whole node, so the job's total "
+            "will be multiplied by the number of ranks per node. Start the "
+            "tracker on one rank per node (SLURM_LOCALID == 0), or use "
+            "tracking_mode='process'."
+        )

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -21,6 +21,7 @@ import psutil
 
 from codecarbon._version import __version__
 from codecarbon.core.config import get_hierarchical_config, normalize_gpu_ids
+from codecarbon.core.slurm import warn_on_multi_rank_double_counting
 from codecarbon.core.units import Energy, Power, Time, Water
 from codecarbon.core.util import count_cpus, count_physical_cpus, suppress
 from codecarbon.external.hardware import CPU, GPU, AppleSiliconChip
@@ -600,6 +601,7 @@ class BaseEmissionsTracker(ABC):
         assert self._tracking_mode in ["machine", "process"]
         set_logger_level(self._log_level)
         set_logger_format(self._logger_preamble)
+        warn_on_multi_rank_double_counting(self._tracking_mode)
         self._initialize_runtime_state()
         self._initialize_scheduler_state()
         self._initialize_emissions_context()

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest import mock
+
+from codecarbon.core.slurm import warn_on_multi_rank_double_counting
+
+
+class TestMultiRankWarning(unittest.TestCase):
+    def _warnings(self, tracking_mode="machine", **env):
+        with mock.patch.dict("os.environ", env, clear=True):
+            with mock.patch("codecarbon.core.slurm.logger") as mocked_logger:
+                warn_on_multi_rank_double_counting(tracking_mode)
+        return mocked_logger.warning.call_count
+
+    def test_several_ranks_per_node_in_machine_mode_warns(self):
+        self.assertEqual(1, self._warnings(SLURM_NTASKS_PER_NODE="4"))
+        # Heterogeneous allocations are written "4(x2)".
+        self.assertEqual(1, self._warnings(SLURM_NTASKS_PER_NODE="4(x2)"))
+
+    def test_no_warning_without_double_counting(self):
+        self.assertEqual(0, self._warnings(SLURM_NTASKS_PER_NODE="1"))
+        self.assertEqual(0, self._warnings())
+        self.assertEqual(
+            0, self._warnings(tracking_mode="process", SLURM_NTASKS_PER_NODE="4")
+        )


### PR DESCRIPTION
Split out of #1366, which mixed it in with the job-metadata columns. It is unrelated scope and stands on its own.

## The hazard

On SLURM, `srun --ntasks-per-node=4` starts four ranks on one node. With `tracking_mode="machine"` — the default — each of those four trackers measures the *whole node*, so the job's total is silently 4x the truth. Nothing in the output says so; the numbers just look wrong in a way nobody notices.

## What this does

`codecarbon/core/slurm.py` reads `SLURM_NTASKS_PER_NODE` at tracker init and, in `machine` mode with more than one rank per node, logs a warning naming the two ways out: elect one tracker per node (`SLURM_LOCALID == 0`) or switch to `tracking_mode="process"`.

That is the whole change: ~20 lines, `os.environ` and a regex, no dependency, no config key, no new output field. `4(x2)` (heterogeneous allocations) parses as 4.

## Not in this PR

Automatic rank election. Suppressing the extra trackers is the real fix, but it is the same problem as `LOCAL_RANK == 0` in distributed training and deserves one generic solution with a caller asking for it. Warning first.

## Tests

`tests/test_slurm.py`: warns for `4` and for `4(x2)`; silent for `1`, for no SLURM variable at all, and for `tracking_mode="process"`.

```
uv run pytest tests/test_slurm.py tests/test_emissions_tracker.py -q
33 passed
```

Based on #1370, same base as #1366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)