### PR TITLE
perf(deps): drop pandas from the default install

### DIFF
--- a/codecarbon/core/cpu.py
+++ b/codecarbon/core/cpu.py
@@ -6,13 +6,15 @@ https://software.intel.com/content/www/us/en/develop/articles/intel-power-gadget
 
 from __future__ import annotations
 
+import csv
 import os
 import re
 import shutil
+import statistics
 import subprocess
 import sys
 from functools import lru_cache
-from typing import TYPE_CHECKING, Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import psutil
 from rapidfuzz import fuzz, process, utils
@@ -21,9 +23,6 @@ from codecarbon.core.rapl import RAPLFile
 from codecarbon.core.units import Time
 from codecarbon.core.util import count_cpus, detect_cpu_model
 from codecarbon.external.logger import logger
-
-if TYPE_CHECKING:
-    import pandas as pd
 
 # default W value per core for a CPU if no model is found in the ref csv
 DEFAULT_POWER_PER_CORE = 4
@@ -375,16 +374,36 @@ class IntelPowerGadget:
         self._log_values()
         cpu_details = {}
         try:
-            import pandas as pd
+            with open(self._log_file_path, newline="", encoding="utf-8-sig") as f:
+                reader = csv.DictReader(f)
+                columns = reader.fieldnames or []
+                # pandas named blank headers "Unnamed: <i>"; keep those keys
+                # stable for anyone consuming the returned details dict.
+                renames = {c: f"Unnamed: {i}" for i, c in enumerate(columns) if not c}
+                # Intel Power Gadget appends a ragged summary block after the
+                # samples; ``.dropna()`` used to discard those rows, and dropping
+                # rows with any missing/blank field does the same thing.
+                rows = [
+                    row
+                    for row in reader
+                    if all(v not in (None, "") for v in row.values())
+                    and None not in row
+                ]
 
-            cpu_data = pd.read_csv(self._log_file_path).dropna()
-            for col_name in cpu_data.columns:
+            for col_name in columns:
                 if col_name in ["System Time", "Elapsed Time (sec)", "RDTSC"]:
                     continue
+                try:
+                    values = [float(row[col_name]) for row in rows]
+                except (TypeError, ValueError):
+                    continue  # non-numeric column, nothing to average
+                if not values:
+                    continue
+                key = renames.get(col_name, col_name)
                 if "Cumulative" in col_name:
-                    cpu_details[col_name] = cpu_data[col_name].iloc[-1]
+                    cpu_details[key] = values[-1]
                 else:
-                    cpu_details[col_name] = cpu_data[col_name].mean()
+                    cpu_details[key] = statistics.fmean(values)
         except Exception as e:
             logger.info(
                 f"Unable to read Intel Power Gadget logged file at {self._log_file_path}\n \
@@ -898,14 +917,14 @@ class TDP:
         self.model, self.tdp = self._main()
 
     @staticmethod
-    def _get_cpu_constant_power(match: str, cpu_power_df: pd.DataFrame) -> int:
+    def _get_cpu_constant_power(match: str, cpu_power_rows: list[dict]) -> int:
         """Extract constant power from matched CPU"""
-        return float(cpu_power_df[cpu_power_df["Name"] == match]["TDP"].values[0])
+        return float(next(r for r in cpu_power_rows if r["Name"] == match)["TDP"])
 
     def _get_cpu_power_from_registry(self, cpu_model_raw: str) -> Optional[int]:
         from codecarbon.input import DataSource
 
-        cpu_power_df = DataSource().get_cpu_power_data()
+        cpu_power_df = DataSource().get_cpu_power_rows()
         cpu_matching = self._get_matching_cpu(cpu_model_raw, cpu_power_df)
         if cpu_matching:
             power = self._get_cpu_constant_power(cpu_matching, cpu_power_df)
@@ -913,7 +932,7 @@ class TDP:
         return None
 
     def _get_matching_cpu(
-        self, model_raw: str, cpu_df: pd.DataFrame, greedy=False
+        self, model_raw: str, cpu_df: list[dict], greedy=False
     ) -> str:
         """
         Get matching cpu name
@@ -921,7 +940,7 @@ class TDP:
         :args:
             model_raw (str): raw name of the cpu model detected on the machine
 
-            cpu_df (DataFrame): table containing cpu models along their tdp
+            cpu_df (list[dict]): rows of cpu models along their tdp
 
             greedy (default False): if multiple cpu models match with an equal
             ratio of similarity, greedy (True) selects the first model,
@@ -945,9 +964,11 @@ class TDP:
         THRESHOLD_DIRECT: int = 100
         THRESHOLD_TOKEN_SET: int = 100
 
+        names = [row["Name"] for row in cpu_df]
+
         direct_match = process.extractOne(
             model_raw,
-            cpu_df["Name"],
+            names,
             processor=lambda s: s.lower(),
             scorer=fuzz.ratio,
             score_cutoff=THRESHOLD_DIRECT,
@@ -964,7 +985,7 @@ class TDP:
         model_raw = re.sub(r" @\s*\d+\.\d+GHz", "", model_raw)
         direct_match = process.extractOne(
             model_raw,
-            cpu_df["Name"],
+            names,
             processor=lambda s: s.lower(),
             scorer=fuzz.ratio,
             score_cutoff=THRESHOLD_DIRECT,
@@ -974,7 +995,7 @@ class TDP:
             return direct_match[0]
         indirect_matches = process.extract(
             model_raw,
-            cpu_df["Name"],
+            names,
             processor=utils.default_process,
             scorer=fuzz.token_set_ratio,
             score_cutoff=THRESHOLD_TOKEN_SET,

--- a/codecarbon/core/emissions.py
+++ b/codecarbon/core/emissions.py
@@ -6,16 +6,13 @@ https://github.com/mlco2/impact
 https://github.com/responsibleproblemsolving/energy-usage
 """
 
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import Dict, Optional
 
 from codecarbon.core import electricitymaps_api
 from codecarbon.core.units import EmissionsPerKWh, Energy
 from codecarbon.external.geography import CloudMetadata, GeoMetadata
 from codecarbon.external.logger import logger
 from codecarbon.input import DataSource, DataSourceException
-
-if TYPE_CHECKING:
-    import pandas as pd
 
 _NORDIC_REGIONS_BY_COUNTRY = {
     "SWE": {"SE1", "SE2", "SE3", "SE4"},
@@ -65,12 +62,12 @@ class Emissions:
             )
             return energy.kWh * (self._force_carbon_intensity_g_co2e_kwh / 1000.0)
 
-        df: pd.DataFrame = self._data_source.get_cloud_emissions_data()
         try:
+            row = self._data_source.find_cloud_region(cloud.provider, cloud.region)
+            if row is None:
+                raise KeyError(f"{cloud.provider}/{cloud.region}")
             emissions_per_kWh: EmissionsPerKWh = EmissionsPerKWh.from_g_per_kWh(
-                df.loc[
-                    (df["provider"] == cloud.provider) & (df["region"] == cloud.region)
-                ]["impact"].item()
+                row["impact"]
             )
             emissions = emissions_per_kWh.kgs_per_kWh * energy.kWh  # kgs
         except Exception as e:
@@ -100,51 +97,44 @@ class Emissions:
         """
         Returns the Country Name where the cloud region is located
         """
-        df: pd.DataFrame = self._data_source.get_cloud_emissions_data()
-        flags = (df["provider"] == cloud.provider) & (df["region"] == cloud.region)
-        selected = df.loc[flags]
-        if not len(selected):
+        row = self._data_source.find_cloud_region(cloud.provider, cloud.region)
+        if row is None:
             raise ValueError(
                 "Unable to find country name for "
                 f"cloud_provider={cloud.provider}, "
                 f"cloud_region={cloud.region}"
             )
-        return selected["country_name"].item()
+        return row["country_name"]
 
     def get_cloud_country_iso_code(self, cloud: CloudMetadata) -> str:
         """
         Returns the Country ISO Code where the cloud region is located
         """
-        df: pd.DataFrame = self._data_source.get_cloud_emissions_data()
-        flags = (df["provider"] == cloud.provider) & (df["region"] == cloud.region)
-        selected = df.loc[flags]
-        if not len(selected):
+        row = self._data_source.find_cloud_region(cloud.provider, cloud.region)
+        if row is None:
             raise ValueError(
                 "Unable to find country ISO Code for "
                 f"cloud_provider={cloud.provider}, "
                 f"cloud_region={cloud.region}"
             )
-        return selected["countryIsoCode"].item()
+        return row["countryIsoCode"]
 
     def get_cloud_geo_region(self, cloud: CloudMetadata) -> str:
         """
         Returns the State/City where the cloud region is located
         """
-        df: pd.DataFrame = self._data_source.get_cloud_emissions_data()
-        flags = (df["provider"] == cloud.provider) & (df["region"] == cloud.region)
-        selected = df.loc[flags]
-        if not len(selected):
+        row = self._data_source.find_cloud_region(cloud.provider, cloud.region)
+        if row is None:
             raise ValueError(
                 "Unable to find State/City name for "
                 f"cloud_provider={cloud.provider}, "
                 f"cloud_region={cloud.region}"
             )
 
-        state = selected["state"].item()
-        if state is not None:
-            return state
-        city = selected["city"].item()
-        return city
+        # Empty ``state`` used to arrive here as pandas' NaN, which is not None,
+        # so this returned NaN for the 30 of 40 rows that only have a city.
+        # It now falls through to the city as originally intended.
+        return row["state"] if row["state"] is not None else row["city"]
 
     def get_private_infra_emissions(self, energy: Energy, geo: GeoMetadata) -> float:
         """

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -619,7 +619,6 @@ class BaseEmissionsTracker(ABC):
         from codecarbon.output_methods.file import FileOutput
         from codecarbon.output_methods.http import CodeCarbonAPIOutput, HTTPOutput
         from codecarbon.output_methods.metrics.logfire import LogfireOutput
-        from codecarbon.output_methods.metrics.prometheus import PrometheusOutput
 
         methods = set(self._output_methods) if self._output_methods else set()
 
@@ -651,6 +650,8 @@ class BaseEmissionsTracker(ABC):
             self.run_id = uuid.uuid4()
 
         if OutputMethod.PROMETHEUS in methods:
+            from codecarbon.output_methods.metrics.prometheus import PrometheusOutput
+
             self._output_handlers.append(
                 PrometheusOutput(
                     self._prometheus_url,
@@ -1381,15 +1382,9 @@ class OfflineEmissionsTracker(BaseEmissionsTracker):
     def _validate_offline_cloud_provider(self) -> None:
         if not self._cloud_provider:
             return
-        df = DataSource().get_cloud_emissions_data()
         if (
-            len(
-                df.loc[
-                    (df["provider"] == self._cloud_provider)
-                    & (df["region"] == self._cloud_region)
-                ]
-            )
-            == 0
+            DataSource().find_cloud_region(self._cloud_provider, self._cloud_region)
+            is None
         ):
             logger.error(
                 "Cloud Provider/Region "

--- a/codecarbon/input.py
+++ b/codecarbon/input.py
@@ -8,14 +8,13 @@ to keep `import codecarbon` fast for measurement startup.
 from __future__ import annotations
 
 import atexit
+import csv
 import json
+import warnings
 from contextlib import ExitStack
 from importlib.resources import as_file as importlib_resources_as_file
 from importlib.resources import files as importlib_resources_files
-from typing import TYPE_CHECKING, Any, Dict
-
-if TYPE_CHECKING:
-    import pandas as pd
+from typing import Any, Dict
 
 _CACHE: Dict[str, Any] = {}
 _MODULE_NAME = "codecarbon"
@@ -30,6 +29,37 @@ def _get_resource_path(filepath: str):
     return path
 
 
+def _read_csv(path, numeric_columns=()) -> list[dict[str, Any]]:
+    """
+    Read a bundled reference CSV into a list of row dicts.
+
+    ``utf-8-sig`` is required: ``data/cloud/impact.csv`` starts with a UTF-8 BOM,
+    which would otherwise end up glued to the first column name. Empty fields
+    become ``None`` (not ``""``) so callers can test them with ``is None``, and
+    the columns listed in ``numeric_columns`` are coerced to ``float`` at this
+    boundary rather than being left as strings for callers to guess about.
+    """
+    with open(path, newline="", encoding="utf-8-sig") as f:
+        rows = []
+        for raw in csv.DictReader(f):
+            row: dict[str, Any] = {k: (v if v else None) for k, v in raw.items()}
+            for column in numeric_columns:
+                if row.get(column) is not None:
+                    row[column] = float(row[column])
+            rows.append(row)
+        return rows
+
+
+def _deprecated_rows_accessor(old: str, new: str) -> None:
+    warnings.warn(
+        f"DataSource.{old}() no longer returns a pandas DataFrame; it returns a "
+        f"list of row dicts. Use DataSource.{new}() instead. "
+        f"{old}() will be removed in a future version.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 def _load_static_data() -> None:
     """
     Load all static reference data at module import.
@@ -37,8 +67,6 @@ def _load_static_data() -> None:
     Called once when codecarbon is imported. All data loaded here
     is immutable and shared across all tracker instances.
     """
-    import pandas as pd
-
     # Global energy mix - used for emissions calculations
     path = _get_resource_path("data/private_infra/global_energy_mix.json")
     with open(path) as f:
@@ -46,7 +74,9 @@ def _load_static_data() -> None:
 
     # Cloud emissions data
     path = _get_resource_path("data/cloud/impact.csv")
-    _CACHE["cloud_emissions"] = pd.read_csv(path)
+    _CACHE["cloud_emissions"] = _read_csv(
+        path, numeric_columns=("impact", "offsetRatio")
+    )
 
     # Carbon intensity per source
     path = _get_resource_path("data/private_infra/carbon_intensity_per_source.json")
@@ -55,7 +85,10 @@ def _load_static_data() -> None:
 
     # CPU power data
     path = _get_resource_path("data/hardware/cpu_power.csv")
-    _CACHE["cpu_power"] = pd.read_csv(path)
+    # TDP is deliberately left as text: a handful of rows hold malformed values
+    # such as "27.29.5", and coercing here would fail the whole load instead of
+    # only the lookup for those CPUs (which is what happens today).
+    _CACHE["cpu_power"] = _read_csv(path)
 
     # Nordic country energy mix - used for emissions calculations
     path = _get_resource_path("data/private_infra/nordic_emissions.json")
@@ -147,13 +180,40 @@ class DataSource:
         _ensure_static_data_loaded()
         return _CACHE["global_energy_mix"]
 
-    def get_cloud_emissions_data(self) -> pd.DataFrame:
+    def get_cloud_emissions_rows(self) -> list[dict[str, Any]]:
         """
-        Returns Cloud Regions Impact Data.
+        Returns Cloud Regions Impact Data, as one dict per row.
         Data is loaded on first access and cached for all tracker instances.
         """
         _ensure_static_data_loaded()
         return _CACHE["cloud_emissions"]
+
+    def get_cloud_emissions_data(self) -> list[dict[str, Any]]:
+        """
+        Deprecated alias for :meth:`get_cloud_emissions_rows`.
+
+        This used to return a ``pandas.DataFrame``. pandas is no longer a
+        default dependency, and returning one type or the other depending on
+        whether it happens to be installed would make the return type of a
+        public method depend on the environment, so it always returns rows now.
+        """
+        _deprecated_rows_accessor(
+            "get_cloud_emissions_data", "get_cloud_emissions_rows"
+        )
+        return self.get_cloud_emissions_rows()
+
+    def find_cloud_region(self, provider: str, region: str) -> dict[str, Any] | None:
+        """
+        Returns the cloud impact row for a provider/region pair, or None.
+        """
+        return next(
+            (
+                row
+                for row in self.get_cloud_emissions_rows()
+                if row["provider"] == provider and row["region"] == region
+            ),
+            None,
+        )
 
     def get_country_emissions_data(self, country_iso_code: str) -> Dict:
         """
@@ -195,13 +255,22 @@ class DataSource:
         _ensure_static_data_loaded()
         return _CACHE["carbon_intensity_per_source"]
 
-    def get_cpu_power_data(self) -> pd.DataFrame:
+    def get_cpu_power_rows(self) -> list[dict[str, Any]]:
         """
-        Returns CPU power Data.
+        Returns CPU power Data, as one dict per row.
         Data is loaded on first access and cached for all tracker instances.
         """
         _ensure_static_data_loaded()
         return _CACHE["cpu_power"]
+
+    def get_cpu_power_data(self) -> list[dict[str, Any]]:
+        """
+        Deprecated alias for :meth:`get_cpu_power_rows`. See
+        :meth:`get_cloud_emissions_data` for why it no longer returns a
+        ``pandas.DataFrame``.
+        """
+        _deprecated_rows_accessor("get_cpu_power_data", "get_cpu_power_rows")
+        return self.get_cpu_power_rows()
 
     def get_nordic_country_energy_mix_data(self) -> Dict:
         """

--- a/codecarbon/output_methods/file.py
+++ b/codecarbon/output_methods/file.py
@@ -1,13 +1,41 @@
 import csv
+import math
 import os
 from typing import List
-
-import pandas as pd
 
 from codecarbon.core.util import backup
 from codecarbon.external.logger import logger
 from codecarbon.output_methods.base_output import BaseOutput
 from codecarbon.output_methods.emissions_data import EmissionsData, TaskEmissionsData
+
+
+def _as_csv_row(values: dict) -> dict:
+    """Render a data row as strings, with missing values as empty cells.
+
+    Any non-finite float (NaN, +inf, -inf) is written as an empty cell. NaN
+    matches what pandas' ``to_csv`` did; infinities are a deliberate
+    divergence (``to_csv`` wrote the literal "inf") because an infinite
+    energy or emissions value is not a real measurement, and an empty cell
+    reads back as missing instead of poisoning downstream arithmetic.
+    """
+    return {
+        k: (
+            ""
+            if v is None or (isinstance(v, float) and not math.isfinite(v))
+            else str(v)
+        )
+        for k, v in values.items()
+    }
+
+
+def _write_rows(path: str, fieldnames: list[str], rows: list[dict]) -> None:
+    with open(path, "w", newline="") as csv_file:
+        # extrasaction="ignore" is defensive only: a row can never carry a key
+        # outside `fieldnames`, because `out()` backs the file up and rewrites it
+        # from scratch whenever `has_valid_headers()` reports a mismatch.
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
 
 
 class FileOutput(BaseOutput):
@@ -97,34 +125,40 @@ class FileOutput(BaseOutput):
             backup(self.save_file_path)
             file_exists = False
 
-        new_df = pd.DataFrame.from_records([dict(total.values)])
+        new_row = _as_csv_row(dict(total.values))
 
         if not file_exists:
-            new_df.to_csv(self.save_file_path, index=False)
+            _write_rows(self.save_file_path, list(new_row), [new_row])
         elif self.on_csv_write == "append":
-            # Never drop all-NA columns here: the append is headerless, so column
-            # identity is positional and a missing column shifts every value after it.
-            new_df.to_csv(self.save_file_path, mode="a", header=False, index=False)
+            # Use the header already on disk as the column order: the row dict's
+            # key order is not guaranteed to match it (has_valid_headers()
+            # compares the two sorted), and trusting it would misalign columns.
+            with open(self.save_file_path, newline="") as csv_file:
+                fieldnames = next(csv.reader(csv_file), None)
+            if not fieldnames:
+                _write_rows(self.save_file_path, list(new_row), [new_row])
+            else:
+                with open(self.save_file_path, "a", newline="") as csv_file:
+                    csv.DictWriter(
+                        csv_file, fieldnames=fieldnames, extrasaction="ignore"
+                    ).writerow(new_row)
         else:
-            df = pd.read_csv(self.save_file_path)
-            df_run = df.loc[df.run_id == total.run_id]
-            if len(df_run) < 1:
-                df = pd.concat([df, new_df])
-            elif len(df_run) > 1:
+            with open(self.save_file_path, newline="") as csv_file:
+                reader = csv.DictReader(csv_file)
+                fieldnames = reader.fieldnames or list(new_row)
+                rows = list(reader)
+            matching = [r for r in rows if r.get("run_id") == str(total.run_id)]
+            if len(matching) > 1:
                 logger.warning(
-                    f"CSV contains more than 1 ({len(df_run)})"
+                    f"CSV contains more than 1 ({len(matching)})"
                     + f" rows with current run ID ({total.run_id})."
                     + "Appending instead of updating."
                 )
-                df = pd.concat([df, new_df])
+            if len(matching) == 1:
+                matching[0].update(new_row)
             else:
-                update_values = {}
-                for col, val in dict(total.values).items():
-                    update_values[col] = df[col].dtype.type(val)
-                df.loc[df.run_id == total.run_id, update_values.keys()] = (
-                    update_values.values()
-                )
-            df.to_csv(self.save_file_path, index=False)
+                rows.append(new_row)
+            _write_rows(self.save_file_path, fieldnames, rows)
 
     def task_out(self, data: List[TaskEmissionsData], experiment_name: str):
         """
@@ -136,11 +170,10 @@ class FileOutput(BaseOutput):
         save_task_file_path = os.path.join(
             self.output_dir, "emissions_" + experiment_name + "_" + run_id + ".csv"
         )
-        new_df = pd.DataFrame.from_records(
-            [dict(data_point.values) for data_point in data]
-        )
-        # Filter out empty or all-NA columns only from new_df, to avoid warnings from Pandas
-        # see https://github.com/pandas-dev/pandas/issues/55928
-        new_df = new_df.dropna(axis=1, how="all")
-        df = new_df
-        df.to_csv(save_task_file_path, index=False)
+        rows = [_as_csv_row(dict(data_point.values)) for data_point in data]
+        # Drop columns that are empty in every row, matching the previous
+        # dropna(axis=1, how="all").
+        fieldnames = [
+            column for column in rows[0] if any(row.get(column) != "" for row in rows)
+        ]
+        _write_rows(save_task_file_path, fieldnames, rows)

--- a/codecarbon/viz/data.py
+++ b/codecarbon/viz/data.py
@@ -211,7 +211,9 @@ class Data:
                 "",
                 pd.DataFrame(data={"region": [], "emissions": [], "country_name": []}),
             )
-        cloud_emissions = self._data_source.get_cloud_emissions_data()
+        # DataSource returns plain row dicts; the dashboard is the only consumer
+        # that still wants a DataFrame, so build one here.
+        cloud_emissions = pd.DataFrame(self._data_source.get_cloud_emissions_rows())
         cloud_emissions = cloud_emissions[
             ["provider", "providerName", "region", "impact", "country_name"]
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ dependencies = [
     "authlib>=1.2.1",
     "joserfc>=1.0.0",
     "click",
-    "pandas>=2.3.3;python_version>='3.14'",
-    "pandas;python_version<'3.14'",
     "prometheus_client",
     "psutil >= 6.0.0",
     "py-cpuinfo",
@@ -87,6 +85,7 @@ dev = [
     "black",
     "mypy",
     "pytest",
+    "pandas",  # no longer a runtime dep; tests read output CSVs with it
     "requests",
     "requests-mock",
     "responses",
@@ -108,16 +107,28 @@ doc = [
 ]
 
 [project.optional-dependencies]
+# pandas is only needed by the dashboard now; the measurement core parses its
+# reference CSVs with the stdlib csv module.
 carbonboard = [
     "dash",
     "dash_bootstrap_components > 1.0.0",
     "fire",
+    "numpy",
+    "pandas>=2.3.3;python_version>='3.14'",
+    "pandas;python_version<'3.14'",
 ]
 # Backwards compatibility alias - will be removed in v4.0.0
 viz-legacy = [
     "dash",
     "dash_bootstrap_components > 1.0.0",
     "fire",
+    "numpy",
+    "pandas>=2.3.3;python_version>='3.14'",
+    "pandas;python_version<'3.14'",
+]
+# Everything, for users who do not want to think about extras.
+all = [
+    "codecarbon[carbonboard]",
 ]
 
 [project.scripts]

--- a/tests/output_methods/test_file.py
+++ b/tests/output_methods/test_file.py
@@ -1,3 +1,4 @@
+import csv
 import os
 import shutil
 import tempfile
@@ -87,6 +88,22 @@ class TestFileOutput(unittest.TestCase):
 
         self.assertTrue(file_output.has_valid_headers(self.emissions_data))
 
+    def test_non_finite_values_are_written_as_empty_cells(self):
+        """NaN and infinities must round-trip as missing, not as "nan"/"inf"."""
+        for value in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=value):
+                file_output = FileOutput("test.csv", self.temp_dir)
+                self.emissions_data.cpu_power = value
+                file_output.out(self.emissions_data, None)
+
+                with open(file_output.save_file_path) as csv_file:
+                    row = next(csv.DictReader(csv_file))
+                self.assertEqual(row["cpu_power"], "")
+                self.assertTrue(
+                    pd.isna(pd.read_csv(file_output.save_file_path)["cpu_power"][0])
+                )
+                os.remove(file_output.save_file_path)
+
     def test_has_valid_headers_failure(self):
         file_output = FileOutput("test.csv", self.temp_dir)
         file_output.out(self.emissions_data, None)
@@ -131,6 +148,22 @@ class TestFileOutput(unittest.TestCase):
 
         df = pd.read_csv(os.path.join(self.temp_dir, "test.csv"))
         self.assertEqual(len(df), 2)
+
+    def test_file_output_out_append_respects_existing_column_order(self):
+        """Appending must follow the header on disk, not the row's key order."""
+        file_output = FileOutput("test.csv", self.temp_dir, on_csv_write="append")
+        file_output.out(self.emissions_data, None)
+
+        df = pd.read_csv(os.path.join(self.temp_dir, "test.csv"))
+        df = df[list(reversed(df.columns))]
+        df.to_csv(os.path.join(self.temp_dir, "test.csv"), index=False)
+
+        file_output.out(self.emissions_data, None)
+
+        df = pd.read_csv(os.path.join(self.temp_dir, "test.csv"))
+        self.assertEqual(len(df), 2)
+        self.assertEqual(df.iloc[1]["project_name"], self.emissions_data.project_name)
+        self.assertEqual(df.iloc[0].to_dict(), df.iloc[1].to_dict())
 
     def test_file_output_out_update_file_exists_no_matching_row(self):
         file_output = FileOutput("test.csv", self.temp_dir, on_csv_write="update")

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -238,7 +238,12 @@ class TestIntelPowerGadget(unittest.TestCase):
             cpu_details["Cumulative IA Energy_0(mWh)"] = round(
                 cpu_details["Cumulative IA Energy_0(mWh)"], 3
             )
-            self.assertDictEqual(expected_cpu_details, cpu_details)
+            # Compared with a tolerance rather than assertDictEqual: the
+            # values are float means, and pinning one summation order's last
+            # ulp is not a property worth asserting.
+            self.assertEqual(sorted(expected_cpu_details), sorted(cpu_details))
+            for key, expected in expected_cpu_details.items():
+                self.assertAlmostEqual(expected, cpu_details[key], places=9)
 
     def test_setup_cli_uses_windows_backup_when_primary_missing(self):
         with (
@@ -399,7 +404,7 @@ class TestTDP(unittest.TestCase):
             mock.patch("codecarbon.input.DataSource") as mock_data_source,
             mock.patch.object(tdp, "_get_matching_cpu", return_value=None),
         ):
-            mock_data_source.return_value.get_cpu_power_data.return_value = (
+            mock_data_source.return_value.get_cpu_power_rows.return_value = (
                 mock.sentinel.cpu_power_df
             )
 
@@ -407,7 +412,7 @@ class TestTDP(unittest.TestCase):
 
     def test_get_matching_cpu(self):
         tdp = TDP()
-        cpu_data = DataSource().get_cpu_power_data()
+        cpu_data = DataSource().get_cpu_power_rows()
 
         # ======= WORKING AS EXPECTED ========
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -41,11 +41,11 @@ class TestDataSourceCaching(unittest.TestCase):
         self.assertIs(data, _CACHE["global_energy_mix"])
 
     def test_get_cloud_emissions_returns_cached_data(self):
-        """Verify get_cloud_emissions_data() returns cached object."""
+        """Verify get_cloud_emissions_rows() returns cached object."""
         from codecarbon.input import _CACHE, DataSource
 
         ds = DataSource()
-        data = ds.get_cloud_emissions_data()
+        data = ds.get_cloud_emissions_rows()
 
         # Should return the exact same object from cache
         self.assertIs(data, _CACHE["cloud_emissions"])
@@ -61,11 +61,11 @@ class TestDataSourceCaching(unittest.TestCase):
         self.assertIs(data, _CACHE["carbon_intensity_per_source"])
 
     def test_get_cpu_power_returns_cached_data(self):
-        """Verify get_cpu_power_data() returns cached object."""
+        """Verify get_cpu_power_rows() returns cached object."""
         from codecarbon.input import _CACHE, DataSource
 
         ds = DataSource()
-        data = ds.get_cpu_power_data()
+        data = ds.get_cpu_power_rows()
 
         # Should return the exact same object from cache
         self.assertIs(data, _CACHE["cpu_power"])
@@ -95,6 +95,24 @@ class TestDataSourceCaching(unittest.TestCase):
         data2 = ds2.get_global_energy_mix_data()
 
         self.assertIs(data1, data2)
+
+
+class TestDeprecatedDataFrameAccessors(unittest.TestCase):
+    """The old accessors always return rows now, whether or not pandas is around."""
+
+    def test_deprecated_accessors_return_rows_and_warn(self):
+        from codecarbon.input import DataSource
+
+        ds = DataSource()
+        for deprecated, current in (
+            (ds.get_cloud_emissions_data, ds.get_cloud_emissions_rows),
+            (ds.get_cpu_power_data, ds.get_cpu_power_rows),
+        ):
+            with self.assertWarns(DeprecationWarning):
+                rows = deprecated()
+            self.assertIs(rows, current())
+            self.assertIsInstance(rows, list)
+            self.assertIsInstance(rows[0], dict)
 
 
 if __name__ == "__main__":

--- a/tests/test_package_integrity.py
+++ b/tests/test_package_integrity.py
@@ -3,9 +3,11 @@ Test that verifies the package includes all necessary data files.
 This test should be run against the installed package, not the source.
 """
 
+import json
+import subprocess
+import sys
 from importlib import resources as importlib_resources
 
-import pandas as pd
 import pytest
 
 from codecarbon.input import DataSource
@@ -20,11 +22,10 @@ def test_critical_data_files_included():
     assert cloud_path.exists(), f"Cloud emissions file missing: {cloud_path}"
 
     # Test that we can actually read the cloud emissions data
-    cloud_data = ds.get_cloud_emissions_data()
-    assert isinstance(
-        cloud_data, pd.DataFrame
-    ), "Cloud emissions data should be a DataFrame"
-    assert not cloud_data.empty, "Cloud emissions data should not be empty"
+    cloud_data = ds.get_cloud_emissions_rows()
+    assert isinstance(cloud_data, list), "Cloud emissions data should be a list of rows"
+    assert cloud_data, "Cloud emissions data should not be empty"
+    assert "provider" in cloud_data[0], "BOM must not leak into the first column name"
 
     # Test carbon intensity data
     carbon_intensity_path = ds.carbon_intensity_per_source_path
@@ -49,11 +50,9 @@ def test_cpu_power_data_included():
     assert cpu_power_path.exists(), f"CPU power data missing: {cpu_power_path}"
 
     # Test that we can actually read the CPU power data
-    cpu_power_data = ds.get_cpu_power_data()
-    assert isinstance(
-        cpu_power_data, pd.DataFrame
-    ), "CPU power data should be a DataFrame"
-    assert not cpu_power_data.empty, "CPU power data should not be empty"
+    cpu_power_data = ds.get_cpu_power_rows()
+    assert isinstance(cpu_power_data, list), "CPU power data should be a list of rows"
+    assert cpu_power_data, "CPU power data should not be empty"
 
 
 def test_global_energy_mix_data_included():
@@ -150,3 +149,26 @@ def test_package_importability():
     from codecarbon.output import EmissionsData
 
     assert EmissionsData is not None
+
+
+def test_core_does_not_import_pandas_or_numpy():
+    """
+    pandas/numpy are dashboard-only dependencies and are not installed by a
+    default `pip install codecarbon`. Running a tracker end to end must not
+    reach for them, so assert on a fresh interpreter's sys.modules.
+    """
+    script = (
+        "import sys, tempfile, os, json\n"
+        "os.chdir(tempfile.mkdtemp())\n"
+        "from codecarbon import OfflineEmissionsTracker\n"
+        "t = OfflineEmissionsTracker(country_iso_code='FRA', allow_multiple_runs=True)\n"
+        "t.start(); t.stop()\n"
+        "print(json.dumps([m for m in ('pandas', 'numpy', 'prometheus_client')"
+        " if m in sys.modules]))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    leaked = json.loads(result.stdout.strip().splitlines()[-1])
+    assert leaked == [], f"core tracker path imported {leaked}"

--- a/uv.lock
+++ b/uv.lock
@@ -428,8 +428,6 @@ dependencies = [
     { name = "click" },
     { name = "joserfc" },
     { name = "nvidia-ml-py" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "prometheus-client" },
     { name = "psutil" },
     { name = "py-cpuinfo" },
@@ -443,15 +441,35 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "dash" },
+    { name = "dash-bootstrap-components" },
+    { name = "fire" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
 carbonboard = [
     { name = "dash" },
     { name = "dash-bootstrap-components" },
     { name = "fire" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 viz-legacy = [
     { name = "dash" },
     { name = "dash-bootstrap-components" },
     { name = "fire" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -462,6 +480,8 @@ dev = [
     { name = "logfire" },
     { name = "mktestdocs" },
     { name = "mypy" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -488,6 +508,7 @@ requires-dist = [
     { name = "arrow" },
     { name = "authlib", specifier = ">=1.2.1" },
     { name = "click" },
+    { name = "codecarbon", extras = ["carbonboard"], marker = "extra == 'all'" },
     { name = "dash", marker = "extra == 'carbonboard'" },
     { name = "dash", marker = "extra == 'viz-legacy'" },
     { name = "dash-bootstrap-components", marker = "extra == 'carbonboard'", specifier = ">1.0.0" },
@@ -495,9 +516,13 @@ requires-dist = [
     { name = "fire", marker = "extra == 'carbonboard'" },
     { name = "fire", marker = "extra == 'viz-legacy'" },
     { name = "joserfc", specifier = ">=1.0.0" },
+    { name = "numpy", marker = "extra == 'carbonboard'" },
+    { name = "numpy", marker = "extra == 'viz-legacy'" },
     { name = "nvidia-ml-py" },
-    { name = "pandas", marker = "python_full_version < '3.14'" },
-    { name = "pandas", marker = "python_full_version >= '3.14'", specifier = ">=2.3.3" },
+    { name = "pandas", marker = "python_full_version >= '3.14' and extra == 'carbonboard'", specifier = ">=2.3.3" },
+    { name = "pandas", marker = "python_full_version >= '3.14' and extra == 'viz-legacy'", specifier = ">=2.3.3" },
+    { name = "pandas", marker = "python_full_version < '3.14' and extra == 'carbonboard'" },
+    { name = "pandas", marker = "python_full_version < '3.14' and extra == 'viz-legacy'" },
     { name = "prometheus-client" },
     { name = "psutil", specifier = ">=6.0.0" },
     { name = "py-cpuinfo" },
@@ -509,7 +534,7 @@ requires-dist = [
     { name = "rich" },
     { name = "typer" },
 ]
-provides-extras = ["carbonboard", "viz-legacy"]
+provides-extras = ["carbonboard", "viz-legacy", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -519,6 +544,7 @@ dev = [
     { name = "logfire", specifier = ">=1.0.1" },
     { name = "mktestdocs" },
     { name = "mypy" },
+    { name = "pandas" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },


### PR DESCRIPTION
Part of #1338. Split out of #1343.

> **Stacked**: on `scaling/03-dependency-extras` (#1343, numpy removal), which is itself on `fix/powermetrics-nan-totals` (#1345). Review #1343 first; this PR's diff is only the pandas half. **Retarget once the stack lands.**

pandas was used shallowly — reading three bundled reference CSVs, a handful of row filters, and the `emissions.csv` writer — and pulled numpy in behind it. It is now an extra, replaced by the stdlib `csv` module. Nothing a user writes changes.

This was split off #1343 deliberately: it reimplements `read_csv`/`dropna` semantics by hand across 14 files, which is the entire regression risk of the dependency work, and it should be reviewed on its own rather than bundled with a three-line numpy swap.

## Measured on a clean 3.12 venv (`uv venv && uv pip install .`), whole stack

| | master | stack |
|---|---|---|
| installed size | 130 MB | 68 MB |
| packages | 39 | 37 |
| cold `import codecarbon` | 78.4 ms | 37.8 ms |

Import time is the median of 7 `python -X importtime` runs.

A default CSV tracker on `master` pulled pandas, numpy, prometheus_client and pycountry. `prometheus_client` was imported before the `if OutputMethod.PROMETHEUS` check; that import is now inside the branch.

## The real risk surface

The original proposal's inventory listed six shallow call sites and "no vectorised arithmetic", and **missed `output_methods/file.py` entirely** — the writer for the user's `emissions.csv`, which did dtype-preserving in-place row updates by `run_id` and all-NA column dropping. That, not the reference-data parsing, is what to review. It is now on `csv.DictWriter`.

## ⚠️ Public API break — needs a release note

`DataSource.get_cloud_emissions_data()` and `DataSource.get_cpu_power_data()` now **always** return `list[dict]` and emit a `DeprecationWarning`. The supported names are `get_cloud_emissions_rows()` and `get_cpu_power_rows()`.

An earlier revision returned a `DataFrame` when pandas happened to be importable and rows otherwise. That makes the return type of a public method depend on the environment, which is worse than a clean break: downstream code would work on the author's machine and fail on a bare install, at the `.iloc`/`.query()` call rather than at the import. It is a straight break now, warned and named.

Nothing in-tree breaks (three test modules and `codecarbon/viz/` updated — `viz` builds its own frame), but these are importable, undecorated, documented-by-name methods. This repo has no `CHANGELOG` — release notes come from `.github/release-drafter.yml` — so **please label this PR `breaking`**.

## Behaviour changes, both fixes

1. `Emissions.get_cloud_geo_region` returned pandas' `NaN` for **30 of 40** cloud regions that have a `city` but no `state`, because `if state is not None` is true for `NaN`. It now returns the city, as the code plainly intended.
2. Float means/sums are exactly rounded (`fmean`/`fsum`) instead of matching numpy's pairwise order — differences at 1e-16. Two tests were hardcoding pandas'/numpy's summation order in the last ulp and are now tolerance-based. A side-by-side run of the old and new paths over `mock_intel_power_gadget_data.csv` agrees on all 22 columns to within 4.4e-16.

## Risks

CSV float formatting now comes from `str(float)` rather than pandas' `to_csv`. These agree on repr-shortest for normal values but **not** on NaN: `str(float("nan"))` is the literal `"nan"` where `to_csv` wrote an empty cell. `_as_csv_row` renders any non-finite float as `""`, covered by `tests/output_methods/test_file.py::test_non_finite_values_are_written_as_empty_cells` (verified to fail when the guard is removed).

Blanking infinities is a **deliberate divergence from pandas**: `to_csv` wrote the literal `inf`, this writes an empty cell. An infinite energy figure is not a measurement, and writing `inf` propagates a garbage number into everything that reads the file, where an empty cell reads back as missing.

`append` mode previously called `dropna(axis=1, how="all")` on the single new row, writing a short, column-misaligned row whenever a field was `None`; this writes an empty cell instead — correct, but not byte-identical to that old broken output. Three malformed `TDP` values in `cpu_power.csv` (`27.29.5`, `33.34.8`, `29.32.9`) still raise on `float()` exactly as before; left alone, with a comment on why the column stays text.

`extrasaction="ignore"` on the `DictWriter` is defensive only and carries a comment saying so.

## Compatibility

`pip install codecarbon` installs less and behaves the same; `codecarbon[carbonboard]` and `[viz-legacy]` still get pandas and numpy; a new `all` extra pulls everything; `pandas` moved to the `dev` group, since ten test modules read output CSVs with it.

The CLI/auth extras split from the original proposal is **not** here. It is worth 23 MB and 8 packages with **zero runtime benefit** — those imports are already off the hot path — and it breaks `pip install codecarbon && codecarbon monitor`, a documented headline feature. `pycountry` (21 MB) also stays: it sits on the live geolocation path, and a lazy import with an empty fallback would be a silent `country_iso_code`/`country_name` regression.

## Tests

`uv run pytest tests/ -q --ignore=tests/test_viz_data.py` → **633 passed, 21 skipped**. `test_viz_data.py` fails to collect on `master` identically — `dash` not installed.

New guard in `tests/test_package_integrity.py`: runs a full offline tracker in a subprocess and asserts `pandas`, `numpy` and `prometheus_client` are absent from `sys.modules`. End-to-end in a bare venv, two `update`-mode runs produce the same 38-column, 2-row `emissions.csv` as `master`.

Not included: the CI bare-install job (that is #1342) and the docs/README install-instruction sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
