### PR TITLE
perf: probe cloud metadata providers concurrently

### DIFF
--- a/codecarbon/core/cloud.py
+++ b/codecarbon/core/cloud.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, Optional
 
 import requests
@@ -50,22 +51,40 @@ def get_env_cloud_details(timeout: int = 1) -> Optional[Any]:
         'ramdiskId': None,
         'region': 'us-east-1',
         'version': '2017-09-30'}}
+
+    All providers are probed at once. Off cloud that is one timeout instead of
+    one per provider; on a cloud it is slower than returning on the first hit,
+    because the pool is only left once every probe has finished.
     """
-    for provider in CLOUD_METADATA_MAPPING.keys():
-        try:
-            params = CLOUD_METADATA_MAPPING[provider]
-            response = requests.get(
-                params["url"], headers=params["headers"], timeout=timeout
-            )
-            response.raise_for_status()
-            response_data = response.json()
+    providers = list(CLOUD_METADATA_MAPPING.keys())
 
-            postprocess_function = params.get("postprocess_function")
-            if postprocess_function is not None:
-                response_data = postprocess_function(response_data)
-
-            return {"provider": provider, "metadata": response_data}
-        except requests.exceptions.RequestException:
-            logger.debug("Not running on %s", provider)
+    # Off cloud every provider times out, and sequentially that is one timeout each.
+    with ThreadPoolExecutor(max_workers=len(providers)) as executor:
+        futures = [executor.submit(_probe_provider, p, timeout) for p in providers]
+        # Resolve in mapping order, not completion order, so detection stays
+        # deterministic if more than one provider answers.
+        for provider, future in zip(providers, futures):
+            response_data = future.result()
+            if response_data is not None:
+                return {"provider": provider, "metadata": response_data}
 
     return None
+
+
+def _probe_provider(provider: str, timeout: int) -> Optional[Dict[str, Any]]:
+    params = CLOUD_METADATA_MAPPING[provider]
+    try:
+        response = requests.get(
+            params["url"], headers=params["headers"], timeout=timeout
+        )
+        response.raise_for_status()
+        response_data = response.json()
+    except requests.exceptions.RequestException:
+        logger.debug("Not running on %s", provider)
+        return None
+
+    postprocess_function = params.get("postprocess_function")
+    if postprocess_function is not None:
+        response_data = postprocess_function(response_data)
+
+    return response_data

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -79,3 +79,17 @@ def test_get_env_cloud_details_mapping_nothing():
     setup_cloud_details_responses("localhost", metadata)
 
     assert get_env_cloud_details() is None
+
+
+@responses.activate
+def test_get_env_cloud_details_probes_all_providers_concurrently():
+    """Every provider is probed, and detection stays deterministic if several answer."""
+    for params in CLOUD_METADATA_MAPPING.values():
+        responses.add(responses.GET, params["url"], json={"region": "here"}, status=200)
+
+    first_provider = next(iter(CLOUD_METADATA_MAPPING))
+    assert get_env_cloud_details() == {
+        "provider": first_provider,
+        "metadata": {"region": "here"},
+    }
+    assert len(responses.calls) == len(CLOUD_METADATA_MAPPING)


### PR DESCRIPTION
Split out of #1359, which bundled this with a `cloud_detection` switch. This is only the probing change, so it can be judged on its own.

`get_env_cloud_details()` walks AWS, Azure and GCP metadata endpoints in order, each with a 1 second `requests` timeout. On a machine that is not on any of the three, all three time out one after the other, so tracker startup pays roughly 3 seconds of link-local requests that were never going to answer. It runs once, in `CloudMetadata.from_utils()` during tracker init.

This submits all three probes to a `ThreadPoolExecutor` and then resolves the futures in `CLOUD_METADATA_MAPPING` order, so if more than one endpoint answers, the provider picked is the same one master would have picked. The per-provider request body moves to a `_probe_provider` helper that returns `None` instead of raising.

The tradeoff a reviewer should weigh, because this is not a pure win in both directions:

- Off cloud: three concurrent 1 second timeouts instead of three sequential ones, so ~1 second instead of ~3. That is the case this targets, and it is the common one.
- On a cloud: master returned as soon as the first matching provider answered, typically in milliseconds, and never probed the rest. Here the `with ThreadPoolExecutor(...)` block calls `shutdown(wait=True)` on exit, and the early `return` is inside that block, so returning still waits for the other two probes to hit their 1 second timeout. Cloud users therefore go from near-instant detection to about 1 second.

Both are once per tracker start, not per measurement, so the on-cloud regression is a one-off second at startup rather than anything recurring. If that is still unacceptable, the alternative is to keep the executor alive past the return (an explicit `shutdown(wait=False)`) and leak the pending threads, which trades the wait for daemon threads outliving the call. I went with the blocking form because it leaves no threads behind; say the word if you prefer the other side of that trade.

`tests/test_cloud.py` gains a case that stubs all three endpoints as answering and asserts both that the first mapping entry wins and that all three were actually called. `uv run pytest tests/test_cloud.py` passes (6 tests).
