### PR TITLE
fix(ui): landing page links show without scrolling

### DIFF
--- a/webapp/src/pages/LandingPage.tsx
+++ b/webapp/src/pages/LandingPage.tsx
@@ -7,8 +7,8 @@ export default function LandingPage() {
     const mock = isMockMode();
     const apiConfigured = !!import.meta.env.VITE_API_URL;
     return (
-        <>
-            <main className="flex min-h-[100dvh] flex-col items-center justify-center bg-background px-4 py-12 sm:px-6 lg:px-8">
+        <div className="flex min-h-[100dvh] flex-col bg-background">
+            <main className="flex flex-1 flex-col items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
                 <div className="mx-auto text-center">
                     <h1 className="text-4xl font-semi-bold tracking-tight text-foreground sm:text-5xl">
                         Welcome to Code Carbon!
@@ -52,7 +52,7 @@ export default function LandingPage() {
                     </div>
                 </div>
             </main>
-            <footer className="mx-auto text-center mb-4 text-sm text-muted-foreground space-y-2">
+            <footer className="mx-auto text-center px-4 pb-6 text-sm text-muted-foreground space-y-2">
                 <p>
                     New to Code Carbon? Learn more at{" "}
                     <a
@@ -74,6 +74,6 @@ export default function LandingPage() {
                     .
                 </p>
             </footer>
-        </>
+        </div>
     );
 }


### PR DESCRIPTION
## Description
Show links in the landing page without scrolling.

### Before
<img width="1522" height="1154" alt="image" src="https://github.com/user-attachments/assets/a03af820-daf5-44b7-9d13-870c760e3d20" />
### After
<img width="1380" height="1059" alt="image" src="https://github.com/user-attachments/assets/489fceaf-a4b6-482f-9971-8199f0402a29" />


## AI Usage Disclosure


- [ ] 🟥 AI-vibecoded: You cannot explain the logic. Car analogy : the car drive by itself, you are outside it and just tell it where to go.
- [ ] 🟠 AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [x] ⭐ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] ♻️ No AI used. Car analogy : you drive the car.
