### PR TITLE
docs: stop presenting Threadripper 68+68=137 W as a correct RAPL sum

### DIFF
--- a/docs/explanation/rapl.md
+++ b/docs/explanation/rapl.md
@@ -78,6 +78,13 @@ counting!)
 
 **Correct approach**: Use only psys (9.6W) ✅
 
+A second, unrelated double-count shows up on some multi-die AMD CPUs
+(Threadripper / EPYC): `package-0-die-0` and `package-0-die-1` can both
+expose the **same** socket-wide energy counter. They are not two
+independent packages. Summing identical readings multiplies CPU power
+by the die count. See the Threadripper teaser below and
+[issue #1274](https://github.com/mlco2/codecarbon/issues/1274).
+
 ## CodeCarbon's RAPL Strategy
 
 CodeCarbon implements intelligent domain selection to provide reliable
@@ -124,7 +131,9 @@ and consistent measurements:
 -   `core` reports very low energy values
 -   Unclear if `core` is included in `package` (vendor documentation is
     sparse)
--   Multiple dies may report as separate packages (e.g., Threadripper)
+-   Multiple dies may report as separate packages (e.g., Threadripper).
+    On some parts those domains mirror the same socket-wide counter;
+    summing identical readings double-counts CPU power.
 
 **What RAPL Does NOT Measure**:
 
@@ -164,7 +173,25 @@ We investigate RAPL on various architectures :
 Desktop computer with AMD Ryzen Threadripper 1950X 16-Core (32 threads)
 Power plug measure when idle (10% CPU): 125 W
 package-0-die-0: 68 W | package-0-die-1: 68 W | CodeCarbon: 137 W
+
+⚠️  WRONG: 68 W + 68 W = 137 W. The two dies report the same
+    socket-wide RAPL counter (issue 1274). This is one meter read
+    twice, not two independent 68 W packages. CPU RAPL here is
+    ~68 W, not 137 W.
 ```
+
+!!! warning "Mirrored per-die RAPL counters"
+
+    Two dies reporting the exact same 68 W is not a coincidence. On
+    some multi-die AMD CPUs the Linux powercap `package-*-die-*`
+    domains all read one socket-wide energy counter. CodeCarbon's
+    Linux RAPL path still sums them today, so this 137 W figure is
+    the known over-count, not a confirmed-correct reading. The
+    Windows EMI backend already drops mirrored channels. A later
+    kernel on the same machine can expose a single `package-0`
+    instead (see the detailed Threadripper section below). Tracking:
+    [#1274](https://github.com/mlco2/codecarbon/issues/1274),
+    [#1276](https://github.com/mlco2/codecarbon/pull/1276).
 
 ### Laptop: Intel(R) Core(TM) Ultra 7 265H (TDP 28W)
 
@@ -301,19 +328,24 @@ Total Power Consumption: 181.05 Watts
 280 - 100 (idle) = 180 W
 
 Analysis:
-- Each die independently measured via RAPL
+- This capture exposes a single package-0 domain (kernel-dependent)
+- It is not the mirrored 68 W + 68 W case in the teaser above
 - No psys domain available on this AMD system
 - RAPL counter range: 234 sec at 280W (potential wraparound consideration)
 ```
 
 **AMD RAPL Characteristics**:
 
--   Multi-die CPUs report separate packages (package-0-die-0,
-    package-0-die-1)
+-   Multi-die CPUs may report separate packages (package-0-die-0,
+    package-0-die-1). On some parts those domains **mirror the same
+    socket-wide counter**; summing identical readings double-counts
+    CPU power (the 68 W + 68 W → 137 W teaser above). Distinct
+    counters (for example two sockets) should still be added.
 -   No psys domain available on older AMD processors
 -   `core` domain reports very low values (unclear if included in
     package)
--   Package measurements are generally reliable for total CPU power
+-   A single, non-mirrored package reading is generally reliable for
+    total CPU power
 
 ## Key Takeaways for RAPL Measurements
 
@@ -346,7 +378,9 @@ Analysis:
 7.  **Platform-specific behavior**:
     -   Intel modern: package or psys (with prefer_psys=True)
     -   Intel older: package-0 for CPU only
-    -   AMD: Sum all package-X-die-Y for multi-die CPUs
+    -   AMD: use package domains. If several `package-X-die-Y`
+        domains report the same energy, keep one — do not sum
+        mirrors. Sum only domains with distinct counters.
 8.  **Limitations**: RAPL does NOT measure:
     -   Discrete GPUs (use nvidia-smi/rocm-smi)
     -   SSDs, peripherals, fans


### PR DESCRIPTION
## Description

`docs/explanation/rapl.md` showed the Threadripper 1950X teaser

`package-0-die-0: 68 W | package-0-die-1: 68 W | CodeCarbon: 137 W`

with no note that those two dies can report the same socket-wide RAPL counter. That line was easy to read as confirmed-correct behaviour. It is the double-count discussed in #1274 / #1276 / #1379: one meter read twice, so the CPU RAPL value is ~68 W, not 137 W.

This PR only annotates the docs. It does not implement Linux RAPL deduplication (that remains #1276).

Changes in `docs/explanation/rapl.md`:

- Mark the 68 W + 68 W = 137 W teaser as the known over-count.
- Note mirrored per-die packages next to the existing hierarchy double-count explanation.
- Qualify the AMD bullets that told readers to sum every `package-X-die-Y` domain.
- Distinguish the later Threadripper capture, which exposes a single `package-0` (kernel-dependent).

## Related Issue

Fixes #1392

Related: #1274, #1276, #1379

## Motivation and Context

Readers were being taught that summing two identical 68 W die readings is the right RAPL result. Whatever lands in #1276, that example should not stay unannotated.

## How Has This Been Tested?

- Confirmed no open complete PR already targets #1392.
- Built the docs: `uv run --only-group doc task docs` — no issues found, link check passed.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure

Please refer to [docs/how-to/ai-policy.md](https://docs.codecarbon.io/latest/how-to/ai_policy/) for detailed guidelines on how to disclose AI usage in your PR. Accurately completing this section is mandatory.

- [ ] 🟥 AI-vibecoded: You cannot explain the logic. Car analogy : the car drive by itself, you are outside it and just tell it where to go.
- [x] 🟠 AI-generated: Car analogy : the car drive by itself, you are inside and give instructions.
- [ ] ⭐ AI-assisted. Car analogy : you drive the car, AI help you find your way.
- [ ] ♻️ No AI used. Car analogy : you drive the car.

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[docs/how-to/contributing.md](https://docs.codecarbon.io/latest/how-to/contributing/)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.