### PR TITLE
fix(cli): use output_dir when printing Saved to path in monitor

### DIFF
--- a/codecarbon/cli/monitor.py
+++ b/codecarbon/cli/monitor.py
@@ -118,10 +118,9 @@ def run_and_monitor(
 
         # Show where the data was saved
         if hasattr(tracker, "_conf") and "output_file" in tracker._conf:
-            output_path = tracker._conf["output_file"]
-            # Make it absolute if it's relative
-            if not os.path.isabs(output_path):
-                output_path = os.path.abspath(output_path)
+            output_dir = tracker._conf.get("output_dir", ".")
+            output_file = tracker._conf["output_file"]
+            output_path = os.path.abspath(os.path.join(output_dir, output_file))
             print(f"   Saved to: {output_path}")
 
         print("   ⚠️  Note: Tracked the command process and its children")


### PR DESCRIPTION
## Description
Fix the "Saved to" path printed by `codecarbon monitor` to include `output_dir`, not just the bare filename resolved against CWD.

## Related Issue
Closes #1322

## Motivation and Context
When `output_dir` is set (via config or env var), the CLI printed `<cwd>/emissions.csv` instead of `<output_dir>/emissions.csv`. The actual CSV was written to the correct location by `FileOutput`, but the user-facing message pointed to the wrong place.

## How Has This Been Tested?
- Ran `codecarbon monitor` with custom `output_dir` and verified the printed path matches the actual file locatio

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure
- [ ]  AI-vibecoded
- [ ]  AI-generated
- [ ]  AI-assisted
- [x]  No AI used

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **docs/how-to/contributing.md** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.