### PR TITLE
Fix/flush missing experiment name

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -903,7 +903,9 @@ class BaseEmissionsTracker(ABC):
         emissions_data_delta = self._compute_emissions_delta(emissions_data)
 
         self._persist_data(
-            total_emissions=emissions_data, delta_emissions=emissions_data_delta
+            total_emissions=emissions_data,
+            delta_emissions=emissions_data_delta,
+            experiment_name=self._experiment_name,
         )
 
         return emissions_data.emissions

--- a/tests/test_emissions_tracker_flush.py
+++ b/tests/test_emissions_tracker_flush.py
@@ -96,6 +96,19 @@ class TestCarbonTrackerFlush(unittest.TestCase):
         )
         self.assertEqual("test", emissions_df["experiment_id"].values[0])
 
+    def test_flush_with_active_task(self):
+        tracker = EmissionsTracker(
+            output_dir=self.emissions_path, output_file=self.emissions_file
+        )
+        tracker.start()
+        tracker.start_task("my_task")
+        heavy_computation(run_time_secs=1)
+        tracker.flush()
+        tracker.stop_task()
+        emissions = tracker.stop()
+        assert isinstance(emissions, float)
+        self.assertNotEqual(emissions, 0.0)
+
     def verify_output_file(self, file_path: str, expected_lines=3) -> None:
         with open(file_path, "r") as f:
             lines = [line.rstrip() for line in f]


### PR DESCRIPTION
## Description
Pass `experiment_name=self._exhen calling
`_persist_data()`, matching what `stop()` already does.

## Related Issue
Fixes #1410

## Motivation and Context
`flush()` with active tasks crashes because `_persist_data()` receives
`experiment_name=None` (the deout()` tries
to concatenate it into a filename string. `stop()` already passes
`experiment_name=self._experims simply
missed in `flush()`.

## How Has This Been Tested?
- Added `test_flush_with_activons_tracker_flush.py`
- Ran existing flush and tracker test suites locally
- Verified the crash reproducewith it

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breakinlity)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## AI Usage Disclosure
- [ ]  AI-vibecoded
- [ ]  AI-generated
- [x]  AI-assisted
- [ ]  No AI used

## Checklist:
- [x] My code follows the code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the docum
- [x] I have read the **docs/how-to/contributing.md** document.
- [x] I have added tests to co
- [x] All new and existing tests passed.